### PR TITLE
curl.css: use fixed margin for mobile screen, scale the front page image

### DIFF
--- a/_index.html
+++ b/_index.html
@@ -73,7 +73,7 @@ Currently, __CURR of the listed <a href="download.html" title="Binary download p
 
 TITLE(Everything curl)
 <a href="https://curl.haxx.se/book.html">
-<img style="margin: 0px 0px 20px 20px;" align="right" width="200" height="262" border="0" src="pix/everything-curl.jpg" alt="Everything curl book cover"></a>
+<img style="margin: 0px 0px 10px 10px;" align="right" width="200" height="262" class="scale" border="0" src="pix/everything-curl.jpg" alt="Everything curl book cover"></a>
 <p>
   <a href="https://curl.haxx.se/book.html">Everything curl</a> is a detailed
   and totally free book available in several formats, that explains basically

--- a/curl.css
+++ b/curl.css
@@ -350,6 +350,18 @@ div.yellowbox {
   margin-right: auto;
 }
 
+@media screen and (max-width: 640px) {
+    .contents {
+        margin-left: 5px;
+        margin-right: 5px;
+    }
+    img.scale {
+        max-width: 30%;
+    }
+}
+
+
+
 /* Filtering menus on the autobuild page */
 .filtermenu {
   /* Position select box to the right of the text */


### PR DESCRIPTION
The "responsive design tool" on Firefox shows the image to only scale the book image horizontally at times though which makes me uncertain that this is a good way...

Fixes #44
Reported-by: Dan Jacobson