### PR TITLE
relinfo: report vuln count in csv correctly

### DIFF
--- a/docs/relinfo.pl
+++ b/docs/relinfo.pl
@@ -147,19 +147,9 @@ for my $str (@releases) {
                $numreleases - $index);
     }
     $index++;
-    my $vulc=0;
 
-#   my $vulstr;
-#    for my $i (0 .. scalar(@vuln)-1 ) {
-#        if($v[$i]) {
-#            $vulstr .= sprintf("<a href=\"%s\" title=\"%s - %s\">#%d</a> ",
-#                               $vulnurl[$i+1], $vulntitle[$i+1], $vulnid[$i+1],
-#                               $i+1);
-#            $vulc++;
-#        }
-#    }
     if($raw) {
-        printf "%d;", $vulc;
+        printf "%d;", $vulns{$str};
     }
 
     if($date =~ /([A-Za-z]+) (\d+) (\d\d\d\d)/) {


### PR DESCRIPTION
Simple fix for the CSV produced by `relinfo.pl --raw`
It currently reports `0` as vulnerability count for all releases.

This makes it use the values that are loaded from `allvulns.gen`, like the html output does.