### PR TITLE
comparison-table: HTTPie supports SOCKS

### DIFF
--- a/docs/_comparison-table.html
+++ b/docs/_comparison-table.html
@@ -171,7 +171,7 @@ TITLE(Compare curl with other download tools)
 
   FEAT SOCKS ENDFEAT
 
-  YES YES no_ no_ YES no_ no_ YES no_ no_ no_ ENDLINE
+  YES YES no_ no_ YES no_ no_ YES no_ no_ YES ENDLINE
 
   FEAT TFTP ENDFEAT
 


### PR DESCRIPTION
The HTTPie tool now offers SOCKS support, as long as it's enabled in Requests. For reference see https://httpie.org/doc#socks

Closes #41
Reported-by: Github user RadRussianRus