### PR TITLE
adv_20160127B: Patches v3

### DIFF
--- a/CVE-2016-0754_v3_curl-7.24.0_to_7.39.0.patch
+++ b/CVE-2016-0754_v3_curl-7.24.0_to_7.39.0.patch
@@ -1,7 +1,7 @@
-From 861891464fb35b34d9e1c1d84f99a651797c499f Mon Sep 17 00:00:00 2001
+From dfae5aa7a789d4fbd1e89485a1f41e7bfb17340c Mon Sep 17 00:00:00 2001
 From: Jay Satiro <raysatiro@yahoo.com>
-Date: Sun, 7 Feb 2016 18:29:01 -0500
-Subject: [PATCH] curl: Consolidated patch v2 for CVE-2016-0754 (Windows)
+Date: Thu, 11 Feb 2016 16:46:41 -0500
+Subject: [PATCH] curl: Consolidated patch v3 for CVE-2016-0754 (Windows)
 
 curl does not sanitize colons in a remote file name that is used as the
 local file name. This may lead to a vulnerability on systems where the
@@ -16,18 +16,18 @@ Instructions
 This patch will only apply to curl 7.24.0 - 7.39.0. If you have a
 different version of curl consult the advisory.
 
-If you have applied the first version of the patch revert it and then
-apply v2.
+If you have applied an older version of the patch revert it and then
+apply v3.
 
-patch -p1 < CVE-2016-0754_v2_curl-7.24.0_to_7.39.0.patch
+patch -p1 < CVE-2016-0754_v3_curl-7.24.0_to_7.39.0.patch
 ---
  src/tool_cb_hdr.c  |  23 ++-
- src/tool_doswin.c  | 462 +++++++++++++++++++++++++++++++++++++++++++++++------
+ src/tool_doswin.c  | 469 +++++++++++++++++++++++++++++++++++++++++++++++------
  src/tool_doswin.h  |  24 ++-
- src/tool_operate.c |   9 --
- src/tool_operhlp.c |  18 ++-
- src/tool_urlglob.c |  16 ++
- 6 files changed, 487 insertions(+), 65 deletions(-)
+ src/tool_operate.c |   9 -
+ src/tool_operhlp.c |  18 +-
+ src/tool_urlglob.c |  17 ++
+ 6 files changed, 495 insertions(+), 65 deletions(-)
 
 diff --git a/src/tool_cb_hdr.c b/src/tool_cb_hdr.c
 index ef340f7..0a375f6 100644
@@ -80,10 +80,10 @@ index ef340f7..0a375f6 100644
     * named CURL_TESTDIR to prefix the given file name to put it into a
     * specific directory
 diff --git a/src/tool_doswin.c b/src/tool_doswin.c
-index dd6e8bb..ed35d06 100644
+index dd6e8bb..a346644 100644
 --- a/src/tool_doswin.c
 +++ b/src/tool_doswin.c
-@@ -85,44 +85,252 @@ __pragma(warning(pop))
+@@ -85,44 +85,259 @@ __pragma(warning(pop))
  #  include <fcntl.h>                /* _use_lfn(f) prototype */
  #endif
  
@@ -166,9 +166,8 @@ index dd6e8bb..ed35d06 100644
 +
 +  if((flags & SANITIZE_ALLOW_PATH)) {
 +#ifndef MSDOS
-+    if((flags & SANITIZE_ALLOW_PATH) &&
-+       file_name[0] == '\\' && file_name[1] == '\\')
-+      /* UNC prefixed path, eg \\?\C:\foo */
++    if(file_name[0] == '\\' && file_name[1] == '\\')
++      /* UNC prefixed path \\ (eg \\?\C:\foo) */
 +      max_sanitized_len = 32767-1;
 +    else
 +#endif
@@ -196,8 +195,16 @@ index dd6e8bb..ed35d06 100644
 +  strncpy(target, file_name, len);
 +  target[len] = '\0';
 +
++#ifndef MSDOS
++  if((flags & SANITIZE_ALLOW_PATH) && !strncmp(target, "\\\\?\\", 4))
++    /* Skip the literal path prefix \\?\ */
++    p = target + 4;
++  else
++#endif
++    p = target;
++
 +  /* replace control characters and other banned characters */
-+  for(p = target; *p; ++p) {
++  for(; *p; ++p) {
 +    const char *banned;
 +
 +    if((1 <= *p && *p <= 31) ||
@@ -214,7 +221,9 @@ index dd6e8bb..ed35d06 100644
 +      }
 +    }
 +  }
-+
+ 
+-  if(strlen(file_name) >= PATH_MAX)
+-    file_name[PATH_MAX-1] = '\0'; /* truncate it */
 +  /* remove trailing spaces and periods if not allowing paths */
 +  if(!(flags & SANITIZE_ALLOW_PATH) && len) {
 +    char *clip = NULL;
@@ -233,8 +242,7 @@ index dd6e8bb..ed35d06 100644
 +    }
 +  }
  
--  if(strlen(file_name) >= PATH_MAX)
--    file_name[PATH_MAX-1] = '\0'; /* truncate it */
+-  strcpy(new_name, msdosify(file_name));
 +#ifdef MSDOS
 +  sc = msdosify(&p, target, flags);
 +  free(target);
@@ -249,7 +257,7 @@ index dd6e8bb..ed35d06 100644
 +  }
 +#endif
  
--  strcpy(new_name, msdosify(file_name));
+-  Curl_safefree(file_name);
 +  if(!(flags & SANITIZE_ALLOW_RESERVED)) {
 +    sc = rename_if_reserved_dos_device_name(&p, target, flags);
 +    free(target);
@@ -264,12 +272,15 @@ index dd6e8bb..ed35d06 100644
 +    }
 +  }
  
--  Curl_safefree(file_name);
+-  return strdup(rename_if_dos_device_name(new_name));
 +  *sanitized = target;
 +  return SANITIZE_ERR_OK;
-+}
-+
-+
+ }
+ 
+-/* The following functions are taken with modification from the DJGPP
+- * port of tar 1.12. They use algorithms originally from DJTAR. */
+ 
+-static const char *msdosify (const char *file_name)
 +/*
 +Test if truncating a path to a file will leave at least a single character in
 +the filename. Filenames suffixed by an alternate data stream can't be
@@ -296,10 +307,10 @@ index dd6e8bb..ed35d06 100644
 +!= SANITIZE_ERR_OK && != SANITIZE_ERR_INVALID_PATH: Error
 +*/
 +SANITIZEcode truncate_dryrun(const char *path, const size_t truncate_pos)
-+{
+ {
+-  static char dos_name[PATH_MAX];
 +  size_t len;
- 
--  return strdup(rename_if_dos_device_name(new_name));
++
 +  if(!path)
 +    return SANITIZE_ERR_BAD_ARGUMENT;
 +
@@ -325,10 +336,8 @@ index dd6e8bb..ed35d06 100644
 +  }
 +
 +  return SANITIZE_ERR_OK;
- }
- 
--/* The following functions are taken with modification from the DJGPP
-- * port of tar 1.12. They use algorithms originally from DJTAR. */
++}
++
 +/* The functions msdosify, rename_if_dos_device_name and __crt0_glob_function
 + * were taken with modification from the DJGPP port of tar 1.12. They use
 + * algorithms originally from DJTAR.
@@ -343,16 +352,14 @@ index dd6e8bb..ed35d06 100644
 +that some path information may pass through. For example drive letter names
 +(C:, D:, etc) are allowed to pass through. For sanitizing a filename use
 +sanitize_file_name.
- 
--static const char *msdosify (const char *file_name)
++
 +Success: (SANITIZE_ERR_OK) *sanitized points to a sanitized copy of file_name.
 +Failure: (!= SANITIZE_ERR_OK) *sanitized is NULL.
 +*/
 +#if defined(MSDOS) || defined(UNITTESTS)
 +SANITIZEcode msdosify(char **const sanitized, const char *file_name,
 +                      int flags)
- {
--  static char dos_name[PATH_MAX];
++{
 +  char dos_name[PATH_MAX];
    static const char illegal_chars_dos[] = ".+, ;=[]" /* illegal in DOS */
 -    "|<>\\\":?*"; /* illegal in DOS & W95 */
@@ -360,7 +367,7 @@ index dd6e8bb..ed35d06 100644
    static const char *illegal_chars_w95 = &illegal_chars_dos[8];
    int idx, dot_idx;
    const char *s = file_name;
-@@ -131,6 +339,19 @@ static const char *msdosify (const char *file_name)
+@@ -131,6 +346,19 @@ static const char *msdosify (const char *file_name)
    const char *illegal_aliens = illegal_chars_dos;
    size_t len = sizeof(illegal_chars_dos) - 1;
  
@@ -380,7 +387,7 @@ index dd6e8bb..ed35d06 100644
    /* Support for Windows 9X VFAT systems, when available. */
    if(_use_lfn(file_name)) {
      illegal_aliens = illegal_chars_w95;
-@@ -140,22 +361,35 @@ static const char *msdosify (const char *file_name)
+@@ -140,22 +368,35 @@ static const char *msdosify (const char *file_name)
    /* Get past the drive letter, if any. */
    if(s[0] >= 'A' && s[0] <= 'z' && s[1] == ':') {
      *d++ = *s++;
@@ -420,7 +427,7 @@ index dd6e8bb..ed35d06 100644
            *d = *s;
          }
          else if(idx == 0)
-@@ -177,12 +411,22 @@ static const char *msdosify (const char *file_name)
+@@ -177,12 +418,22 @@ static const char *msdosify (const char *file_name)
        else if(*s == '+' && s[1] == '+') {
          if(idx - 2 == dot_idx) { /* .c++, .h++ etc. */
            *d++ = 'x';
@@ -445,7 +452,7 @@ index dd6e8bb..ed35d06 100644
          }
          s++;
          idx++;
-@@ -192,44 +436,168 @@ static const char *msdosify (const char *file_name)
+@@ -192,44 +443,168 @@ static const char *msdosify (const char *file_name)
      }
      else
        *d = *s;
@@ -738,7 +745,7 @@ index 7a6ed20..efa64e7 100644
     * named CURL_TESTDIR to prefix the given file name to put it into a
     * specific directory
 diff --git a/src/tool_urlglob.c b/src/tool_urlglob.c
-index 36e83c3..978b3f9 100644
+index 36e83c3..bc2201c 100644
 --- a/src/tool_urlglob.c
 +++ b/src/tool_urlglob.c
 @@ -27,6 +27,9 @@
@@ -751,7 +758,7 @@ index 36e83c3..978b3f9 100644
  #include "memdebug.h" /* keep this as LAST include */
  
  typedef enum {
-@@ -668,6 +671,19 @@ int glob_match_url(char **result, char *filename, URLGlob *glob)
+@@ -668,6 +671,20 @@ int glob_match_url(char **result, char *filename, URLGlob *glob)
      stringlen += appendlen;
    }
    target[stringlen]= '\0';
@@ -760,7 +767,8 @@ index 36e83c3..978b3f9 100644
 +  {
 +    char *sanitized;
 +    SANITIZEcode sc = sanitize_file_name(&sanitized, target,
-+                                         SANITIZE_ALLOW_PATH);
++                                         (SANITIZE_ALLOW_PATH |
++                                          SANITIZE_ALLOW_RESERVED));
 +    Curl_safefree(target);
 +    if(sc)
 +      return CURLE_URL_MALFORMAT;

--- a/CVE-2016-0754_v3_curl-7.40.0_to_7.46.0.patch
+++ b/CVE-2016-0754_v3_curl-7.40.0_to_7.46.0.patch
@@ -1,7 +1,7 @@
-From 1818c2ef101f63542ac3f9ac2049ae7f0994e623 Mon Sep 17 00:00:00 2001
+From 7172c5bb5b077279824a2068bc2532d543beace0 Mon Sep 17 00:00:00 2001
 From: Jay Satiro <raysatiro@yahoo.com>
-Date: Sun, 7 Feb 2016 18:48:34 -0500
-Subject: [PATCH] curl: Consolidated patch v2 for CVE-2016-0754 (Windows)
+Date: Thu, 11 Feb 2016 16:56:33 -0500
+Subject: [PATCH] curl: Consolidated patch v3 for CVE-2016-0754 (Windows)
 
 curl does not sanitize colons in a remote file name that is used as the
 local file name. This may lead to a vulnerability on systems where the
@@ -13,63 +13,55 @@ Bug: https://curl.haxx.se/docs/adv_20160127B.html
 Instructions
 ------------
 
-This patch will only apply to curl 7.47.0. If you have a different
-version of curl consult the advisory.
+This patch will only apply to curl 7.40.0 - 7.46.0. If you have a
+different version of curl consult the advisory.
 
-If you have applied the first version of the patch revert it and then
-apply v2.
+If you have applied an older version of the patch revert it and then
+apply v3.
 
-patch -p1 < CVE-2016-0754_v2_curl-7.47.0.patch
+patch -p1 < CVE-2016-0754_v3_curl-7.40.0_to_7.46.0.patch
 ---
- src/tool_cb_hdr.c  |  39 +++--
- src/tool_doswin.c  | 448 +++++++++++++++++++++++++++++++++++++++++------------
+ src/tool_cb_hdr.c  |  23 ++-
+ src/tool_doswin.c  | 469 +++++++++++++++++++++++++++++++++++++++++++++++------
  src/tool_doswin.h  |  24 ++-
- src/tool_operate.c |  20 ---
- src/tool_operhlp.c |  18 ++-
- src/tool_urlglob.c |  15 ++
- 6 files changed, 428 insertions(+), 136 deletions(-)
+ src/tool_operate.c |   9 -
+ src/tool_operhlp.c |  18 +-
+ src/tool_urlglob.c |  17 ++
+ 6 files changed, 495 insertions(+), 65 deletions(-)
 
 diff --git a/src/tool_cb_hdr.c b/src/tool_cb_hdr.c
-index 0fca39f..d603cac 100644
+index fd208e8..d603cac 100644
 --- a/src/tool_cb_hdr.c
 +++ b/src/tool_cb_hdr.c
-@@ -115,24 +115,18 @@ size_t tool_header_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
-       */
-       len = (ssize_t)cb - (p - str);
-       filename = parse_filename(p, len);
--      if(!filename)
--        return failure;
--
--#if defined(MSDOS) || defined(WIN32)
--      if(sanitize_file_name(&filename)) {
--        free(filename);
--        return failure;
-+      if(filename) {
-+        outs->filename = filename;
-+        outs->alloc_filename = TRUE;
-+        outs->is_cd_filename = TRUE;
-+        outs->s_isreg = TRUE;
-+        outs->fopened = FALSE;
-+        outs->stream = NULL;
-+        hdrcbdata->honor_cd_filename = FALSE;
-+        break;
-       }
--#endif /* MSDOS || WIN32 */
--
--      outs->filename = filename;
--      outs->alloc_filename = TRUE;
--      outs->is_cd_filename = TRUE;
--      outs->s_isreg = TRUE;
--      outs->fopened = FALSE;
--      outs->stream = NULL;
--      hdrcbdata->honor_cd_filename = FALSE;
--      break;
-+      else
-+        return failure;
-     }
+@@ -28,6 +28,7 @@
+ #include "curlx.h"
+ 
+ #include "tool_cfgable.h"
++#include "tool_doswin.h"
+ #include "tool_msgs.h"
+ #include "tool_cb_hdr.h"
+ 
+@@ -181,15 +182,12 @@ static char *parse_filename(const char *ptr, size_t len)
    }
  
-@@ -207,6 +201,17 @@ static char *parse_filename(const char *ptr, size_t len)
+   /* scan for the end letter and stop there */
+-  q = p;
+-  while(*q) {
+-    if(q[1] && (q[0] == '\\'))
+-      q++;
+-    else if(q[0] == stop)
++  for(q = p; *q; ++q) {
++    if(*q == stop) {
++      *q = '\0';
+       break;
+-    q++;
++    }
+   }
+-  *q = '\0';
+ 
+   /* make sure the file name doesn't end in \r or \n */
+   q = strchr(p, '\r');
+@@ -203,6 +201,17 @@ static char *parse_filename(const char *ptr, size_t len)
    if(copy != p)
      memmove(copy, p, strlen(p) + 1);
  
@@ -88,15 +80,15 @@ index 0fca39f..d603cac 100644
     * named CURL_TESTDIR to prefix the given file name to put it into a
     * specific directory
 diff --git a/src/tool_doswin.c b/src/tool_doswin.c
-index 9c6a7a3..ed35d06 100644
+index dd6e8bb..a346644 100644
 --- a/src/tool_doswin.c
 +++ b/src/tool_doswin.c
-@@ -85,50 +85,113 @@ __pragma(warning(pop))
+@@ -85,44 +85,259 @@ __pragma(warning(pop))
  #  include <fcntl.h>                /* _use_lfn(f) prototype */
  #endif
  
--static char *msdosify(const char *file_name);
--static char *rename_if_dos_device_name(const char *file_name);
+-static const char *msdosify (const char *file_name);
+-static char *rename_if_dos_device_name (char *file_name);
 +#ifndef UNITTESTS
 +static SANITIZEcode truncate_dryrun(const char *path,
 +                                    const size_t truncate_pos);
@@ -109,12 +101,18 @@ index 9c6a7a3..ed35d06 100644
 +                                                       int flags);
 +#endif /* !UNITTESTS (static declarations used if no unit tests) */
  
+-/*
+- * sanitize_dos_name: returns a newly allocated string holding a
+- * valid file name which will be a transformation of given argument
+- * in case this wasn't already a valid file name.
+- *
+- * This function takes ownership of given argument, free'ing it before
+- * returning. Caller is responsible of free'ing returned string. Upon
+- * out of memory condition function returns NULL.
+- */
  
- /*
--Sanitize *file_name.
--Success: (CURLE_OK) *file_name points to a sanitized version of the original.
--         This function takes ownership of the original *file_name and frees it.
--Failure: (!= CURLE_OK) *file_name is unchanged.
+-char *sanitize_dos_name(char *file_name)
++/*
 +Sanitize a file or path name.
 +
 +All banned characters are replaced by underscores, for example:
@@ -147,42 +145,29 @@ index 9c6a7a3..ed35d06 100644
 +
 +Success: (SANITIZE_ERR_OK) *sanitized points to a sanitized copy of file_name.
 +Failure: (!= SANITIZE_ERR_OK) *sanitized is NULL.
- */
--CURLcode sanitize_file_name(char **file_name)
++*/
 +SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
 +                                int flags)
  {
+-  char new_name[PATH_MAX];
 +  char *p, *target;
-   size_t len;
--  char *p, *sanitized;
--
--  /* Calculate the maximum length of a filename.
--     FILENAME_MAX is often the same as PATH_MAX, in other words it does not
--     discount the path information. PATH_MAX size is calculated based on:
--     <drive-letter><colon><path-sep><max-filename-len><NULL> */
--  const size_t max_filename_len = PATH_MAX - 3 - 1;
++  size_t len;
 +  SANITIZEcode sc;
 +  size_t max_sanitized_len;
- 
--  if(!file_name || !*file_name)
--    return CURLE_BAD_FUNCTION_ARGUMENT;
++
 +  if(!sanitized)
 +    return SANITIZE_ERR_BAD_ARGUMENT;
- 
--  len = strlen(*file_name);
++
 +  *sanitized = NULL;
  
--  if(len >= max_filename_len)
--    len = max_filename_len - 1;
-+  if(!file_name)
+   if(!file_name)
+-    return NULL;
 +    return SANITIZE_ERR_BAD_ARGUMENT;
- 
--  sanitized = malloc(len + 1);
++
 +  if((flags & SANITIZE_ALLOW_PATH)) {
 +#ifndef MSDOS
-+    if((flags & SANITIZE_ALLOW_PATH) &&
-+       file_name[0] == '\\' && file_name[1] == '\\')
-+      /* UNC prefixed path, eg \\?\C:\foo */
++    if(file_name[0] == '\\' && file_name[1] == '\\')
++      /* UNC prefixed path \\ (eg \\?\C:\foo) */
 +      max_sanitized_len = 32767-1;
 +    else
 +#endif
@@ -202,40 +187,43 @@ index 9c6a7a3..ed35d06 100644
 +
 +    len = max_sanitized_len;
 +  }
- 
--  if(!sanitized)
--    return CURLE_OUT_OF_MEMORY;
++
 +  target = malloc(len + 1);
 +  if(!target)
 +    return SANITIZE_ERR_OUT_OF_MEMORY;
- 
--  strncpy(sanitized, *file_name, len);
--  sanitized[len] = '\0';
++
 +  strncpy(target, file_name, len);
 +  target[len] = '\0';
- 
--  for(p = sanitized; *p; ++p ) {
++
++#ifndef MSDOS
++  if((flags & SANITIZE_ALLOW_PATH) && !strncmp(target, "\\\\?\\", 4))
++    /* Skip the literal path prefix \\?\ */
++    p = target + 4;
++  else
++#endif
++    p = target;
++
 +  /* replace control characters and other banned characters */
-+  for(p = target; *p; ++p) {
-     const char *banned;
--    if(1 <= *p && *p <= 31) {
++  for(; *p; ++p) {
++    const char *banned;
 +
 +    if((1 <= *p && *p <= 31) ||
 +       (!(flags & (SANITIZE_ALLOW_COLONS|SANITIZE_ALLOW_PATH)) && *p == ':') ||
 +       (!(flags & SANITIZE_ALLOW_PATH) && (*p == '/' || *p == '\\'))) {
-       *p = '_';
-       continue;
-     }
--    for(banned = "|<>/\\\":?*"; *banned; ++banned) {
++      *p = '_';
++      continue;
++    }
 +
 +    for(banned = "|<>\"?*"; *banned; ++banned) {
-       if(*p == *banned) {
-         *p = '_';
-         break;
-@@ -136,39 +199,111 @@ CURLcode sanitize_file_name(char **file_name)
-     }
-   }
++      if(*p == *banned) {
++        *p = '_';
++        break;
++      }
++    }
++  }
  
+-  if(strlen(file_name) >= PATH_MAX)
+-    file_name[PATH_MAX-1] = '\0'; /* truncate it */
 +  /* remove trailing spaces and periods if not allowing paths */
 +  if(!(flags & SANITIZE_ALLOW_PATH) && len) {
 +    char *clip = NULL;
@@ -253,16 +241,9 @@ index 9c6a7a3..ed35d06 100644
 +      len = clip - target;
 +    }
 +  }
-+
- #ifdef MSDOS
--  /* msdosify checks for more banned characters for MSDOS, however it allows
--     for some path information to pass through. since we are sanitizing only a
--     filename and cannot allow a path it's important this call be done in
--     addition to and not instead of the banned character check above. */
--  p = msdosify(sanitized);
--  if(!p) {
--    free(sanitized);
--    return CURLE_BAD_FUNCTION_ARGUMENT;
+ 
+-  strcpy(new_name, msdosify(file_name));
++#ifdef MSDOS
 +  sc = msdosify(&p, target, flags);
 +  free(target);
 +  if(sc)
@@ -273,15 +254,10 @@ index 9c6a7a3..ed35d06 100644
 +  if(len > max_sanitized_len) {
 +    free(target);
 +    return SANITIZE_ERR_INVALID_PATH;
-   }
--  sanitized = p;
--  len = strlen(sanitized);
- #endif
++  }
++#endif
  
--  p = rename_if_dos_device_name(sanitized);
--  if(!p) {
--    free(sanitized);
--    return CURLE_BAD_FUNCTION_ARGUMENT;
+-  Curl_safefree(file_name);
 +  if(!(flags & SANITIZE_ALLOW_RESERVED)) {
 +    sc = rename_if_reserved_dos_device_name(&p, target, flags);
 +    free(target);
@@ -294,23 +270,17 @@ index 9c6a7a3..ed35d06 100644
 +      free(target);
 +      return SANITIZE_ERR_INVALID_PATH;
 +    }
-   }
--  sanitized = p;
--  len = strlen(sanitized);
--
--  /* dos_device_name rename will rename a device name, possibly changing the
--     length. If the length is too long now we can't truncate it because we
--     could end up with a device name. In practice this shouldn't be a problem
--     because device names are short, but you never know. */
--  if(len >= max_filename_len) {
--    free(sanitized);
--    return CURLE_BAD_FUNCTION_ARGUMENT;
-+
++  }
+ 
+-  return strdup(rename_if_dos_device_name(new_name));
 +  *sanitized = target;
 +  return SANITIZE_ERR_OK;
-+}
-+
-+
+ }
+ 
+-/* The following functions are taken with modification from the DJGPP
+- * port of tar 1.12. They use algorithms originally from DJTAR. */
+ 
+-static const char *msdosify (const char *file_name)
 +/*
 +Test if truncating a path to a file will leave at least a single character in
 +the filename. Filenames suffixed by an alternate data stream can't be
@@ -337,7 +307,8 @@ index 9c6a7a3..ed35d06 100644
 +!= SANITIZE_ERR_OK && != SANITIZE_ERR_INVALID_PATH: Error
 +*/
 +SANITIZEcode truncate_dryrun(const char *path, const size_t truncate_pos)
-+{
+ {
+-  static char dos_name[PATH_MAX];
 +  size_t len;
 +
 +  if(!path)
@@ -362,21 +333,18 @@ index 9c6a7a3..ed35d06 100644
 +      if(*p == ':')
 +        return SANITIZE_ERR_INVALID_PATH;
 +    } while(p != path && *p != '\\' && *p != '/');
-   }
- 
--  *file_name = sanitized;
--  return CURLE_OK;
++  }
++
 +  return SANITIZE_ERR_OK;
- }
- 
- /* The functions msdosify, rename_if_dos_device_name and __crt0_glob_function
-@@ -178,15 +313,24 @@ CURLcode sanitize_file_name(char **file_name)
- 
- /*
- Extra sanitization MSDOS for file_name.
--Returns a copy of file_name that is sanitized by MSDOS standards.
--Warning: path information may pass through. For sanitizing a filename use
--sanitize_file_name which calls this function after sanitizing path info.
++}
++
++/* The functions msdosify, rename_if_dos_device_name and __crt0_glob_function
++ * were taken with modification from the DJGPP port of tar 1.12. They use
++ * algorithms originally from DJTAR.
++ */
++
++/*
++Extra sanitization MSDOS for file_name.
 +
 +This is a supporting function for sanitize_file_name.
 +
@@ -387,20 +355,19 @@ index 9c6a7a3..ed35d06 100644
 +
 +Success: (SANITIZE_ERR_OK) *sanitized points to a sanitized copy of file_name.
 +Failure: (!= SANITIZE_ERR_OK) *sanitized is NULL.
- */
--static char *msdosify(const char *file_name)
++*/
 +#if defined(MSDOS) || defined(UNITTESTS)
 +SANITIZEcode msdosify(char **const sanitized, const char *file_name,
 +                      int flags)
- {
-   char dos_name[PATH_MAX];
++{
++  char dos_name[PATH_MAX];
    static const char illegal_chars_dos[] = ".+, ;=[]" /* illegal in DOS */
 -    "|<>\\\":?*"; /* illegal in DOS & W95 */
 +    "|<>/\\\":?*"; /* illegal in DOS & W95 */
    static const char *illegal_chars_w95 = &illegal_chars_dos[8];
    int idx, dot_idx;
    const char *s = file_name;
-@@ -195,6 +339,19 @@ static char *msdosify(const char *file_name)
+@@ -131,6 +346,19 @@ static const char *msdosify (const char *file_name)
    const char *illegal_aliens = illegal_chars_dos;
    size_t len = sizeof(illegal_chars_dos) - 1;
  
@@ -420,7 +387,7 @@ index 9c6a7a3..ed35d06 100644
    /* Support for Windows 9X VFAT systems, when available. */
    if(_use_lfn(file_name)) {
      illegal_aliens = illegal_chars_w95;
-@@ -204,22 +361,35 @@ static char *msdosify(const char *file_name)
+@@ -140,22 +368,35 @@ static const char *msdosify (const char *file_name)
    /* Get past the drive letter, if any. */
    if(s[0] >= 'A' && s[0] <= 'z' && s[1] == ':') {
      *d++ = *s++;
@@ -460,7 +427,7 @@ index 9c6a7a3..ed35d06 100644
            *d = *s;
          }
          else if(idx == 0)
-@@ -241,12 +411,22 @@ static char *msdosify(const char *file_name)
+@@ -177,12 +418,22 @@ static const char *msdosify (const char *file_name)
        else if(*s == '+' && s[1] == '+') {
          if(idx - 2 == dot_idx) { /* .c++, .h++ etc. */
            *d++ = 'x';
@@ -485,7 +452,7 @@ index 9c6a7a3..ed35d06 100644
          }
          s++;
          idx++;
-@@ -256,55 +436,90 @@ static char *msdosify(const char *file_name)
+@@ -192,44 +443,168 @@ static const char *msdosify (const char *file_name)
      }
      else
        *d = *s;
@@ -499,7 +466,7 @@ index 9c6a7a3..ed35d06 100644
    }
 -
    *d = '\0';
--  return strdup(dos_name);
+-  return dos_name;
 +
 +  if(*s) {
 +    /* dos_name is truncated, check that truncation requirements are met,
@@ -515,10 +482,8 @@ index 9c6a7a3..ed35d06 100644
  }
 +#endif /* MSDOS || UNITTESTS */
  
- /*
--Rename file_name if it's a representation of a device name.
--Returns a copy of file_name, and the copy will have contents different from the
--original if a device name was found.
+-static char *rename_if_dos_device_name (char *file_name)
++/*
 +Rename file_name if it's a reserved dos device name.
 +
 +This is a supporting function for sanitize_file_name.
@@ -530,8 +495,7 @@ index 9c6a7a3..ed35d06 100644
 +
 +Success: (SANITIZE_ERR_OK) *sanitized points to a sanitized copy of file_name.
 +Failure: (!= SANITIZE_ERR_OK) *sanitized is NULL.
- */
--static char *rename_if_dos_device_name(const char *file_name)
++*/
 +SANITIZEcode rename_if_reserved_dos_device_name(char **const sanitized,
 +                                                const char *file_name,
 +                                                int flags)
@@ -539,8 +503,9 @@ index 9c6a7a3..ed35d06 100644
    /* We could have a file whose name is a device on MS-DOS.  Trying to
     * retrieve such a file would fail at best and wedge us at worst.  We need
     * to rename such files. */
-   char *p, *base;
+-  char *base;
 -  struct_stat st_buf;
++  char *p, *base;
    char fname[PATH_MAX];
 +#ifdef MSDOS
 +  struct_stat st_buf;
@@ -577,47 +542,39 @@ index 9c6a7a3..ed35d06 100644
    base = basename(fname);
 -  if(((stat(base, &st_buf)) == 0) && (S_ISCHR(st_buf.st_mode))) {
 -    size_t blen = strlen(base);
--
--    if(strlen(fname) == PATH_MAX-1) {
+ 
+-    if(strlen(fname) >= PATH_MAX-1) {
 -      /* Make room for the '_' */
 -      blen--;
 -      base[blen] = '\0';
--    }
--    /* Prepend a '_'.  */
--    memmove(base + 1, base, blen + 1);
--    base[0] = '_';
--  }
--
--  /* The above stat check does not identify devices for me in Windows 7. For
--     example a stat on COM1 returns a regular file S_IFREG. According to MSDN
--     stat doc that is the correct behavior, so I assume the above code is
--     legacy, maybe MSDOS or DJGPP specific? */
- 
--  /* Rename devices.
--     Examples: CON => _CON, CON.EXT => CON_EXT, CON:ADS => CON_ADS */
 +  /* Rename reserved device names that are known to be accessible without \\.\
 +     Examples: CON => _CON, CON.EXT => CON_EXT, CON:ADS => CON_ADS
 +     https://support.microsoft.com/en-us/kb/74496
 +     https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
 +     */
-   for(p = fname; p; p = (p == fname && fname != base ? base : NULL)) {
-     size_t p_len;
-     int x = (curl_strnequal(p, "CON", 3) ||
-@@ -319,31 +534,70 @@ static char *rename_if_dos_device_name(const char *file_name)
-       continue;
- 
-     /* the devices may be accessible with an extension or ADS, for
--       example CON.AIR and CON:AIR both access console */
--    if(p[x] == '.' || p[x] == ':') {
++  for(p = fname; p; p = (p == fname && fname != base ? base : NULL)) {
++    size_t p_len;
++    int x = (curl_strnequal(p, "CON", 3) ||
++             curl_strnequal(p, "PRN", 3) ||
++             curl_strnequal(p, "AUX", 3) ||
++             curl_strnequal(p, "NUL", 3)) ? 3 :
++            (curl_strnequal(p, "CLOCK$", 6)) ? 6 :
++            (curl_strnequal(p, "COM", 3) || curl_strnequal(p, "LPT", 3)) ?
++              (('1' <= p[3] && p[3] <= '9') ? 4 : 3) : 0;
++
++    if(!x)
++      continue;
++
++    /* the devices may be accessible with an extension or ADS, for
 +       example CON.AIR and 'CON . AIR' and CON:AIR access console */
 +
 +    for(; p[x] == ' '; ++x)
 +      ;
 +
 +    if(p[x] == '.') {
-       p[x] = '_';
-       continue;
-     }
++      p[x] = '_';
++      continue;
++    }
 +    else if(p[x] == ':') {
 +      if(!(flags & (SANITIZE_ALLOW_COLONS|SANITIZE_ALLOW_PATH))) {
 +        p[x] = '_';
@@ -625,32 +582,28 @@ index 9c6a7a3..ed35d06 100644
 +      }
 +      ++x;
 +    }
-     else if(p[x]) /* no match */
-       continue;
- 
++    else if(p[x]) /* no match */
++      continue;
++
 +    /* p points to 'CON' or 'CON ' or 'CON:', etc */
-     p_len = strlen(p);
- 
++    p_len = strlen(p);
++
 +    /* Prepend a '_' */
-     if(strlen(fname) == PATH_MAX-1) {
--      /* Make room for the '_' */
--      p_len--;
++    if(strlen(fname) == PATH_MAX-1) {
 +      --p_len;
 +      if(!(flags & SANITIZE_ALLOW_TRUNCATE) || truncate_dryrun(p, p_len))
 +        return SANITIZE_ERR_INVALID_PATH;
-       p[p_len] = '\0';
-     }
--    /* Prepend a '_'.  */
-     memmove(p + 1, p, p_len + 1);
-     p[0] = '_';
++      p[p_len] = '\0';
++    }
++    memmove(p + 1, p, p_len + 1);
++    p[0] = '_';
 +    ++p_len;
- 
-     /* if fname was just modified then the basename pointer must be updated */
-     if(p == fname)
-       base = basename(fname);
-   }
- 
--  return strdup(fname);
++
++    /* if fname was just modified then the basename pointer must be updated */
++    if(p == fname)
++      base = basename(fname);
++  }
++
 +  /* This is the legacy portion from rename_if_dos_device_name that checks for
 +     reserved device names. It only works on MSDOS. On Windows XP the stat
 +     check errors with EINVAL if the device name is reserved. On Windows
@@ -671,8 +624,13 @@ index 9c6a7a3..ed35d06 100644
 +      memmove(base + 1, base, blen + 1);
 +      base[0] = '_';
 +      ++blen;
-+    }
-+  }
+     }
+-    /* Prepend a '_'.  */
+-    memmove(base + 1, base, blen + 1);
+-    base[0] = '_';
+-    strcpy(file_name, fname);
+   }
+-  return file_name;
 +#endif
 +
 +  *sanitized = strdup(fname);
@@ -681,14 +639,14 @@ index 9c6a7a3..ed35d06 100644
  
  #if defined(MSDOS) && (defined(__DJGPP__) || defined(__GO32__))
 diff --git a/src/tool_doswin.h b/src/tool_doswin.h
-index fc83f16..7c6aa1e 100644
+index cd216db..7c6aa1e 100644
 --- a/src/tool_doswin.h
 +++ b/src/tool_doswin.h
 @@ -25,7 +25,29 @@
  
  #if defined(MSDOS) || defined(WIN32)
  
--CURLcode sanitize_file_name(char **filename);
+-char *sanitize_dos_name(char *file_name);
 +#define SANITIZE_ALLOW_COLONS    (1<<0)  /* Allow colons */
 +#define SANITIZE_ALLOW_PATH      (1<<1)  /* Allow path separators and colons */
 +#define SANITIZE_ALLOW_RESERVED  (1<<2)  /* Allow reserved device names */
@@ -716,43 +674,25 @@ index fc83f16..7c6aa1e 100644
  #if defined(MSDOS) && (defined(__DJGPP__) || defined(__GO32__))
  
 diff --git a/src/tool_operate.c b/src/tool_operate.c
-index 272ebd4..8fb1d4c 100644
+index 66ab0fa..56c773f 100644
 --- a/src/tool_operate.c
 +++ b/src/tool_operate.c
-@@ -543,15 +543,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
-             result = get_url_file_name(&outfile, this_url);
-             if(result)
-               goto show_error;
--
+@@ -548,15 +548,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
+               result = CURLE_WRITE_ERROR;
+               goto quit_urls;
+             }
 -#if defined(MSDOS) || defined(WIN32)
--            result = sanitize_file_name(&outfile);
--            if(result) {
--              Curl_safefree(outfile);
+-            /* For DOS and WIN32, we do some major replacing of
+-               bad characters in the file name before using it */
+-            outfile = sanitize_dos_name(outfile);
+-            if(!outfile) {
+-              result = CURLE_OUT_OF_MEMORY;
 -              goto show_error;
 -            }
 -#endif /* MSDOS || WIN32 */
--
-             if(!*outfile && !config->content_disposition) {
-               helpf(global->errors, "Remote file name has no length!\n");
-               result = CURLE_WRITE_ERROR;
-@@ -563,17 +554,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
-             char *storefile = outfile;
-             result = glob_match_url(&outfile, storefile, urls);
-             Curl_safefree(storefile);
--
--#if defined(MSDOS) || defined(WIN32)
--            if(!result) {
--              result = sanitize_file_name(&outfile);
--              if(result) {
--                Curl_safefree(outfile);
--                goto show_error;
--              }
--            }
--#endif /* MSDOS || WIN32 */
--
-             if(result) {
-               /* bad globbing */
-               warnf(config->global, "bad output glob!\n");
+           }
+           else if(urls) {
+             /* fill '#1' ... '#9' terms from URL pattern */
 diff --git a/src/tool_operhlp.c b/src/tool_operhlp.c
 index abf9496..3566520 100644
 --- a/src/tool_operhlp.c
@@ -805,19 +745,20 @@ index abf9496..3566520 100644
     * named CURL_TESTDIR to prefix the given file name to put it into a
     * specific directory
 diff --git a/src/tool_urlglob.c b/src/tool_urlglob.c
-index 1337252..589a097 100644
+index 1337252..0c2e0a4 100644
 --- a/src/tool_urlglob.c
 +++ b/src/tool_urlglob.c
-@@ -24,6 +24,8 @@
- #define ENABLE_CURLX_PRINTF
- /* use our own printf() functions */
- #include "curlx.h"
-+#include "tool_cfgable.h"
-+#include "tool_doswin.h"
+@@ -27,6 +27,9 @@
  #include "tool_urlglob.h"
  #include "tool_vms.h"
  
-@@ -666,6 +668,19 @@ CURLcode glob_match_url(char **result, char *filename, URLGlob *glob)
++#include "tool_cfgable.h"
++#include "tool_doswin.h"
++
+ #include "memdebug.h" /* keep this as LAST include */
+ 
+ #define GLOBERROR(string, column, code) \
+@@ -666,6 +669,20 @@ CURLcode glob_match_url(char **result, char *filename, URLGlob *glob)
      stringlen += appendlen;
    }
    target[stringlen]= '\0';
@@ -826,7 +767,8 @@ index 1337252..589a097 100644
 +  {
 +    char *sanitized;
 +    SANITIZEcode sc = sanitize_file_name(&sanitized, target,
-+                                         SANITIZE_ALLOW_PATH);
++                                         (SANITIZE_ALLOW_PATH |
++                                          SANITIZE_ALLOW_RESERVED));
 +    Curl_safefree(target);
 +    if(sc)
 +      return CURLE_URL_MALFORMAT;

--- a/CVE-2016-0754_v3_curl-7.47.0.patch
+++ b/CVE-2016-0754_v3_curl-7.47.0.patch
@@ -1,7 +1,7 @@
-From b5c59a75a00cc585c388606afb96765b4f01648a Mon Sep 17 00:00:00 2001
+From 99fede1b5ca0dd734d534eea747140449310c86d Mon Sep 17 00:00:00 2001
 From: Jay Satiro <raysatiro@yahoo.com>
-Date: Sun, 7 Feb 2016 18:34:40 -0500
-Subject: [PATCH] curl: Consolidated patch v2 for CVE-2016-0754 (Windows)
+Date: Thu, 11 Feb 2016 17:03:08 -0500
+Subject: [PATCH] curl: Consolidated patch v3 for CVE-2016-0754 (Windows)
 
 curl does not sanitize colons in a remote file name that is used as the
 local file name. This may lead to a vulnerability on systems where the
@@ -13,55 +13,63 @@ Bug: https://curl.haxx.se/docs/adv_20160127B.html
 Instructions
 ------------
 
-This patch will only apply to curl 7.40.0 - 7.46.0. If you have a
-different version of curl consult the advisory.
+This patch will only apply to curl 7.47.0. If you have a different
+version of curl consult the advisory.
 
-If you have applied the first version of the patch revert it and then
-apply v2.
+If you have applied an older version of the patch revert it and then
+apply v3.
 
-patch -p1 < CVE-2016-0754_v2_curl-7.40.0_to_7.46.0.patch
+patch -p1 < CVE-2016-0754_v3_curl-7.47.0.patch
 ---
- src/tool_cb_hdr.c  |  23 ++-
- src/tool_doswin.c  | 462 +++++++++++++++++++++++++++++++++++++++++++++++------
+ src/tool_cb_hdr.c  |  39 +++--
+ src/tool_doswin.c  | 453 +++++++++++++++++++++++++++++++++++++++++------------
  src/tool_doswin.h  |  24 ++-
- src/tool_operate.c |   9 --
+ src/tool_operate.c |  20 ---
  src/tool_operhlp.c |  18 ++-
  src/tool_urlglob.c |  16 ++
- 6 files changed, 487 insertions(+), 65 deletions(-)
+ 6 files changed, 435 insertions(+), 135 deletions(-)
 
 diff --git a/src/tool_cb_hdr.c b/src/tool_cb_hdr.c
-index fd208e8..d603cac 100644
+index 0fca39f..d603cac 100644
 --- a/src/tool_cb_hdr.c
 +++ b/src/tool_cb_hdr.c
-@@ -28,6 +28,7 @@
- #include "curlx.h"
- 
- #include "tool_cfgable.h"
-+#include "tool_doswin.h"
- #include "tool_msgs.h"
- #include "tool_cb_hdr.h"
- 
-@@ -181,15 +182,12 @@ static char *parse_filename(const char *ptr, size_t len)
+@@ -115,24 +115,18 @@ size_t tool_header_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
+       */
+       len = (ssize_t)cb - (p - str);
+       filename = parse_filename(p, len);
+-      if(!filename)
+-        return failure;
+-
+-#if defined(MSDOS) || defined(WIN32)
+-      if(sanitize_file_name(&filename)) {
+-        free(filename);
+-        return failure;
++      if(filename) {
++        outs->filename = filename;
++        outs->alloc_filename = TRUE;
++        outs->is_cd_filename = TRUE;
++        outs->s_isreg = TRUE;
++        outs->fopened = FALSE;
++        outs->stream = NULL;
++        hdrcbdata->honor_cd_filename = FALSE;
++        break;
+       }
+-#endif /* MSDOS || WIN32 */
+-
+-      outs->filename = filename;
+-      outs->alloc_filename = TRUE;
+-      outs->is_cd_filename = TRUE;
+-      outs->s_isreg = TRUE;
+-      outs->fopened = FALSE;
+-      outs->stream = NULL;
+-      hdrcbdata->honor_cd_filename = FALSE;
+-      break;
++      else
++        return failure;
+     }
    }
  
-   /* scan for the end letter and stop there */
--  q = p;
--  while(*q) {
--    if(q[1] && (q[0] == '\\'))
--      q++;
--    else if(q[0] == stop)
-+  for(q = p; *q; ++q) {
-+    if(*q == stop) {
-+      *q = '\0';
-       break;
--    q++;
-+    }
-   }
--  *q = '\0';
- 
-   /* make sure the file name doesn't end in \r or \n */
-   q = strchr(p, '\r');
-@@ -203,6 +201,17 @@ static char *parse_filename(const char *ptr, size_t len)
+@@ -207,6 +201,17 @@ static char *parse_filename(const char *ptr, size_t len)
    if(copy != p)
      memmove(copy, p, strlen(p) + 1);
  
@@ -80,15 +88,15 @@ index fd208e8..d603cac 100644
     * named CURL_TESTDIR to prefix the given file name to put it into a
     * specific directory
 diff --git a/src/tool_doswin.c b/src/tool_doswin.c
-index dd6e8bb..ed35d06 100644
+index 9c6a7a3..a346644 100644
 --- a/src/tool_doswin.c
 +++ b/src/tool_doswin.c
-@@ -85,44 +85,252 @@ __pragma(warning(pop))
+@@ -85,50 +85,120 @@ __pragma(warning(pop))
  #  include <fcntl.h>                /* _use_lfn(f) prototype */
  #endif
  
--static const char *msdosify (const char *file_name);
--static char *rename_if_dos_device_name (char *file_name);
+-static char *msdosify(const char *file_name);
+-static char *rename_if_dos_device_name(const char *file_name);
 +#ifndef UNITTESTS
 +static SANITIZEcode truncate_dryrun(const char *path,
 +                                    const size_t truncate_pos);
@@ -101,18 +109,12 @@ index dd6e8bb..ed35d06 100644
 +                                                       int flags);
 +#endif /* !UNITTESTS (static declarations used if no unit tests) */
  
--/*
-- * sanitize_dos_name: returns a newly allocated string holding a
-- * valid file name which will be a transformation of given argument
-- * in case this wasn't already a valid file name.
-- *
-- * This function takes ownership of given argument, free'ing it before
-- * returning. Caller is responsible of free'ing returned string. Upon
-- * out of memory condition function returns NULL.
-- */
  
--char *sanitize_dos_name(char *file_name)
-+/*
+ /*
+-Sanitize *file_name.
+-Success: (CURLE_OK) *file_name points to a sanitized version of the original.
+-         This function takes ownership of the original *file_name and frees it.
+-Failure: (!= CURLE_OK) *file_name is unchanged.
 +Sanitize a file or path name.
 +
 +All banned characters are replaced by underscores, for example:
@@ -145,30 +147,39 @@ index dd6e8bb..ed35d06 100644
 +
 +Success: (SANITIZE_ERR_OK) *sanitized points to a sanitized copy of file_name.
 +Failure: (!= SANITIZE_ERR_OK) *sanitized is NULL.
-+*/
+ */
+-CURLcode sanitize_file_name(char **file_name)
 +SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
 +                                int flags)
  {
--  char new_name[PATH_MAX];
 +  char *p, *target;
-+  size_t len;
+   size_t len;
+-  char *p, *sanitized;
 +  SANITIZEcode sc;
 +  size_t max_sanitized_len;
-+
+ 
+-  /* Calculate the maximum length of a filename.
+-     FILENAME_MAX is often the same as PATH_MAX, in other words it does not
+-     discount the path information. PATH_MAX size is calculated based on:
+-     <drive-letter><colon><path-sep><max-filename-len><NULL> */
+-  const size_t max_filename_len = PATH_MAX - 3 - 1;
 +  if(!sanitized)
 +    return SANITIZE_ERR_BAD_ARGUMENT;
-+
+ 
+-  if(!file_name || !*file_name)
+-    return CURLE_BAD_FUNCTION_ARGUMENT;
 +  *sanitized = NULL;
  
-   if(!file_name)
--    return NULL;
+-  len = strlen(*file_name);
++  if(!file_name)
 +    return SANITIZE_ERR_BAD_ARGUMENT;
-+
+ 
+-  if(len >= max_filename_len)
+-    len = max_filename_len - 1;
 +  if((flags & SANITIZE_ALLOW_PATH)) {
 +#ifndef MSDOS
-+    if((flags & SANITIZE_ALLOW_PATH) &&
-+       file_name[0] == '\\' && file_name[1] == '\\')
-+      /* UNC prefixed path, eg \\?\C:\foo */
++    if(file_name[0] == '\\' && file_name[1] == '\\')
++      /* UNC prefixed path \\ (eg \\?\C:\foo) */
 +      max_sanitized_len = 32767-1;
 +    else
 +#endif
@@ -188,33 +199,49 @@ index dd6e8bb..ed35d06 100644
 +
 +    len = max_sanitized_len;
 +  }
-+
+ 
+-  sanitized = malloc(len + 1);
 +  target = malloc(len + 1);
 +  if(!target)
 +    return SANITIZE_ERR_OUT_OF_MEMORY;
-+
+ 
+-  if(!sanitized)
+-    return CURLE_OUT_OF_MEMORY;
 +  strncpy(target, file_name, len);
 +  target[len] = '\0';
-+
+ 
+-  strncpy(sanitized, *file_name, len);
+-  sanitized[len] = '\0';
++#ifndef MSDOS
++  if((flags & SANITIZE_ALLOW_PATH) && !strncmp(target, "\\\\?\\", 4))
++    /* Skip the literal path prefix \\?\ */
++    p = target + 4;
++  else
++#endif
++    p = target;
+ 
+-  for(p = sanitized; *p; ++p ) {
 +  /* replace control characters and other banned characters */
-+  for(p = target; *p; ++p) {
-+    const char *banned;
++  for(; *p; ++p) {
+     const char *banned;
+-    if(1 <= *p && *p <= 31) {
 +
 +    if((1 <= *p && *p <= 31) ||
 +       (!(flags & (SANITIZE_ALLOW_COLONS|SANITIZE_ALLOW_PATH)) && *p == ':') ||
 +       (!(flags & SANITIZE_ALLOW_PATH) && (*p == '/' || *p == '\\'))) {
-+      *p = '_';
-+      continue;
-+    }
+       *p = '_';
+       continue;
+     }
+-    for(banned = "|<>/\\\":?*"; *banned; ++banned) {
 +
 +    for(banned = "|<>\"?*"; *banned; ++banned) {
-+      if(*p == *banned) {
-+        *p = '_';
-+        break;
-+      }
-+    }
-+  }
-+
+       if(*p == *banned) {
+         *p = '_';
+         break;
+@@ -136,39 +206,111 @@ CURLcode sanitize_file_name(char **file_name)
+     }
+   }
+ 
 +  /* remove trailing spaces and periods if not allowing paths */
 +  if(!(flags & SANITIZE_ALLOW_PATH) && len) {
 +    char *clip = NULL;
@@ -232,10 +259,16 @@ index dd6e8bb..ed35d06 100644
 +      len = clip - target;
 +    }
 +  }
- 
--  if(strlen(file_name) >= PATH_MAX)
--    file_name[PATH_MAX-1] = '\0'; /* truncate it */
-+#ifdef MSDOS
++
+ #ifdef MSDOS
+-  /* msdosify checks for more banned characters for MSDOS, however it allows
+-     for some path information to pass through. since we are sanitizing only a
+-     filename and cannot allow a path it's important this call be done in
+-     addition to and not instead of the banned character check above. */
+-  p = msdosify(sanitized);
+-  if(!p) {
+-    free(sanitized);
+-    return CURLE_BAD_FUNCTION_ARGUMENT;
 +  sc = msdosify(&p, target, flags);
 +  free(target);
 +  if(sc)
@@ -246,10 +279,15 @@ index dd6e8bb..ed35d06 100644
 +  if(len > max_sanitized_len) {
 +    free(target);
 +    return SANITIZE_ERR_INVALID_PATH;
-+  }
-+#endif
+   }
+-  sanitized = p;
+-  len = strlen(sanitized);
+ #endif
  
--  strcpy(new_name, msdosify(file_name));
+-  p = rename_if_dos_device_name(sanitized);
+-  if(!p) {
+-    free(sanitized);
+-    return CURLE_BAD_FUNCTION_ARGUMENT;
 +  if(!(flags & SANITIZE_ALLOW_RESERVED)) {
 +    sc = rename_if_reserved_dos_device_name(&p, target, flags);
 +    free(target);
@@ -262,9 +300,18 @@ index dd6e8bb..ed35d06 100644
 +      free(target);
 +      return SANITIZE_ERR_INVALID_PATH;
 +    }
-+  }
- 
--  Curl_safefree(file_name);
+   }
+-  sanitized = p;
+-  len = strlen(sanitized);
+-
+-  /* dos_device_name rename will rename a device name, possibly changing the
+-     length. If the length is too long now we can't truncate it because we
+-     could end up with a device name. In practice this shouldn't be a problem
+-     because device names are short, but you never know. */
+-  if(len >= max_filename_len) {
+-    free(sanitized);
+-    return CURLE_BAD_FUNCTION_ARGUMENT;
++
 +  *sanitized = target;
 +  return SANITIZE_ERR_OK;
 +}
@@ -298,8 +345,7 @@ index dd6e8bb..ed35d06 100644
 +SANITIZEcode truncate_dryrun(const char *path, const size_t truncate_pos)
 +{
 +  size_t len;
- 
--  return strdup(rename_if_dos_device_name(new_name));
++
 +  if(!path)
 +    return SANITIZE_ERR_BAD_ARGUMENT;
 +
@@ -322,20 +368,21 @@ index dd6e8bb..ed35d06 100644
 +      if(*p == ':')
 +        return SANITIZE_ERR_INVALID_PATH;
 +    } while(p != path && *p != '\\' && *p != '/');
-+  }
-+
+   }
+ 
+-  *file_name = sanitized;
+-  return CURLE_OK;
 +  return SANITIZE_ERR_OK;
  }
  
--/* The following functions are taken with modification from the DJGPP
-- * port of tar 1.12. They use algorithms originally from DJTAR. */
-+/* The functions msdosify, rename_if_dos_device_name and __crt0_glob_function
-+ * were taken with modification from the DJGPP port of tar 1.12. They use
-+ * algorithms originally from DJTAR.
-+ */
-+
-+/*
-+Extra sanitization MSDOS for file_name.
+ /* The functions msdosify, rename_if_dos_device_name and __crt0_glob_function
+@@ -178,15 +320,24 @@ CURLcode sanitize_file_name(char **file_name)
+ 
+ /*
+ Extra sanitization MSDOS for file_name.
+-Returns a copy of file_name that is sanitized by MSDOS standards.
+-Warning: path information may pass through. For sanitizing a filename use
+-sanitize_file_name which calls this function after sanitizing path info.
 +
 +This is a supporting function for sanitize_file_name.
 +
@@ -343,24 +390,23 @@ index dd6e8bb..ed35d06 100644
 +that some path information may pass through. For example drive letter names
 +(C:, D:, etc) are allowed to pass through. For sanitizing a filename use
 +sanitize_file_name.
- 
--static const char *msdosify (const char *file_name)
++
 +Success: (SANITIZE_ERR_OK) *sanitized points to a sanitized copy of file_name.
 +Failure: (!= SANITIZE_ERR_OK) *sanitized is NULL.
-+*/
+ */
+-static char *msdosify(const char *file_name)
 +#if defined(MSDOS) || defined(UNITTESTS)
 +SANITIZEcode msdosify(char **const sanitized, const char *file_name,
 +                      int flags)
  {
--  static char dos_name[PATH_MAX];
-+  char dos_name[PATH_MAX];
+   char dos_name[PATH_MAX];
    static const char illegal_chars_dos[] = ".+, ;=[]" /* illegal in DOS */
 -    "|<>\\\":?*"; /* illegal in DOS & W95 */
 +    "|<>/\\\":?*"; /* illegal in DOS & W95 */
    static const char *illegal_chars_w95 = &illegal_chars_dos[8];
    int idx, dot_idx;
    const char *s = file_name;
-@@ -131,6 +339,19 @@ static const char *msdosify (const char *file_name)
+@@ -195,6 +346,19 @@ static char *msdosify(const char *file_name)
    const char *illegal_aliens = illegal_chars_dos;
    size_t len = sizeof(illegal_chars_dos) - 1;
  
@@ -380,7 +426,7 @@ index dd6e8bb..ed35d06 100644
    /* Support for Windows 9X VFAT systems, when available. */
    if(_use_lfn(file_name)) {
      illegal_aliens = illegal_chars_w95;
-@@ -140,22 +361,35 @@ static const char *msdosify (const char *file_name)
+@@ -204,22 +368,35 @@ static char *msdosify(const char *file_name)
    /* Get past the drive letter, if any. */
    if(s[0] >= 'A' && s[0] <= 'z' && s[1] == ':') {
      *d++ = *s++;
@@ -420,7 +466,7 @@ index dd6e8bb..ed35d06 100644
            *d = *s;
          }
          else if(idx == 0)
-@@ -177,12 +411,22 @@ static const char *msdosify (const char *file_name)
+@@ -241,12 +418,22 @@ static char *msdosify(const char *file_name)
        else if(*s == '+' && s[1] == '+') {
          if(idx - 2 == dot_idx) { /* .c++, .h++ etc. */
            *d++ = 'x';
@@ -445,7 +491,7 @@ index dd6e8bb..ed35d06 100644
          }
          s++;
          idx++;
-@@ -192,44 +436,168 @@ static const char *msdosify (const char *file_name)
+@@ -256,55 +443,90 @@ static char *msdosify(const char *file_name)
      }
      else
        *d = *s;
@@ -459,7 +505,7 @@ index dd6e8bb..ed35d06 100644
    }
 -
    *d = '\0';
--  return dos_name;
+-  return strdup(dos_name);
 +
 +  if(*s) {
 +    /* dos_name is truncated, check that truncation requirements are met,
@@ -475,8 +521,10 @@ index dd6e8bb..ed35d06 100644
  }
 +#endif /* MSDOS || UNITTESTS */
  
--static char *rename_if_dos_device_name (char *file_name)
-+/*
+ /*
+-Rename file_name if it's a representation of a device name.
+-Returns a copy of file_name, and the copy will have contents different from the
+-original if a device name was found.
 +Rename file_name if it's a reserved dos device name.
 +
 +This is a supporting function for sanitize_file_name.
@@ -488,7 +536,8 @@ index dd6e8bb..ed35d06 100644
 +
 +Success: (SANITIZE_ERR_OK) *sanitized points to a sanitized copy of file_name.
 +Failure: (!= SANITIZE_ERR_OK) *sanitized is NULL.
-+*/
+ */
+-static char *rename_if_dos_device_name(const char *file_name)
 +SANITIZEcode rename_if_reserved_dos_device_name(char **const sanitized,
 +                                                const char *file_name,
 +                                                int flags)
@@ -496,9 +545,8 @@ index dd6e8bb..ed35d06 100644
    /* We could have a file whose name is a device on MS-DOS.  Trying to
     * retrieve such a file would fail at best and wedge us at worst.  We need
     * to rename such files. */
--  char *base;
+   char *p, *base;
 -  struct_stat st_buf;
-+  char *p, *base;
    char fname[PATH_MAX];
 +#ifdef MSDOS
 +  struct_stat st_buf;
@@ -535,39 +583,47 @@ index dd6e8bb..ed35d06 100644
    base = basename(fname);
 -  if(((stat(base, &st_buf)) == 0) && (S_ISCHR(st_buf.st_mode))) {
 -    size_t blen = strlen(base);
- 
--    if(strlen(fname) >= PATH_MAX-1) {
+-
+-    if(strlen(fname) == PATH_MAX-1) {
 -      /* Make room for the '_' */
 -      blen--;
 -      base[blen] = '\0';
+-    }
+-    /* Prepend a '_'.  */
+-    memmove(base + 1, base, blen + 1);
+-    base[0] = '_';
+-  }
+-
+-  /* The above stat check does not identify devices for me in Windows 7. For
+-     example a stat on COM1 returns a regular file S_IFREG. According to MSDN
+-     stat doc that is the correct behavior, so I assume the above code is
+-     legacy, maybe MSDOS or DJGPP specific? */
+ 
+-  /* Rename devices.
+-     Examples: CON => _CON, CON.EXT => CON_EXT, CON:ADS => CON_ADS */
 +  /* Rename reserved device names that are known to be accessible without \\.\
 +     Examples: CON => _CON, CON.EXT => CON_EXT, CON:ADS => CON_ADS
 +     https://support.microsoft.com/en-us/kb/74496
 +     https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
 +     */
-+  for(p = fname; p; p = (p == fname && fname != base ? base : NULL)) {
-+    size_t p_len;
-+    int x = (curl_strnequal(p, "CON", 3) ||
-+             curl_strnequal(p, "PRN", 3) ||
-+             curl_strnequal(p, "AUX", 3) ||
-+             curl_strnequal(p, "NUL", 3)) ? 3 :
-+            (curl_strnequal(p, "CLOCK$", 6)) ? 6 :
-+            (curl_strnequal(p, "COM", 3) || curl_strnequal(p, "LPT", 3)) ?
-+              (('1' <= p[3] && p[3] <= '9') ? 4 : 3) : 0;
-+
-+    if(!x)
-+      continue;
-+
-+    /* the devices may be accessible with an extension or ADS, for
+   for(p = fname; p; p = (p == fname && fname != base ? base : NULL)) {
+     size_t p_len;
+     int x = (curl_strnequal(p, "CON", 3) ||
+@@ -319,31 +541,70 @@ static char *rename_if_dos_device_name(const char *file_name)
+       continue;
+ 
+     /* the devices may be accessible with an extension or ADS, for
+-       example CON.AIR and CON:AIR both access console */
+-    if(p[x] == '.' || p[x] == ':') {
 +       example CON.AIR and 'CON . AIR' and CON:AIR access console */
 +
 +    for(; p[x] == ' '; ++x)
 +      ;
 +
 +    if(p[x] == '.') {
-+      p[x] = '_';
-+      continue;
-+    }
+       p[x] = '_';
+       continue;
+     }
 +    else if(p[x] == ':') {
 +      if(!(flags & (SANITIZE_ALLOW_COLONS|SANITIZE_ALLOW_PATH))) {
 +        p[x] = '_';
@@ -575,28 +631,32 @@ index dd6e8bb..ed35d06 100644
 +      }
 +      ++x;
 +    }
-+    else if(p[x]) /* no match */
-+      continue;
-+
+     else if(p[x]) /* no match */
+       continue;
+ 
 +    /* p points to 'CON' or 'CON ' or 'CON:', etc */
-+    p_len = strlen(p);
-+
+     p_len = strlen(p);
+ 
 +    /* Prepend a '_' */
-+    if(strlen(fname) == PATH_MAX-1) {
+     if(strlen(fname) == PATH_MAX-1) {
+-      /* Make room for the '_' */
+-      p_len--;
 +      --p_len;
 +      if(!(flags & SANITIZE_ALLOW_TRUNCATE) || truncate_dryrun(p, p_len))
 +        return SANITIZE_ERR_INVALID_PATH;
-+      p[p_len] = '\0';
-+    }
-+    memmove(p + 1, p, p_len + 1);
-+    p[0] = '_';
+       p[p_len] = '\0';
+     }
+-    /* Prepend a '_'.  */
+     memmove(p + 1, p, p_len + 1);
+     p[0] = '_';
 +    ++p_len;
-+
-+    /* if fname was just modified then the basename pointer must be updated */
-+    if(p == fname)
-+      base = basename(fname);
-+  }
-+
+ 
+     /* if fname was just modified then the basename pointer must be updated */
+     if(p == fname)
+       base = basename(fname);
+   }
+ 
+-  return strdup(fname);
 +  /* This is the legacy portion from rename_if_dos_device_name that checks for
 +     reserved device names. It only works on MSDOS. On Windows XP the stat
 +     check errors with EINVAL if the device name is reserved. On Windows
@@ -617,13 +677,8 @@ index dd6e8bb..ed35d06 100644
 +      memmove(base + 1, base, blen + 1);
 +      base[0] = '_';
 +      ++blen;
-     }
--    /* Prepend a '_'.  */
--    memmove(base + 1, base, blen + 1);
--    base[0] = '_';
--    strcpy(file_name, fname);
-   }
--  return file_name;
++    }
++  }
 +#endif
 +
 +  *sanitized = strdup(fname);
@@ -632,14 +687,14 @@ index dd6e8bb..ed35d06 100644
  
  #if defined(MSDOS) && (defined(__DJGPP__) || defined(__GO32__))
 diff --git a/src/tool_doswin.h b/src/tool_doswin.h
-index cd216db..7c6aa1e 100644
+index fc83f16..7c6aa1e 100644
 --- a/src/tool_doswin.h
 +++ b/src/tool_doswin.h
 @@ -25,7 +25,29 @@
  
  #if defined(MSDOS) || defined(WIN32)
  
--char *sanitize_dos_name(char *file_name);
+-CURLcode sanitize_file_name(char **filename);
 +#define SANITIZE_ALLOW_COLONS    (1<<0)  /* Allow colons */
 +#define SANITIZE_ALLOW_PATH      (1<<1)  /* Allow path separators and colons */
 +#define SANITIZE_ALLOW_RESERVED  (1<<2)  /* Allow reserved device names */
@@ -667,25 +722,43 @@ index cd216db..7c6aa1e 100644
  #if defined(MSDOS) && (defined(__DJGPP__) || defined(__GO32__))
  
 diff --git a/src/tool_operate.c b/src/tool_operate.c
-index 66ab0fa..56c773f 100644
+index 272ebd4..8fb1d4c 100644
 --- a/src/tool_operate.c
 +++ b/src/tool_operate.c
-@@ -548,15 +548,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
-               result = CURLE_WRITE_ERROR;
-               goto quit_urls;
-             }
+@@ -543,15 +543,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
+             result = get_url_file_name(&outfile, this_url);
+             if(result)
+               goto show_error;
+-
 -#if defined(MSDOS) || defined(WIN32)
--            /* For DOS and WIN32, we do some major replacing of
--               bad characters in the file name before using it */
--            outfile = sanitize_dos_name(outfile);
--            if(!outfile) {
--              result = CURLE_OUT_OF_MEMORY;
+-            result = sanitize_file_name(&outfile);
+-            if(result) {
+-              Curl_safefree(outfile);
 -              goto show_error;
 -            }
 -#endif /* MSDOS || WIN32 */
-           }
-           else if(urls) {
-             /* fill '#1' ... '#9' terms from URL pattern */
+-
+             if(!*outfile && !config->content_disposition) {
+               helpf(global->errors, "Remote file name has no length!\n");
+               result = CURLE_WRITE_ERROR;
+@@ -563,17 +554,6 @@ static CURLcode operate_do(struct GlobalConfig *global,
+             char *storefile = outfile;
+             result = glob_match_url(&outfile, storefile, urls);
+             Curl_safefree(storefile);
+-
+-#if defined(MSDOS) || defined(WIN32)
+-            if(!result) {
+-              result = sanitize_file_name(&outfile);
+-              if(result) {
+-                Curl_safefree(outfile);
+-                goto show_error;
+-              }
+-            }
+-#endif /* MSDOS || WIN32 */
+-
+             if(result) {
+               /* bad globbing */
+               warnf(config->global, "bad output glob!\n");
 diff --git a/src/tool_operhlp.c b/src/tool_operhlp.c
 index abf9496..3566520 100644
 --- a/src/tool_operhlp.c
@@ -738,20 +811,19 @@ index abf9496..3566520 100644
     * named CURL_TESTDIR to prefix the given file name to put it into a
     * specific directory
 diff --git a/src/tool_urlglob.c b/src/tool_urlglob.c
-index 1337252..053b73a 100644
+index 1337252..145577f 100644
 --- a/src/tool_urlglob.c
 +++ b/src/tool_urlglob.c
-@@ -27,6 +27,9 @@
+@@ -24,6 +24,8 @@
+ #define ENABLE_CURLX_PRINTF
+ /* use our own printf() functions */
+ #include "curlx.h"
++#include "tool_cfgable.h"
++#include "tool_doswin.h"
  #include "tool_urlglob.h"
  #include "tool_vms.h"
  
-+#include "tool_cfgable.h"
-+#include "tool_doswin.h"
-+
- #include "memdebug.h" /* keep this as LAST include */
- 
- #define GLOBERROR(string, column, code) \
-@@ -666,6 +669,19 @@ CURLcode glob_match_url(char **result, char *filename, URLGlob *glob)
+@@ -666,6 +668,20 @@ CURLcode glob_match_url(char **result, char *filename, URLGlob *glob)
      stringlen += appendlen;
    }
    target[stringlen]= '\0';
@@ -760,7 +832,8 @@ index 1337252..053b73a 100644
 +  {
 +    char *sanitized;
 +    SANITIZEcode sc = sanitize_file_name(&sanitized, target,
-+                                         SANITIZE_ALLOW_PATH);
++                                         (SANITIZE_ALLOW_PATH |
++                                          SANITIZE_ALLOW_RESERVED));
 +    Curl_safefree(target);
 +    if(sc)
 +      return CURLE_URL_MALFORMAT;

--- a/docs/adv_20160127B.txt
+++ b/docs/adv_20160127B.txt
@@ -74,13 +74,16 @@ file name it will be sanitized as `f_foo__$DATA` .
 
 A patch is available at:
 
-    https://curl.haxx.se/CVE-2016-0754_v2_curl-7.24.0_to_7.39.0.patch
-    https://curl.haxx.se/CVE-2016-0754_v2_curl-7.40.0_to_7.46.0.patch
-    https://curl.haxx.se/CVE-2016-0754_v2_curl-7.47.0.patch
+    https://curl.haxx.se/CVE-2016-0754_v3_curl-7.24.0_to_7.39.0.patch
+    https://curl.haxx.se/CVE-2016-0754_v3_curl-7.40.0_to_7.46.0.patch
+    https://curl.haxx.se/CVE-2016-0754_v3_curl-7.47.0.patch
 
-If you have applied the first version of the patch revert it and then apply v2.
-The patch will not apply to curl < 7.24.0, the only solution in such a case is
-to upgrade.
+The patch also includes two fixes not present in 7.47.1 for accessing paths
+using the literal path prefix \\?\ and accessing reserved dos device names
+without using the device prefix \\.\ .
+
+If you have applied an older version of the patch revert it and then apply v3.
+There is no patch for curl < 7.24.0, see RECOMMENDATIONS for alternatives.
 
 Exercise judicious use of the -J option. The -J option when combined with -O
 lets the server choose the file name. Do you trust the server you are using
@@ -211,6 +214,6 @@ therefore the scope of this vulnerability as it applies to Cygwin is limited to
 unchecked user input, such as if you have a script that is passing an untrusted
 URL to curl built for Cygwin.
 
-curl 7.47.1 checks for backslashes for all operating systems. A remote file
+curl 7.47.1 checks for backslashes for all operating systems: A remote file
 name is parsed from the URL by removing anything up to and including the last
 forward slash or back slash of the URL's path segment.


### PR DESCRIPTION
v3 patches integrate two post 7.47.1 fixes:

tool_urlglob: Allow reserved dos device names (Windows)
https://github.com/curl/curl/commit/c3aac48

tool_doswin: Support for literal path prefix \\?\
https://github.com/curl/curl/commit/4fc80f3
