### PR TITLE
vulntable: fix bug causing incorrect vulns to show in table

### DIFF
--- a/docs/vulntable.pl
+++ b/docs/vulntable.pl
@@ -28,8 +28,7 @@ sub head {
     for(@vuln) {
         my ($id, $start, $stop, $desc, $cve, $announce, $report, $cwe)=split('\|');
 
-        if($lastshow &&
-           !(($lastshow >= vernum($start)) && ($lastshow <= vernum($stop)))) {
+        if($lastshow && ($lastshow > vernum($stop))) {
             # not a match!
             next;
         }


### PR DESCRIPTION
The old condition check incorrectly excluded those vulnerabilties
that were both reported and fixed in a version > lastshow.
The check is fixed to exclude only those vulnerabilities that were
fixed in a version before lastshow.