### PR TITLE
naming issues page fixes

### DIFF
--- a/legal/_thename.html
+++ b/legal/_thename.html
@@ -38,7 +38,7 @@ TITLE(Who Owns the Name Curl?)
  curl.
 
 <p>
- Daniel Stenberg was contacted by a Curl Corporation respresentative for the
+ Daniel Stenberg was contacted by a Curl Corporation representative for the
  first time on <b>August 11th 2001</b> (possibly due to a slashdot article
  that appeared on August 6 about their CURL content language where lots of
  people mentioned the name collision).

--- a/legal/_thename.html
+++ b/legal/_thename.html
@@ -2,7 +2,7 @@
 <html>
 <head> <title>curl - naming issues</title>
 #include "css.t"
-</headk>
+</head>
 
 #define CURL_URL legal/thename.html
 #define WHO_DOCS


### PR DESCRIPTION
Two small fixes for the naming page, a misspelled tag and a typo.