### PR TITLE
comparison-table: add HTTPie version and license

### DIFF
--- a/docs/_comparison-table.html
+++ b/docs/_comparison-table.html
@@ -252,7 +252,7 @@ TITLE(Compare curl with other download tools)
   FEAT HSTS ENDFEAT
 
   no_ no_ no_ YES no_ no_ no_ no_ no_ no_ no_ ENDLINE
-  
+
   FEAT HTTP Digest Auth ENDFEAT
 
   YES no_ YES YES YES no_ YES no_ no_ no_ YES ENDLINE
@@ -320,6 +320,7 @@ TITLE(Compare curl with other download tools)
   NEWCOL GPL ENDCOL
   NEWCOL GPL ENDCOL
   NEWCOL GPL ENDCOL
+  NEWCOL BSD ENDCOL
  ENDLINE
 
   FEAT Version ENDFEAT
@@ -333,6 +334,7 @@ TITLE(Compare curl with other download tools)
   NEWCOL 3.5.0 ENDCOL
   NEWCOL 1.8.3 ENDCOL
   NEWCOL 3.43 ENDCOL
+  NEWCOL 1.0.2 ENDCOL
  ENDLINE
 
  </tbody>
@@ -360,7 +362,7 @@ libcurl does.
 <p>
 * HTTPie is written in Python + Requests and thus carry their
  portability and features
-  
+
 <p>
  Please file <a href="https://github.com/curl/curl-www/issues">a bug
  report</a> if this table is incorrect, or tell us other features we


### PR DESCRIPTION
The version and license columns went missing when HTTPie was added
to the table, causing the final two rows to be unaligned with the
content. Fix by adding version 1.0.2 as BSD licensed as per the
docs on https://httpie.org/doc

Closes #4X