### PR TITLE
Edit language for clarity

### DIFF
--- a/docs/_copyright.html
+++ b/docs/_copyright.html
@@ -28,7 +28,8 @@ TITLE(Copyright - License)
  of the curl distributed archives. You may also freely use curl and libcurl in
  your commercial projects.
 <p>
- Curl and libcurl are licensed under a MIT/X derivate license, see below.
+ Curl and libcurl are licensed under the license below, which is inspired by MIT/X,
+ but not identical.
 <p>
  There are other computer-related projects using the name curl as well.  For
  details, check out <a href="../legal/thename.html">our position on the curl


### PR DESCRIPTION
The language used sometimes leads to the mistaken belief that curl is MIT/X licensed. This wording might be clearer to convey there's actually a specific curl license, which is inspired by MIT/X but not the same.