### PR TITLE
support: Fix incorrect valign value

### DIFF
--- a/_support.html
+++ b/_support.html
@@ -7,8 +7,8 @@
 #define FEATURE <td bgcolor="#ffff00" align="center">yes</td>
 #define MISSING <td align="center">no</td>
 #define UNKNOWN <td align="center"><font color="#ff0000">???</font></td>
-#define NEWEVEN <tr valign="center">
-#define NEWODD  <tr valign="center" bgcolor="#e0e0e0">
+#define NEWEVEN <tr valign="middle">
+#define NEWODD  <tr valign="middle" bgcolor="#e0e0e0">
 #define ENDLINE </tr>
 
 #define CURL_SUPPORT


### PR DESCRIPTION
"center" is not a legal value for the valign attribute on <tr> tags in HTML 4.01 (it is however legal for the align attribute on <td> and thus a common error). Fix by setting to "middle", which is what the browsers render "center" like, but it's standards compliant.