### PR TITLE
dev: Terminate all lines with semicolon

### DIFF
--- a/dev/dev.js
+++ b/dev/dev.js
@@ -140,7 +140,7 @@ function filterSystemBuilds() {
 
 function filterLine() {
     var selected;
-    linefiltername = ""
+    linefiltername = "";
 
     /* Alternate between showing all and showing just this build */
     if (linefilter) {
@@ -183,7 +183,7 @@ function filterLine() {
 
 function filterLineName() {
     var selected;
-    linefilter = ""
+    linefilter = "";
 
     /* Alternate between showing all and showing just this builder */
     if (linefiltername) {


### PR DESCRIPTION
While the current coding is legal Javascript, relying on the automatic semicolon insertion can hide subtleties. Also, fixing these two small things will give us a clean bill of health on LGTM as a bonus.