### PR TITLE
autobuild: Remove mention of coveralls

### DIFF
--- a/dev/_builds.html
+++ b/dev/_builds.html
@@ -16,7 +16,6 @@ WHERE2(Development, "/dev/", Automatic Builds)
 <br><a href="howto.html">Howto autobuild</a>
 <br><a href="https://ci.appveyor.com/project/curlorg/curl">AppVeyor CI builds</a>
 <br><a href="https://travis-ci.org/curl/curl/builds">Travis CI builds</a>
-<br><a href="https://coveralls.io/github/curl/curl">Coveralls code coverage builds</a>
 </div>
 
 TITLE(Automatic Builds)


### PR DESCRIPTION
Commit 83c0e96057a6cc61282512dd9204cd78e6c89543 in the curl repo removed the coveralls service from the repo, due to the unreliable results. This removes the mention from the autobuilds page as well.