### PR TITLE
security: use plural for multiple vulns only

### DIFF
--- a/docs/_singlevuln.templ
+++ b/docs/_singlevuln.templ
@@ -21,7 +21,7 @@ TITLE(Vulnerabilities in curl %version)
 #include "adv-related-box.inc"
 
 <p> curl version <b>%version</b> was released on <b>%date</b>. The following
-<b>%vulnnum</b> security problems are known to exist in this version.
+<b>%vulnnum</b> security problem%vulnplural known to exist in this version.
 
 %vulnerabilities
 

--- a/docs/vulntable.pl
+++ b/docs/vulntable.pl
@@ -46,6 +46,7 @@ sub single {
     my $vulnhtml;
     my $vulnnum=scalar(@v);
     my $odd;
+    my $vulnplural;
 
     if($vulnnum) {
         $vulnhtml = "<table><tr class=\"tabletop\"><th>Flaw</th><th>From version</th><th>To and including</th><th>CVE</th><th>CWE</th></tr>";
@@ -98,6 +99,16 @@ sub single {
     my $anchor = $str;
     $anchor =~ s/\./_/g;
 
+    if($vulnnum == 0) {
+      $vulnplural = '';
+    }
+    elsif($vulnnum > 1) {
+      $vulnplural = 's are';
+    }
+    else {
+      $vulnplural = ' is';
+    }
+
     open(T, "<_singlevuln.templ");
     open(O, ">vuln-$str.gen");
     while(<T>) {
@@ -105,6 +116,7 @@ sub single {
         $_ =~ s/%vulnerabilities/$vulnhtml/g;
         $_ =~ s/%date/$date/g;
         $_ =~ s/%vulnnum/$vulnnum/g;
+        $_ =~ s/%vulnplural/$vulnplural/g;
         $_ =~ s/%anchor/$anchor/g;
         $_ =~ s/%nextprev/$n/g;
         print O $_;


### PR DESCRIPTION
Adds support to `vulntable.pl` to generate plural/singular spelling for the amount of vulnerabilities in a release.

Creates `The following <b>1</b> security problem is known to exist in this version.` for single vulnetabilities and `The following <b>7</b> security problems are known to exist in this version.` for multiple.