### PR TITLE
changes: Fix various HTML validation errors/warnings

### DIFF
--- a/_changes.html
+++ b/_changes.html
@@ -47,7 +47,7 @@ SUBTITLE(-- Fixed in 7.20.0 - February 9 2011)
 #define RELEASEVIDEO(desc,video)                                       \
   <div style="height: 3em; line-height: 3em; font-size: 120%;">  \
   <a href=video>                        \
-  <img src="pix/play.svg" height="100%" style="float: left; margin-right: 1em;"> desc </a> \
+  <img src="pix/play.svg" alt="Play video" height="100%" style="float: left; margin-right: 1em;"> desc </a> \
   </div>
 
 <a name="7_73_0"></a>
@@ -62,7 +62,7 @@ SUBTITLE(Fixed in 7.73.0 - October 14 2020)
  CHG <a href="https://curl.se/bug/?i=5365">curl_easy_option_*: new API for meta-data about easy options</a>
  CHG <a href="https://curl.se/bug/?i=5770">CURLE_PROXY: new error code</a>
  CHG <a href="https://curl.se/bug/?i=5858">mqtt: enable by default</a>
- CHG <a href="https://curl.se/bug/?i=5810">sftp: add new quote commands &apos;atime&apos; and &apos;mtime&apos;</a>
+ CHG <a href="https://curl.se/bug/?i=5810">sftp: add new quote commands &#39;atime&#39; and &#39;mtime&#39;</a>
  CHG <a href="https://curl.se/bug/?i=5685">ssh: add the option CURLKHSTAT_FINE_REPLACE</a>
  CHG <a href="https://curl.se/bug/?i=5892">tls: add CURLOPT_SSL_EC_CURVES and --curves</a>
 </ul>
@@ -72,7 +72,7 @@ SUBTITLE(Fixed in 7.73.0 - October 14 2020)
  BGF <a href="https://curl.se/bug/?i=5937">base64: also build for smtp, pop3 and imap</a>
  BGF <a href="https://curl.se/bug/?i=5979">BUGS: convert document to markdown</a>
  BGF <a href="https://curl.se/bug/?i=6033">build-wolfssl: fix build with Visual Studio 2019</a>
- BGF <a href="https://curl.se/bug/?i=5853">buildconf: invoke &apos;autoreconf -fi&apos; instead</a>
+ BGF <a href="https://curl.se/bug/?i=5853">buildconf: invoke &#39;autoreconf -fi&#39; instead</a>
  BGF <a href="https://curl.se/bug/?i=6048">checksrc: detect // comments on column 0</a>
  BGF <a href="https://curl.se/bug/?i=5845">checksrc: verify do-while and spaces between the braces</a>
  BGF <a href="https://curl.se/bug/?i=6034">checksrc: warn on space after exclamation mark</a>
@@ -87,14 +87,14 @@ SUBTITLE(Fixed in 7.73.0 - October 14 2020)
  BGF <a href="https://curl.se/bug/?i=5439">CMake: remove explicit `CMAKE_ANSI_CFLAGS`</a>
  BGF <a href="https://curl.se/bug/?i=5984">cmake: remove scary warning</a>
  BGF <a href="https://curl.se/bug/?i=5898">cmdline-opts/gen.pl: generate nicer &quot;See Also&quot; in curl.1</a>
- BGF <a href="https://github.com/curl/curl/pull/5735#issuecomment-701376388">configure: don&apos;t say HTTPS-proxy is enabled when disabled</a>
+ BGF <a href="https://github.com/curl/curl/pull/5735#issuecomment-701376388">configure: don&#39;t say HTTPS-proxy is enabled when disabled</a>
  BGF <a href="https://curl.se/bug/?i=5848">configure: fix pkg-config detecting wolfssl</a>
  BGF <a href="https://curl.se/bug/?i=5930">configure: let --enable-debug set -Wenum-conversion with gcc &gt;= 10</a>
  BGF <a href="https://curl.se/bug/?i=5884">conn: check for connection being dead before reuse</a>
- BGF <a href="https://curl.se/bug/?i=5912">connect.c: remove superfluous &apos;else&apos; in Curl_getconnectinfo</a>
+ BGF <a href="https://curl.se/bug/?i=5912">connect.c: remove superfluous &#39;else&#39; in Curl_getconnectinfo</a>
  BGF <a href="https://curl.se/bug/?i=5897">curl.1: add see also no-progress-meter on two spots</a>
  BGF <a href="https://curl.se/bug/?i=5846">curl.1: fix typo invokved -&gt; invoked</a>
- BGF <a href="https://curl.se/bug/?i=5916">curl: in retry output don&apos;t call all problems &quot;transient&quot;</a>
+ BGF <a href="https://curl.se/bug/?i=5916">curl: in retry output don&#39;t call all problems &quot;transient&quot;</a>
  BGF <a href="https://curl.se/bug/?i=6031">curl: make --libcurl show binary posts correctly</a>
  BGF <a href="https://curl.se/bug/?i=5952">curl: make checkpasswd use dynbuf</a>
  BGF <a href="https://curl.se/bug/?i=5952">curl: make file2memory use dynbuf</a>
@@ -105,9 +105,9 @@ SUBTITLE(Fixed in 7.73.0 - October 14 2020)
  BGF <a href="https://curl.se/bug/?i=5946">curl: use curlx_dynbuf for realloc when loading config files</a>
  BGF <a href="https://curl.se/bug/?i=5905">curl:parallel_transfers: make sure retry readds the transfer</a>
  BGF <a href="https://curl.se/bug/?i=5851">curl_get_line: build only if cookies or alt-svc are enabled</a>
- BGF <a href="https://curl.se/bug/?i=5942">curl_mime_headers.3: fix the example&apos;s use of curl_slist_append</a>
+ BGF <a href="https://curl.se/bug/?i=5942">curl_mime_headers.3: fix the example&#39;s use of curl_slist_append</a>
  BGF <a href="https://curl.se/bug/?i=5583">Curl_pgrsTime - return new time to avoid timeout integer overflow</a>
- BGF <a href="https://curl.se/bug/?i=6011">Curl_send: return error when pre_receive_plain can&apos;t malloc</a>
+ BGF <a href="https://curl.se/bug/?i=6011">Curl_send: return error when pre_receive_plain can&#39;t malloc</a>
  BGF <a href="https://curl.se/bug/?i=5836">dist: add missing CMake Find modules to the distribution</a>
  BGF <a href="https://curl.se/bug/?i=5955">docs/LICENSE-MIXING: remove</a>
  BGF <a href="https://curl.se/bug/?i=6039">docs/opts: fix typos in two manual pages</a>
@@ -165,7 +165,7 @@ SUBTITLE(Fixed in 7.73.0 - October 14 2020)
  BGF runtests: allow generating a binary sequence from hex
  BGF <a href="https://curl.se/mail/lib-2020-08/0018.html">runtests: clear pid variables when failing to start a server</a>
  BGF <a href="https://curl.se/bug/?i=5838">runtests: make cleardir() erase dot files too</a>
- BGF <a href="https://curl.se/bug/?i=6037">runtests: provide curl&apos;s version string as %VERSION for tests</a>
+ BGF <a href="https://curl.se/bug/?i=6037">runtests: provide curl&#39;s version string as %VERSION for tests</a>
  BGF <a href="https://curl.se/bug/?i=5855">schannel: fix memory leak when using get_cert_location</a>
  BGF <a href="https://curl.se/bug/?i=6003">schannel: return CURLE_PEER_FAILED_VERIFICATION for untrusted root</a>
  BGF scripts: improve the &quot;get latest curl release tag&quot; logic
@@ -232,7 +232,7 @@ SUBTITLE(Fixed in 7.72.0 - August 19 2020)
  BGF <a href="https://curl.se/bug/?i=5694">CI/macos: unconditionally enable warnings-as-errors with autotools</a>
  BGF <a href="https://curl.se/bug/?i=5772">CI: Add muse CI analyzer</a>
  BGF <a href="https://curl.se/bug/?i=5668">cirrus-ci: upgrade 11-STABLE to 11.4</a>
- BGF <a href="https://curl.se/bug/?i=5817">CMake: don&apos;t complain about missing nroff</a>
+ BGF <a href="https://curl.se/bug/?i=5817">CMake: don&#39;t complain about missing nroff</a>
  BGF <a href="https://curl.se/bug/?i=5714">CMake: fix test for warning suppressions</a>
  BGF <a href="https://curl.se/bug/?i=5662">cmake: fix windows xp build</a>
  BGF <a href="https://curl.se/bug/?i=5656">configure.ac: Sort features name in summary</a>
@@ -255,8 +255,8 @@ SUBTITLE(Fixed in 7.72.0 - August 19 2020)
  BGF <a href="https://curl.se/bug/?i=5688">docs: Update a few leftover mentions of DarwinSSL</a>
  BGF <a href="https://curl.se/bug/?i=5704">doh: remove redundant cast</a>
  BGF <a href="https://curl.se/bug/?i=5683">file2memory: use a define instead of -1 unsigned value</a>
- BGF <a href="https://curl.se/bug/?i=5797">ftp: don&apos;t do ssl_shutdown instead of ssl_close</a>
- BGF <a href="https://curl.se/bug/?i=5639">ftpserver: don&apos;t verify SMTP MAIL FROM names</a>
+ BGF <a href="https://curl.se/bug/?i=5797">ftp: don&#39;t do ssl_shutdown instead of ssl_close</a>
+ BGF <a href="https://curl.se/bug/?i=5639">ftpserver: don&#39;t verify SMTP MAIL FROM names</a>
  BGF <a href="https://curl.se/bug/?i=5661">getinfo: reset retry-after value in initinfo</a>
  BGF <a href="https://curl.se/bug/?i=5645">gnutls: repair the build with `CURL_DISABLE_PROXY`</a>
  BGF <a href="https://curl.se/bug/?i=5778">gtls: survive not being able to get name/issuer</a>
@@ -265,10 +265,10 @@ SUBTITLE(Fixed in 7.72.0 - August 19 2020)
  BGF <a href="https://curl.se/bug/?i=5641">http2: fix nghttp2_strerror -> nghttp2_http2_strerror in debug messages</a>
  BGF <a href="https://github.com/curl/curl/commit/7370b4e39f1390e701f5b68d910c619151daf72b#r41334700">libssh2: s/ssherr/sftperr/</a>
  BGF <a href="https://curl.se/bug/?i=5819">libtest/Makefile.am: add -no-undefined for libstubgss for Cygwin</a>
- BGF <a href="https://curl.se/bug/?i=5695">md(4|5): don&apos;t use deprecated macOS functions</a>
+ BGF <a href="https://curl.se/bug/?i=5695">md(4|5): don&#39;t use deprecated macOS functions</a>
  BGF <a href="https://curl.se/bug/?i=5722">mprintf: Fix dollar string handling</a>
  BGF <a href="https://curl.se/bug/?i=5722">mprintf: Fix stack overflows</a>
- BGF <a href="https://curl.se/bug/?i=5759">multi: Condition &apos;extrawait&apos; is always true</a>
+ BGF <a href="https://curl.se/bug/?i=5759">multi: Condition &#39;extrawait&#39; is always true</a>
  BGF <a href="https://curl.se/bug/?i=5805">multi: Remove 10-year old out-commented code</a>
  BGF <a href="https://curl.se/bug/?i=5676">multi: remove two checks always true</a>
  BGF <a href="https://curl.se/bug/?i=5737">multi: update comment to say easyp list is linear</a>
@@ -278,7 +278,7 @@ SUBTITLE(Fixed in 7.72.0 - August 19 2020)
  BGF <a href="https://curl.se/bug/?i=5675">ngtcp2: update to modified qlog callback prototype</a>
  BGF <a href="https://curl.se/bug/?i=5667">nss: fix build with disabled proxy support</a>
  BGF <a href="https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24379">ntlm: free target_info before (re-)malloc</a>
- BGF <a href="https://curl.se/bug/?i=5757">openssl: fix build with LibreSSL < 2.9.1</a>
+ BGF <a href="https://curl.se/bug/?i=5757">openssl: fix build with LibreSSL &lt; 2.9.1</a>
  BGF <a href="https://curl.se/bug/?i=5679">page-header: provide protocol details in the curl.1 man page</a>
  BGF <a href="https://curl.se/bug/?i=5726">quiche: handle calling disconnect twice</a>
  BGF <a href="https://curl.se/bug/?i=5762">runtests.pl: treat LibreSSL and BoringSSL as OpenSSL</a>
@@ -307,7 +307,7 @@ SUBTITLE(Fixed in 7.72.0 - August 19 2020)
  BGF <a href="https://curl.se/bug/?i=5734">transfer: fix data_pending for builds with both h2 and h3 enabled</a>
  BGF <a href="https://curl.se/bug/?i=5665">transfer: fix memory-leak with CURLOPT_CURLU in a duped handle</a>
  BGF <a href="https://curl.se/bug/?i=5794">transfer: move retrycount from connect struct to easy handle</a>
- BGF <a href="https://curl.se/bug/?i=5773">travis/script.sh: fix use of `-n&apos; with unquoted envvar</a>
+ BGF <a href="https://curl.se/bug/?i=5773">travis/script.sh: fix use of `-n&#39; with unquoted envvar</a>
  BGF <a href="https://curl.se/bug/?i=5752">travis: add ppc64le and s390x builds</a>
  BGF <a href="https://curl.se/bug/?i=5691">travis: update quiche builds for new boringssl layout</a>
  BGF <a href="https://curl.se/bug/?i=5709">url: fix CURLU and location following</a>
@@ -351,7 +351,7 @@ SUBTITLE(Fixed in 7.71.0 - June 24 2020)
   RELEASEVIDEO(curl 7.71.0 release video, "https://youtu.be/E4gtW3kS1Cw")
 <p> Changes:
 <ul class="changes">
- CHG <a href="https://curl.se/bug/?i=4346">CURLOPT_SSL_OPTIONS: optional use of Windows&apos; CA store (with openssl)</a>
+ CHG <a href="https://curl.se/bug/?i=4346">CURLOPT_SSL_OPTIONS: optional use of Windows&#39; CA store (with openssl)</a>
  CHG <a href="https://curl.se/bug/?i=5431">setopt: add CURLOPT_PROXY_ISSUERCERT(_BLOB) for coherency</a>
  CHG <a href="https://curl.se/bug/?i=5357">setopt: support certificate options in memory with struct curl_blob</a>
  CHG <a href="https://curl.se/bug/?i=5185">tool: Add option --retry-all-errors to retry on any error</a>
@@ -361,7 +361,7 @@ SUBTITLE(Fixed in 7.71.0 - June 24 2020)
  BGF <a href="https://curl.se/bug/?i=5355">*_sspi: fix bad uses of CURLE_NOT_BUILT_IN</a>
  BGF <a href="https://curl.se/bug/?i=5452">all: fix codespell errors</a>
  BGF <a href="https://curl.se/bug/?i=5584">altsvc: bump to h3-29</a>
- BGF altsvc: fix &apos;dsthost&apos; may be used uninitialized in this function
+ BGF altsvc: fix &#39;dsthost&#39; may be used uninitialized in this function
  BGF <a href="https://curl.se/bug/?i=5445">altsvc: fix parser for lines ending with CRLF</a>
  BGF <a href="https://curl.se/bug/?i=5553">altsvc: remove the num field from the altsvc struct</a>
  BGF <a href="https://curl.se/bug/?i=5477">appveyor: add non-debug plain autotools-based build</a>
@@ -372,7 +372,7 @@ SUBTITLE(Fixed in 7.71.0 - June 24 2020)
  BGF <a href="https://curl.se/bug/?i=5466">build: disable more code/data when built without proxy support</a>
  BGF buildconf: remove -print from the find command that removes files
  BGF <a href="https://curl.se/bug/?i=5386">checksrc: enhance the ASTERISKSPACE and update code accordingly</a>
- BGF <a href="https://curl.se/bug/?i=5513">CI/macos: fix &apos;is already installed&apos; errors by using bundle</a>
+ BGF <a href="https://curl.se/bug/?i=5513">CI/macos: fix &#39;is already installed&#39; errors by using bundle</a>
  BGF <a href="https://curl.se/bug/?i=5315">cirrus: disable SFTP and SCP tests</a>
  BGF CMake: add ENABLE_ALT_SVC option
  BGF <a href="https://curl.se/bug/?i=5359">CMake: add HTTP/3 support (ngtcp2+nghttp3, quiche)</a>
@@ -417,7 +417,7 @@ SUBTITLE(Fixed in 7.71.0 - June 24 2020)
  BGF <a href="https://curl.se/bug/?i=5566">http: move header storage to Curl_easy from connectdata</a>
  BGF <a href="https://curl.se/bug/?i=5373">libcurl.pc: Merge Libs.private into Libs for static-only builds</a>
  BGF <a href="https://curl.se/bug/?i=5474">libssh2: improved error output for wrong quote syntax</a>
- BGF <a href="https://curl.se/bug/?i=5534">libssh2: keep sftp errors as &apos;unsigned long&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=5534">libssh2: keep sftp errors as &#39;unsigned long&#39;</a>
  BGF <a href="https://curl.se/mail/archive-2020-05/0000.html">libssh2: set the expected total size in SCP upload init</a>
  BGF <a href="https://curl.se/bug/?i=5311">libtest/cmake: Remove commented code</a>
  BGF list-only.d: this option existed already in 4.0
@@ -477,8 +477,8 @@ SUBTITLE(Fixed in 7.71.0 - June 24 2020)
  BGF travis: add "qlog" as feature in the quiche build
  BGF travis: Add ngtcp2 and quiche tests for CMake
  BGF <a href="https://curl.se/bug/?i=5370">travis: upgrade to bionic, clang-9, improve readability</a>
- BGF <a href="https://curl.se/bug/?i=5432">typecheck-gcc.h: CURLINFO_PRIVATE does not need a &apos;char *&apos;</a>
- BGF <a href="https://curl.se/bug/?i=5476">unit1604.c: fix implicit conv from &apos;SANITIZEcode&apos; to &apos;CURLcode&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=5432">typecheck-gcc.h: CURLINFO_PRIVATE does not need a &#39;char *&#39;</a>
+ BGF <a href="https://curl.se/bug/?i=5476">unit1604.c: fix implicit conv from &#39;SANITIZEcode&#39; to &#39;CURLcode&#39;</a>
  BGF <a href="https://curl.se/bug/?i=5448">url: accept "any length" credentials for proxy auth</a>
  BGF <a href="https://curl.se/bug/?i=5472">url: alloc the download buffer at transfer start</a>
  BGF <a href="https://github.com/jeroen/curl/issues/224">url: make the updated credentials URL-encoded in the URL</a>
@@ -505,7 +505,7 @@ SUBTITLE(Fixed in 7.70.0 - April 29 2020)
  CHG <a href="https://curl.se/bug/?i=4981">curl: add --ssl-revoke-best-effort to allow a "best effort" revocation check</a>
  CHG <a href="https://curl.se/bug/?i=5173">mqtt: add new experimental protocol</a>
  CHG <a href="https://curl.se/bug/?i=4981">schannel: add "best effort" revocation check option: CURLSSLOPT_REVOKE_BEST_EFFORT</a>
- CHG <a href="https://curl.se/bug/?i=4870">writeout: support to generate JSON output with &apos;%{json}&apos;</a>
+ CHG <a href="https://curl.se/bug/?i=4870">writeout: support to generate JSON output with &#39;%{json}&#39;</a>
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -535,8 +535,8 @@ SUBTITLE(Fixed in 7.70.0 - April 29 2020)
  BGF <a href="https://github.com/curl/curl/issues/5182#issuecomment-611638008">compressed.d: stress that the headers are not modified</a>
  BGF <a href="https://curl.se/bug/?i=5144">config: remove all defines of HAVE_DES_H</a>
  BGF <a href="https://curl.se/bug/?i=5060">configure: convert -I to -isystem as a last step</a>
- BGF <a href="https://curl.se/bug/?i=5069">configure: document &apos;compiler_num&apos; for gcc</a>
- BGF <a href="https://curl.se/bug/?i=5189">configure: don&apos;t check for Security.framework when cross-compiling</a>
+ BGF <a href="https://curl.se/bug/?i=5069">configure: document &#39;compiler_num&#39; for gcc</a>
+ BGF <a href="https://curl.se/bug/?i=5189">configure: don&#39;t check for Security.framework when cross-compiling</a>
  BGF <a href="https://curl.se/bug/?i=5067">configure: fix -pedantic-errors for GCC 5 and later</a>
  BGF <a href="https://curl.se/bug/?i=5096">configure: remove use of -vec-report0 from CFLAGS with icc</a>
  BGF <a href="https://curl.se/bug/?i=4954">connect: happy eyeballs cleanup</a>
@@ -557,12 +557,12 @@ SUBTITLE(Fixed in 7.70.0 - April 29 2020)
  BGF <a href="https://curl.se/bug/?i=5171">examples/sessioninfo.c: add include to fix compiler warning</a>
  BGF <a href="https://curl.se/bug/?i=5201">github actions: run when pushed to master or &#42;/ci + PRs</a>
  BGF <a href="https://curl.se/bug/?i=5276">gnutls: bump lowest supported version to 3.1.10</a>
- BGF <a href="https://curl.se/bug/?i=5271">gnutls: Don&apos;t skip really long certificate fields</a>
- BGF <a href="https://curl.se/bug/?i=5223">gnutls: ensure TLS 1.3 when SRP isn&apos;t requested</a>
+ BGF <a href="https://curl.se/bug/?i=5271">gnutls: Don&#39;t skip really long certificate fields</a>
+ BGF <a href="https://curl.se/bug/?i=5223">gnutls: ensure TLS 1.3 when SRP isn&#39;t requested</a>
  BGF <a href="https://curl.se/bug/?i=5214">gopher: check remaining time left during write busy loop</a>
  BGF <a href="https://curl.se/bug/?i=5106">gskit: use our internal select wrapper for portability</a>
  BGF <a href="https://curl.se/bug/?i=5118">http2: Fix erroneous debug message that h2 connection closed</a>
- BGF <a href="https://curl.se/bug/?i=4919">http: don&apos;t consider upload done if the request isn&apos;t completely sent off</a>
+ BGF <a href="https://curl.se/bug/?i=4919">http: don&#39;t consider upload done if the request isn&#39;t completely sent off</a>
  BGF <a href="https://curl.se/bug/?i=5268">http: free memory when Alt-Used header creation fails due to OOM</a>
  BGF <a href="https://curl.se/bug/?i=5278">lib/mk-ca-bundle: skip empty certs</a>
  BGF lib670: use the same Win32 API check as all other lib tests
@@ -574,7 +574,7 @@ SUBTITLE(Fixed in 7.70.0 - April 29 2020)
  BGF mailmap: fixup a few author names/fields
  BGF <a href="https://curl.se/bug/?i=5099">Makefile.m32: Improve windres parameter compatibility</a>
  BGF <a href="https://curl.se/bug/?i=5073">Makefile: run the cd commands in a subshell</a>
- BGF memdebug: don&apos;t log free(NULL)
+ BGF memdebug: don&#39;t log free(NULL)
  BGF <a href="https://curl.se/bug/?i=5256">mime: properly check Content-Type even if it has parameters</a>
  BGF <a href="https://curl.se/bug/?i=5255">multi-ssl: reset the SSL backend on `Curl_global_cleanup()`</a>
  BGF <a href="https://curl.se/bug/?i=5116">multi: improve parameter check for curl_multi_remove_handle</a>
@@ -636,12 +636,12 @@ SUBTITLE(Fixed in 7.70.0 - April 29 2020)
  BGF <a href="https://curl.se/bug/?i=5301">travis: bump the wolfssl CI build to use 4.4.0</a>
  BGF travis: update the ngtcp2 build to use the latest OpenSSL patch
  BGF <a href="https://curl.se/bug/?i=5205">url: allow non-HTTPS altsvc-matching for debug builds</a>
- BGF <a href="https://curl.se/bug/?i=5150">version: add &apos;cainfo&apos; and &apos;capath&apos; to version info struct</a>
+ BGF <a href="https://curl.se/bug/?i=5150">version: add &#39;cainfo&#39; and &#39;capath&#39; to version info struct</a>
  BGF <a href="https://curl.se/bug/?i=5222">version: increase buffer space for ssl version output</a>
  BGF <a href="https://curl.se/bug/?i=5281">version: skip idn2_check_version() check and add precaution</a>
  BGF <a href="https://curl.se/bug/?i=5148">vquic: add support for GnuTLS backend of ngtcp2</a>
  BGF <a href="https://curl.se/bug/?i=5108">vtls: fix ssl_config memory-leak on out-of-memory</a>
- BGF <a href="https://curl.se/bug/?i=5096">warnless: remove code block for icc that didn&apos;t work</a>
+ BGF <a href="https://curl.se/bug/?i=5096">warnless: remove code block for icc that didn&#39;t work</a>
  BGF windows: enable UnixSockets with all build toolchains
  BGF <a href="https://curl.se/bug/?i=5088">windows: suppress UI in all CryptAcquireContext() calls</a>
 </ul>
@@ -654,7 +654,7 @@ SUBTITLE(Fixed in 7.69.1 - March 11 2020)
 <ul class="bugfixes">
  BGF <a href="https://curl.se/bug/?i=4893">ares: store dns parameters for duphandle</a>
  BGF <a href="https://curl.se/bug/?i=5028">cirrus-ci: disable the FreeBSD 13 builds</a>
- BGF <a href="https://curl.se/mail/lib-2020-03/0019.html">curl_share_setopt.3: Note sharing cookies doesn&apos;t enable the engine</a>
+ BGF <a href="https://curl.se/mail/lib-2020-03/0019.html">curl_share_setopt.3: Note sharing cookies doesn&#39;t enable the engine</a>
  BGF <a href="https://curl.se/bug/?i=5037">lib1564: reduce number of mid-wait wakeup calls</a>
  BGF <a href="https://curl.se/bug/?i=4971">libssh: Fix matching user-specified MD5 hex key</a>
  BGF MANUAL: update a dict-using command line
@@ -664,7 +664,7 @@ SUBTITLE(Fixed in 7.69.1 - March 11 2020)
  BGF <a href="https://curl.se/bug/?i=5047">multi: skip EINTR check on wakeup socket if it was closed</a>
  BGF <a href="https://curl.se/bug/?i=5050">pause: bail out on bad input</a>
  BGF <a href="https://curl.se/bug/?i=5049">pause: force a connection recheck after unpausing (take 2)</a>
- BGF <a href="https://curl.se/bug/?i=5026">pause: return early for calls that don&apos;t change pause state</a>
+ BGF <a href="https://curl.se/bug/?i=5026">pause: return early for calls that don&#39;t change pause state</a>
  BGF <a href="https://curl.se/bug/?i=5033">runtests.1: rephrase how to specify what tests to run</a>
  BGF runtests: fix missing use of exe_ext helper function
  BGF <a href="https://curl.se/bug/?i=5055">seek: fix fall back for missing ftruncate on Windows</a>
@@ -677,7 +677,7 @@ SUBTITLE(Fixed in 7.69.1 - March 11 2020)
  BGF <a href="https://curl.se/bug/?i=5065">tests: fix static ip:port instead of dynamic values being used</a>
  BGF <a href="https://curl.se/bug/?i=5035">tests: make sleeping portable by avoiding select</a>
  BGF <a href="https://curl.se/bug/?i=5024">unit1612: fix the inclusion and compilation of the HMAC unit test</a>
- BGF <a href="https://curl.se/bug/?i=5046">urldata: remove the &apos;stream_was_rewound&apos; connectdata struct member</a>
+ BGF <a href="https://curl.se/bug/?i=5046">urldata: remove the &#39;stream_was_rewound&#39; connectdata struct member</a>
  BGF <a href="https://curl.se/bug/?i=5010">version: make curl_version* thread-safe without using global context</a>
 </ul>
 
@@ -726,8 +726,8 @@ SUBTITLE(Fixed in 7.69.0 - March 4 2020)
  BGF <a href="https://curl.se/bug/?i=4762">curl: let -D merge headers in one file again</a>
  BGF <a href="https://curl.se/bug/?i=4812">curl: make #0 not output the full URL</a>
  BGF <a href="https://curl.se/bug/?i=4849">curl: make the -# spaceship bar not wrap the line</a>
- BGF <a href="https://curl.se/bug/?i=4807">curl: remove &apos;config&apos; field from OutStruct</a>
- BGF <a href="https://curl.se/bug/?i=4818">curl:progressbarinit: ignore column width from terminals < 20</a>
+ BGF <a href="https://curl.se/bug/?i=4807">curl: remove &#39;config&#39; field from OutStruct</a>
+ BGF <a href="https://curl.se/bug/?i=4818">curl:progressbarinit: ignore column width from terminals &lt; 20</a>
  BGF <a href="https://curl.se/bug/?i=5016">curl_escape.3: add a link to curl_free</a>
  BGF <a href="https://curl.se/bug/?i=5016">curl_getenv.3: fix the memory handling description</a>
  BGF <a href="https://curl.se/bug/?i=4840">curl_global_init: assume the EINTR bit by default</a>
@@ -738,18 +738,18 @@ SUBTITLE(Fixed in 7.69.0 - March 4 2020)
  BGF <a href="https://curl.se/bug/?i=4943">CURLOPT_REDIR_PROTOCOLS.3: update the DEFAULT section</a>
  BGF <a href="https://curl.se/mail/archive-2020-01/0016.html">data.d: remove "Multiple files can also be specified"</a>
  BGF <a href="https://curl.se/bug/?i=4890">digest: do not quote algorithm in HTTP authorisation</a>
- BGF docs/HTTP3: add --enable-alt-svc to curl&apos;s configure
+ BGF docs/HTTP3: add --enable-alt-svc to curl&#39;s configure
  BGF docs/HTTP3: update the OpenSSL branch to use for ngtcp2
  BGF <a href="https://curl.se/bug/?i=5005">docs: fix typo on CURLINFO_RETRY_AFTER</a>
  BGF <a href="https://curl.se/bug/?i=4900">easy: remove dead code</a>
  BGF <a href="https://curl.se/bug/?i=4843">form.d: fix two minor typos</a>
- BGF <a href="https://curl.se/bug/?i=4929">ftp: convert &apos;sock_accepted&apos; to a plain boolean</a>
+ BGF <a href="https://curl.se/bug/?i=4929">ftp: convert &#39;sock_accepted&#39; to a plain boolean</a>
  BGF <a href="https://curl.se/bug/?i=4887">ftp: remove superfluous checking for crlf in user or pwd</a>
  BGF <a href="https://curl.se/bug/?i=4880">ftp: shrink temp buffers used for PORT</a>
  BGF <a href="https://curl.se/bug/?i=4960">github action: add CIFuzz</a>
  BGF <a href="https://curl.se/bug/?i=4896">github: Instructions to post "uname -a" on Unix systems in issues</a>
  BGF <a href="https://curl.se/bug/?i=1411">GnuTLS: always send client cert</a>
- BGF <a href="https://curl.se/bug/?i=4984">gtls: fixed compilation when using GnuTLS < 3.5.0</a>
+ BGF <a href="https://curl.se/bug/?i=4984">gtls: fixed compilation when using GnuTLS &lt; 3.5.0</a>
  BGF <a href="https://curl.se/bug/?i=4798">hostip: move code to resolve IP address literals to `Curl_resolv`</a>
  BGF <a href="https://curl.se/bug/?i=4805">HTTP-COOKIES: describe the cookie file format</a>
  BGF <a href="https://curl.se/bug/?i=4946">HTTP-COOKIES: mention that a trailing newline is required</a>
@@ -772,7 +772,7 @@ SUBTITLE(Fixed in 7.69.0 - March 4 2020)
  BGF <a href="https://curl.se/bug/?i=4834">mk-ca-bundle: add support for CKA_NSS_SERVER_DISTRUST_AFTER</a>
  BGF <a href="https://curl.se/bug/?i=4763">multi: change curl_multi_wait/poll to error on negative timeout</a>
  BGF <a href="https://curl.se/bug/?i=4901">multi: fix outdated comment</a>
- BGF <a href="https://curl.se/bug/?i=4927">multi: if Curl_readwrite sets &apos;comeback&apos; use expire, not loop</a>
+ BGF <a href="https://curl.se/bug/?i=4927">multi: if Curl_readwrite sets &#39;comeback&#39; use expire, not loop</a>
  BGF <a href="https://curl.se/bug/?i=4845">multi_done: if multiplexed, make conn->data point to another transfer</a>
  BGF <a href="https://curl.se/mail/archive-2020-02/0011.html">multi_wait: stop loop when sread() returns zero</a>
  BGF <a href="https://curl.se/bug/?i=4754">ngtcp2: add error code for QUIC connection errors</a>
@@ -801,14 +801,14 @@ SUBTITLE(Fixed in 7.69.0 - March 4 2020)
  BGF <a href="https://curl.se/bug/?i=4907">SOCKS: make the connect phase non-blocking</a>
  BGF <a href="https://curl.se/bug/?i=4842">strcase: turn Curl_raw_tolower into static</a>
  BGF <a href="https://curl.se/bug/?i=4920">strerror: increase STRERROR_LEN 128 -> 256</a>
- BGF test1323: added missing &apos;unit test&apos; feature requirement
+ BGF test1323: added missing &#39;unit test&#39; feature requirement
  BGF <a href="https://curl.se/bug/?i=4970">tests: add a unit test for MD4 digest generation</a>
  BGF <a href="https://curl.se/bug/?i=4968">tests: add a unit test for SHA256 digest generation</a>
  BGF <a href="https://curl.se/bug/?i=4973">tests: add a unit test for the HMAC hash generation</a>
  BGF <a href="https://curl.se/bug/?i=4976">tests: deduce the tool name from the test case for unit tests</a>
  BGF tests: fix Python 3 compatibility of smbserver.py
  BGF <a href="https://curl.se/bug/?i=4796">tool_dirhie: allow directory traversal during creation</a>
- BGF <a href="https://curl.se/bug/?i=4774">tool_homedir: change GetEnv() to use libcurl&apos;s curl_getenv()</a>
+ BGF <a href="https://curl.se/bug/?i=4774">tool_homedir: change GetEnv() to use libcurl&#39;s curl_getenv()</a>
  BGF <a href="https://curl.se/bug/?i=4947">tool_util: improve Windows version of tvnow()</a>
  BGF <a href="https://curl.se/bug/?i=4872">travis: update non-OpenSSL Linux jobs to Bionic</a>
  BGF <a href="https://curl.se/bug/?i=4899">url: include the failure reason when curl_win32_idn_to_ascii() fails</a>
@@ -844,8 +844,8 @@ SUBTITLE(Fixed in 7.68.0 - January 8 2020)
  BGF HISTORY: the SMB(S) support landed in 2014
  BGF <a href="https://curl.se/bug/?i=4606">INSTALL.md: provide Android build instructions</a>
  BGF <a href="https://curl.se/bug/?i=4296">KNOWN_BUGS: Connection information when using TCP Fast Open</a>
- BGF <a href="https://curl.se/bug/?i=4261">KNOWN_BUGS: LDAP on Windows doesn&apos;t work correctly</a>
- BGF <a href="https://curl.se/bug/?i=4301">KNOWN_BUGS: TLS session cache doesn&apos;t work with TFO</a>
+ BGF <a href="https://curl.se/bug/?i=4261">KNOWN_BUGS: LDAP on Windows doesn&#39;t work correctly</a>
+ BGF <a href="https://curl.se/bug/?i=4301">KNOWN_BUGS: TLS session cache doesn&#39;t work with TFO</a>
  BGF <a href="https://curl.se/mail/lib-2019-12/0007.html">OPENSOCKETFUNCTION.3: correct the purpose description</a>
  BGF <a href="https://curl.se/bug/?i=4788">TrackMemory tests: always remove CR before LF</a>
  BGF <a href="https://curl.se/bug/?i=4604">altsvc: bump to h3-24</a>
@@ -857,7 +857,7 @@ SUBTITLE(Fixed in 7.68.0 - January 8 2020)
  BGF <a href="https://curl.se/bug/?i=4557">cirrus-ci: enable clang sanitizers on freebsd 13</a>
  BGF cirrus: Drop the FreeBSD 10.4 build
  BGF <a href="https://curl.se/bug/?i=4590">config-win32: cpu-machine-OS for Windows on ARM</a>
- BGF <a href="https://curl.se/bug/?i=4567">configure: avoid unportable `==&apos; test(1) operator</a>
+ BGF <a href="https://curl.se/bug/?i=4567">configure: avoid unportable `==&#39; test(1) operator</a>
  BGF <a href="https://curl.se/bug/?i=4662">configure: enable IPv6 support without `getaddrinfo`</a>
  BGF <a href="https://curl.se/bug/?i=4570">configure: fix typo in help text</a>
  BGF <a href="https://curl.se/bug/?i=4369">conncache: CONNECT_ONLY connections assumed always in-use</a>
@@ -878,8 +878,8 @@ SUBTITLE(Fixed in 7.68.0 - January 8 2020)
  BGF <a href="https://curl.se/bug/?i=4785">curl: show error for --http3 if libcurl lacks support</a>
  BGF <a href="https://curl.se/bug/?i=4649">curl_setup_once: consistently use WHILE_FALSE in macros</a>
  BGF <a href="https://curl.se/bug/?i=4725">define: remove HAVE_ENGINE_LOAD_BUILTIN_ENGINES, not used anymore</a>
- BGF <a href="https://curl.se/bug/?i=4618">docs: Change &apos;experiemental&apos; to &apos;experimental&apos;</a>
- BGF <a href="https://curl.se/bug/?i=4262">docs: TLS SRP doesn&apos;t work with TLS 1.3</a>
+ BGF <a href="https://curl.se/bug/?i=4618">docs: Change &#39;experiemental&#39; to &#39;experimental&#39;</a>
+ BGF <a href="https://curl.se/bug/?i=4262">docs: TLS SRP doesn&#39;t work with TLS 1.3</a>
  BGF <a href="https://curl.se/bug/?i=4680">docs: fix several typos</a>
  BGF <a href="https://curl.se/bug/?i=4783">docs: mention CURL_MAX_INPUT_LENGTH restrictions</a>
  BGF <a href="https://curl.se/bug/?i=4598">doh: improved both encoding and decoding</a>
@@ -1013,7 +1013,7 @@ SUBTITLE(Fixed in 7.67.0 - November 6 2019)
  BGF <a href="https://curl.se/bug/?i=4454">cookie: avoid harmless use after free</a>
  BGF <a href="https://curl.se/bug/?i=4386">cookie: pass in the correct cookie amount to qsort()</a>
  BGF <a href="https://curl.se/bug/?i=4455">cookies: change argument type for Curl_flush_cookies</a>
- BGF <a href="https://curl.se/bug/?i=4429">cookies: using a share with cookies shouldn&apos;t enable the cookie engine</a>
+ BGF <a href="https://curl.se/bug/?i=4429">cookies: using a share with cookies shouldn&#39;t enable the cookie engine</a>
  BGF <a href="https://curl.se/bug/?i=4547">copyrights: update copyright notices to 2019</a>
  BGF <a href="https://curl.se/bug/?i=4393">curl: create easy handles on-demand and not ahead of time</a>
  BGF <a href="https://curl.se/bug/?i=4465">curl: ensure HTTP 429 triggers --retry</a>
@@ -1035,7 +1035,7 @@ SUBTITLE(Fixed in 7.67.0 - November 6 2019)
  BGF <a href="https://curl.se/bug/?i=4441">git: add tests/server/disabled to .gitignore</a>
  BGF <a href="https://curl.se/bug/?i=4487">gnutls: make gnutls_bye() not wait for response on shutdown</a>
  BGF <a href="https://curl.se/bug/?i=4496">http2: expire a timeout at end of stream</a>
- BGF <a href="https://curl.se/bug/?i=4303">http2: prevent dup&apos;ed handles to send dummy PRIORITY frames</a>
+ BGF <a href="https://curl.se/bug/?i=4303">http2: prevent dup&#39;ed handles to send dummy PRIORITY frames</a>
  BGF <a href="https://curl.se/bug/?i=4365">http2: relax verification of :authority in push promise requests</a>
  BGF <a href="https://curl.se/bug/?i=4496">http2_recv: a closed stream trumps pause state</a>
  BGF <a href="https://curl.se/bug/?i=4400">http: lowercase headernames for HTTP/2 and HTTP/3</a>
@@ -1046,14 +1046,14 @@ SUBTITLE(Fixed in 7.67.0 - November 6 2019)
  BGF <a href="https://curl.se/bug/?i=4457">ngtcp2: adapt to API change</a>
  BGF <a href="https://curl.se/bug/?i=4392">ngtcp2: compile with latest ngtcp2 + nghttp3 draft-23</a>
  BGF <a href="https://curl.se/bug/?i=4421">ngtcp2: remove fprintf() calls</a>
- BGF <a href="https://curl.se/bug/?i=4329">openssl: close_notify on the FTP data connection doesn&apos;t mean closure</a>
+ BGF <a href="https://curl.se/bug/?i=4329">openssl: close_notify on the FTP data connection doesn&#39;t mean closure</a>
  BGF <a href="https://curl.se/bug/?i=4397">openssl: fix compiler warning with LibreSSL</a>
  BGF <a href="https://curl.se/bug/?i=4411">openssl: use strerror on SSL_ERROR_SYSCALL</a>
  BGF <a href="https://curl.se/bug/?i=4214">os400: getpeername() and getsockname() return ebcdic AF_UNIX sockaddr</a>
  BGF <a href="https://curl.se/bug/?i=4325">parsedate: fix date parsing disabled builds</a>
- BGF quiche: don&apos;t close connection at end of stream
+ BGF quiche: don&#39;t close connection at end of stream
  BGF <a href="https://curl.se/bug/?i=4358">quiche: persist connection details (fixes -I with --http3)</a>
- BGF quiche: set &apos;drain&apos; when returning without having drained the queues
+ BGF quiche: set &#39;drain&#39; when returning without having drained the queues
  BGF <a href="https://curl.se/bug/?i=4437">quiche: update HTTP/3 config creation to new API</a>
  BGF <a href="https://curl.se/bug/?i=4445">redirect: handle redirects to absolute URLs containing spaces</a>
  BGF <a href="https://curl.se/bug/?i=4506">runtests: get textaware info from curl instead of perl</a>
@@ -1066,7 +1066,7 @@ SUBTITLE(Fixed in 7.67.0 - November 6 2019)
  BGF <a href="https://curl.se/bug/?i=4363">smb: check for full size message before reading message details</a>
  BGF <a href="https://curl.se/bug/?i=4484">smbserver: fix Python 3 compatibility</a>
  BGF <a href="https://curl.se/bug/?i=4394">socks: Fix destination host shown on SOCKS5 error</a>
- BGF test1162: disable MSYS2&apos;s POSIX path conversion
+ BGF test1162: disable MSYS2&#39;s POSIX path conversion
  BGF <a href="https://curl.se/bug/?i=4520">test1591: fix spelling of http feature</a>
  BGF <a href="https://curl.se/bug/?i=4511">tests: add `connect to non-listen` keywords</a>
  BGF <a href="https://curl.se/bug/?i=4415">tests: fix narrowing conversion warnings</a>
@@ -1077,7 +1077,7 @@ SUBTITLE(Fixed in 7.67.0 - November 6 2019)
  BGF <a href="https://curl.se/bug/?i=4498">tool_operate: Fix retry sleep time shown to user when Retry-After</a>
  BGF travis: Add an ARM64 build
  BGF <a href="https://curl.se/bug/?i=4463">url: Curl_free_request_state() should also free doh handles</a>
- BGF <a href="https://curl.se/bug/?i=3760">url: don&apos;t set appconnect time for non-ssl/non-ssh connections</a>
+ BGF <a href="https://curl.se/bug/?i=3760">url: don&#39;t set appconnect time for non-ssl/non-ssh connections</a>
  BGF <a href="https://curl.se/bug/?i=4403">url: fix the NULL hostname compiler warning</a>
  BGF <a href="https://curl.se/bug/?i=4491">url: normalize CURLINFO_EFFECTIVE_URL</a>
  BGF <a href="https://curl.se/mail/lib-2019-09/0061.html">url: only reuse TLS connections with matching pinning</a>
@@ -1085,7 +1085,7 @@ SUBTITLE(Fixed in 7.67.0 - November 6 2019)
  BGF <a href="https://curl.se/bug/?i=4447">urlapi: fix URL encoding when setting a full URL</a>
  BGF <a href="https://curl.se/bug/?i=4444">urlapi: fix unused variable warning</a>
  BGF <a href="https://curl.se/bug/?i=4412">urlapi: question mark within fragment is still fragment</a>
- BGF <a href="https://curl.se/bug/?i=4387">urldata: use &apos;bool&apos; for the bit type on MSVC compilers</a>
+ BGF <a href="https://curl.se/bug/?i=4387">urldata: use &#39;bool&#39; for the bit type on MSVC compilers</a>
  BGF <a href="https://curl.se/bug/?i=4425">vtls: Fix comment typo about macosx-version-min compiler flag</a>
  BGF <a href="https://curl.se/bug/?i=4398">vtls: fix narrowing conversion warnings</a>
  BGF <a href="https://curl.se/bug/?i=4322">winbuild/MakefileBuild.vc: Add vssh</a>
@@ -1132,7 +1132,7 @@ SUBTITLE(Fixed in 7.66.0 - September 11 2019)
  BGF <a href="https://curl.se/bug/?i=4157">asyn-thread: create a socketpair to wait on</a>
  BGF <a href="https://curl.se/bug/?i=4188">build-openssl: fix build with Visual Studio 2019</a>
  BGF <a href="https://curl.se/bug/?i=4289">cleanup: move functions out of url.c and make them static</a>
- BGF <a href="https://curl.se/bug/?i=4169">cleanup: remove the &apos;numsocks&apos; argument used in many places</a>
+ BGF <a href="https://curl.se/bug/?i=4169">cleanup: remove the &#39;numsocks&#39; argument used in many places</a>
  BGF <a href="https://curl.se/bug/?i=4213">configure: avoid undefined check_for_ca_bundle</a>
  BGF curl.h: add CURL_HTTP_VERSION_3 to the version enum
  BGF <a href="https://curl.se/bug/?i=4167">curl.h: fix outdated comment</a>
@@ -1167,7 +1167,7 @@ SUBTITLE(Fixed in 7.66.0 - September 11 2019)
  BGF <a href="https://curl.se/bug/?i=4230">netrc: make the code try ".netrc" on Windows</a>
  BGF <a href="https://curl.se/bug/?i=4187">nss: use TLSv1.3 as default if supported</a>
  BGF <a href="https://curl.se/bug/?i=4244">openssl: build warning free with boringssl</a>
- BGF <a href="https://curl.se/bug/?i=4304">openssl: use SSL_CTX_set_<min|max>_proto_version() when available</a>
+ BGF <a href="https://curl.se/bug/?i=4304">openssl: use SSL_CTX_set_&lt;min|max&gt;_proto_version() when available</a>
  BGF <a href="https://curl.se/bug/?i=3701">plan9: add support for running on Plan 9</a>
  BGF <a href="https://curl.se/bug/?i=4084">progress: reset download/uploaded counter between transfers</a>
  BGF <a href="https://curl.se/bug/?i=4136">readwrite_data: repair setting the TIMER_STARTTRANSFER stamp</a>
@@ -1183,10 +1183,10 @@ SUBTITLE(Fixed in 7.66.0 - September 11 2019)
  BGF <a href="https://curl.se/bug/?i=4227">tests: Replace outdated test case numbering documentation</a>
  BGF tftp: return error when packet is too small for options
  BGF <a href="https://curl.se/bug/?i=4165">timediff: make it 64 bit (if possible) even with 32 bit time_t</a>
- BGF <a href="https://curl.se/bug/?i=4223">travis: reduce number of torture tests in &apos;coverage&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=4223">travis: reduce number of torture tests in &#39;coverage&#39;</a>
  BGF <a href="https://curl.se/bug/?i=4183">url: make use of new HTTP version if alt-svc has one</a>
  BGF <a href="https://curl.se/bug/?i=4315">urlapi: verify the IPv6 numerical address</a>
- BGF <a href="https://curl.se/bug/?i=4290">urldata: avoid &apos;generic&apos;, use dedicated pointers</a>
+ BGF <a href="https://curl.se/bug/?i=4290">urldata: avoid &#39;generic&#39;, use dedicated pointers</a>
  BGF <a href="https://curl.se/bug/?i=3848">vauth: Use CURLE_AUTH_ERROR for auth function errors</a>
 </ul>
     
@@ -1218,7 +1218,7 @@ SUBTITLE(Fixed in 7.65.2 - July 17 2019)
  BGF <a href="https://curl.se/bug/?i=4037">config-os400: add getpeername and getsockname defines</a>
  BGF <a href="https://curl.se/bug/?i=4023">configure: --disable-progress-meter</a>
  BGF <a href="https://curl.se/bug/?i=4099">configure: fix --disable-code-coverage</a>
- BGF <a href="https://curl.se/bug/?i=4076">configure: fix typo &apos;--disable-http-uath&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=4076">configure: fix typo &#39;--disable-http-uath&#39;</a>
  BGF <a href="https://curl.se/bug/?i=4009">configure: more --disable switches to toggle off individual features</a>
  BGF <a href="https://curl.se/bug/?i=4010">configure: remove CURL_DISABLE_TLS_SRP</a>
  BGF <a href="https://curl.se/bug/?i=4029">conn_maxage: move the check to prune_dead_connections()</a>
@@ -1231,7 +1231,7 @@ SUBTITLE(Fixed in 7.65.2 - July 17 2019)
  BGF <a href="https://curl.se/bug/?i=3975">examples/htmltitle: use C++ casts between pointer types</a>
  BGF <a href="https://curl.se/bug/?i=4096">headers: Remove no longer exported functions</a>
  BGF <a href="https://curl.se/bug/?i=4068">http2: call done_sending on end of upload</a>
- BGF <a href="https://curl.se/bug/?i=4055">http2: don&apos;t call stream-close on already closed streams</a>
+ BGF <a href="https://curl.se/bug/?i=4055">http2: don&#39;t call stream-close on already closed streams</a>
  BGF http2: remove CURL_DISABLE_TYPECHECK define
  BGF <a href="https://curl.se/bug/?i=4103">http: allow overriding timecond with custom header</a>
  BGF http: clarify header buffer size calculation
@@ -1241,9 +1241,9 @@ SUBTITLE(Fixed in 7.65.2 - July 17 2019)
  BGF <a href="https://curl.se/bug/?i=4094">libcurl: Restrict redirect schemes to HTTP, HTTPS, FTP and FTPS</a>
  BGF <a href="https://curl.se/bug/?i=4051">multi: enable multiplexing by default (again)</a>
  BGF <a href="https://curl.se/bug/?i=4012">multi: fix the transfer hashes in the socket hash entries</a>
- BGF <a href="https://curl.se/bug/?i=3986">multi: make sure &apos;data&apos; can present in several sockhash entries</a>
+ BGF <a href="https://curl.se/bug/?i=3986">multi: make sure &#39;data&#39; can present in several sockhash entries</a>
  BGF <a href="https://curl.se/bug/?i=4036">netrc: Return the correct error code when out of memory</a>
- BGF <a href="https://curl.se/bug/?i=4054">nss: don&apos;t set unused parameter</a>
+ BGF <a href="https://curl.se/bug/?i=4054">nss: don&#39;t set unused parameter</a>
  BGF <a href="https://curl.se/bug/?i=4110">nss: inspect returnvalue of token check</a>
  BGF <a href="https://curl.se/bug/?i=4053">nss: only cache valid CRL entries</a>
  BGF <a href="https://curl.se/bug/?i=4046">nss: support using libnss on macOS</a>
@@ -1304,7 +1304,7 @@ SUBTITLE(Fixed in 7.65.1 - June 5 2019)
  BGF <a href="https://curl.se/bug/?i=3919">example/http2-download: fix format specifier</a>
  BGF <a href="https://curl.se/bug/?i=3919">examples: cleanups and compiler warning fixes</a>
  BGF <a href="https://curl.se/bug/?i=3966">http2: Stop drain from being permanently set</a>
- BGF <a href="https://curl.se/bug/?i=3968">http: don&apos;t parse body-related headers in bodyless responses</a>
+ BGF <a href="https://curl.se/bug/?i=3968">http: don&#39;t parse body-related headers in bodyless responses</a>
  BGF <a href="https://curl.se/bug/?i=3921">md4: build correctly with openssl without MD4</a>
  BGF <a href="https://curl.se/bug/?i=3922">md4: include the mbedtls config.h to get the MD4 info</a>
  BGF <a href="https://curl.se/bug/?i=3952">multi: track users of a socket better</a>
@@ -1366,8 +1366,8 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF <a href="https://curl.se/bug/?i=3743">cmake: clear CMAKE_REQUIRED_LIBRARIES after each use</a>
  BGF <a href="https://curl.se/bug/?i=3769">cmake: rename CMAKE_USE_DARWINSSL to CMAKE_USE_SECTRANSP</a>
  BGF <a href="https://curl.se/bug/?i=3736">cmake: set SSL_BACKENDS</a>
- BGF <a href="https://curl.se/bug/?i=3709">configure: avoid unportable `==&apos; test(1) operator</a>
- BGF <a href="https://curl.se/bug/?i=3824">configure: error out if OpenSSL wasn&apos;t detected when asked for</a>
+ BGF <a href="https://curl.se/bug/?i=3709">configure: avoid unportable `==&#39; test(1) operator</a>
+ BGF <a href="https://curl.se/bug/?i=3824">configure: error out if OpenSSL wasn&#39;t detected when asked for</a>
  BGF <a href="https://curl.se/bug/?i=3723">configure: fix default location for fish completions</a>
  BGF <a href="https://curl.se/bug/?i=3820">cookie: Guard against possible NULL ptr deref</a>
  BGF <a href="https://curl.se/bug/?i=3844">curl: make code work with protocol-disabled libcurl</a>
@@ -1379,14 +1379,14 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF <a href="https://curl.se/bug/?i=3895">docs/RELEASE-PROCEDURE: link to live iCalendar</a>
  BGF <a href="https://curl.se/bug/?i=3724">documentation: Fix several typos</a>
  BGF doh: acknowledge CURL_DISABLE_DOH
- BGF <a href="https://curl.se/bug/?i=3850">doh: disable DOH for the cases it doesn&apos;t work</a>
+ BGF <a href="https://curl.se/bug/?i=3850">doh: disable DOH for the cases it doesn&#39;t work</a>
  BGF <a href="https://curl.se/bug/?i=3908">examples: remove unused variables</a>
  BGF <a href="https://curl.se/bug/?i=3732">ftplistparser: fix LGTM alert "Empty block without comment"</a>
  BGF <a href="https://curl.se/bug/?i=3844">hostip: acknowledge CURL_DISABLE_SHUFFLE_DNS</a>
  BGF <a href="https://curl.se/bug/?i=3570">http: Ignore HTTP/2 prior knowledge setting for HTTP proxies</a>
  BGF http: acknowledge CURL_DISABLE_HTTP_AUTH
- BGF <a href="https://curl.se/bug/?i=3813">http: mark bundle as not for multiuse on < HTTP/2 response</a>
- BGF <a href="https://curl.se/bug/?i=3861">http_digest: Don&apos;t expose functions when HTTP and Crypto Auth are disabled</a>
+ BGF <a href="https://curl.se/bug/?i=3813">http: mark bundle as not for multiuse on &lt; HTTP/2 response</a>
+ BGF <a href="https://curl.se/bug/?i=3861">http_digest: Don&#39;t expose functions when HTTP and Crypto Auth are disabled</a>
  BGF <a href="https://curl.se/bug/?i=3726">http_negotiate: do not treat failure of gss_init_sec_context() as fatal</a>
  BGF <a href="https://curl.se/bug/?i=3867">http_ntlm: Corrected the name of the include guard</a>
  BGF <a href="https://curl.se/bug/?i=3894">http_ntlm_wb: Handle auth for only a single request</a>
@@ -1401,7 +1401,7 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF <a href="https://curl.se/bug/?i=3807">nss: allow fifos and character devices for certificates</a>
  BGF <a href="https://curl.se/bug/?i=3808">nss: provide more specific error messages on failed init</a>
  BGF <a href="https://curl.se/bug/?i=3858">ntlm: Fix misaligned function comments for Curl_auth_ntlm_cleanup</a>
- BGF ntlm: Support the NT response in the type-3 when OpenSSL doesn&apos;t include MD4
+ BGF ntlm: Support the NT response in the type-3 when OpenSSL doesn&#39;t include MD4
  BGF <a href="https://curl.se/bug/?i=3750">openssl: mark connection for close on TLS close_notify</a>
  BGF <a href="https://curl.se/bug/?i=3768">openvms: Remove pre-processor for SecureTransport</a>
  BGF <a href="https://curl.se/bug/?i=3768">openvms: Remove pre-processors for Windows</a>
@@ -1413,8 +1413,8 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF proxy: acknowledge DISABLE_PROXY more
  BGF <a href="https://curl.se/bug/?i=3699">resolve: apply Happy Eyeballs philosophy to parallel c-ares queries</a>
  BGF <a href="https://curl.se/bug/?i=3856">revert "multi: support verbose conncache closure handle"</a>
- BGF sasl: Don&apos;t send authcid as authzid for the PLAIN mechanism as per RFC 4616
- BGF sasl: only enable if there&apos;s a protocol enabled using it
+ BGF sasl: Don&#39;t send authcid as authzid for the PLAIN mechanism as per RFC 4616
+ BGF sasl: only enable if there&#39;s a protocol enabled using it
  BGF scripts: fix typos
  BGF singleipconnect: show port in the verbose "Trying ..." message
  BGF <a href="https://curl.se/bug/?i=3729">smtp: fix compiler warning</a>
@@ -1424,7 +1424,7 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF <a href="https://curl.se/bug/?i=3726">spnego_gssapi: fix return code on gss_init_sec_context() failure</a>
  BGF <a href="https://curl.se/bug/?i=3873">ssh-libssh: remove unused variable</a>
  BGF <a href="https://curl.se/bug/?i=3846">ssh: define USE_SSH if SSH is enabled (any backend)</a>
- BGF <a href="https://curl.se/bug/?i=3873">ssh: move variable declaration to where it&apos;s used</a>
+ BGF <a href="https://curl.se/bug/?i=3873">ssh: move variable declaration to where it&#39;s used</a>
  BGF test1002: correct the name
  BGF test2100: Fix typos in test description
  BGF <a href="https://curl.se/bug/?i=3758">tests/server/util: fix Windows Unicode build</a>
@@ -1433,7 +1433,7 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF <a href="https://curl.se/bug/?i=3718">tool_cb_wrt: fix bad-function-cast warning</a>
  BGF <a href="https://curl.se/bug/?i=3873">tool_formparse: remove redundant assignment</a>
  BGF <a href="https://curl.se/bug/?i=3774">tool_help: Warn if curl and libcurl versions do not match</a>
- BGF <a href="https://curl.se/bug/?i=3715">tool_help: include <strings.h> for strcasecmp</a>
+ BGF <a href="https://curl.se/bug/?i=3715">tool_help: include &lt;strings.h&gt; for strcasecmp</a>
  BGF <a href="https://curl.se/bug/?i=3732">transfer: fix LGTM alert "Comparison is always true"</a>
  BGF <a href="https://curl.se/bug/?i=3887">travis: add an osx http-only build</a>
  BGF travis: allow builds on branches named "ci"
@@ -1452,7 +1452,7 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF <a href="https://curl.se/bug/?i=2487">vauth/oauth2: Fix OAUTHBEARER token generation</a>
  BGF <a href="https://curl.se/bug/?i=3860">vauth: Fix incorrect function description for Curl_auth_user_contains_domain</a>
  BGF <a href="https://curl.se/bug/?i=3863">vtls: fix potential ssl_buffer stack overflow</a>
- BGF wildcard: disable from build when FTP isn&apos;t present
+ BGF wildcard: disable from build when FTP isn&#39;t present
  BGF <a href="https://curl.se/bug/?i=3772">winbuild: Support MultiSSL builds</a>
  BGF <a href="https://curl.se/bug/?i=3759">xattr: skip unittest on unsupported platforms</a>
 </ul>
@@ -1472,7 +1472,7 @@ SUBTITLE(Fixed in 7.64.1 - March 27 2019)
  BGF <a href="https://curl.se/bug/?i=3626">Curl_easy: remove req.maxfd - never used!</a>
  BGF <a href="https://curl.se/bug/?i=3572">Curl_now: figure out windows version in win32_init:</a>
  BGF <a href="https://curl.se/bug/?i=3562">Curl_resolv: fix a gcc -Werror=maybe-uninitialized warning</a>
- BGF <a href="https://curl.se/bug/?i=3660">DoH: inherit some SSL options from user&apos;s easy handle</a>
+ BGF <a href="https://curl.se/bug/?i=3660">DoH: inherit some SSL options from user&#39;s easy handle</a>
  BGF <a href="https://curl.se/bug/?i=3619">Secure Transport: no more "darwinssl"</a>
  BGF <a href="https://curl.se/bug/?i=3689">Secure Transport: tvOS 11 is required for ALPN support</a>
  BGF cirrus: Added FreeBSD builds using Cirrus CI
@@ -1490,7 +1490,7 @@ SUBTITLE(Fixed in 7.64.1 - March 27 2019)
  BGF <a href="https://curl.se/bug/?i=3649">cookies: dotless names can set cookies again</a>
  BGF <a href="https://curl.se/bug/?i=3613">cookies: fix NULL dereference if flushing cookies with no CookieInfo set</a>
  BGF <a href="https://curl.se/bug/?i=3680">curl.1: --user and --proxy-user are hidden from ps output</a>
- BGF <a href="https://curl.se/bug/?i=3682">curl.1: mark the argument to --cookie as <data|filename></a>
+ BGF <a href="https://curl.se/bug/?i=3682">curl.1: mark the argument to --cookie as &lt;data|filename&gt;</a>
  BGF <a href="https://curl.se/bug/?i=3616">curl.h: use __has_declspec_attribute for shared builds</a>
  BGF <a href="https://curl.se/bug/?i=3611">curl: display --version features sorted alphabetically</a>
  BGF <a href="https://curl.se/bug/?i=3550">curl: fix FreeBSD compiler warning in the --xattr code</a>
@@ -1509,13 +1509,13 @@ SUBTITLE(Fixed in 7.64.1 - March 27 2019)
  BGF examples/http2-download: cleaned up
  BGF <a href="https://curl.se/bug/?i=3580">examples/http2-serverpush: add some sensible error checks</a>
  BGF examples/http2-upload: cleaned up
- BGF examples/httpcustomheader: Value stored to &apos;res&apos; is never read
- BGF examples/postinmemory: Potential leak of memory pointed to by &apos;chunk.memory&apos;
- BGF examples/sftpuploadresume: Value stored to &apos;result&apos; is never read
- BGF <a href="https://curl.se/bug/?i=3645">examples: only include <curl/curl.h></a>
+ BGF examples/httpcustomheader: Value stored to &#39;res&#39; is never read
+ BGF examples/postinmemory: Potential leak of memory pointed to by &#39;chunk.memory&#39;
+ BGF examples/sftpuploadresume: Value stored to &#39;result&#39; is never read
+ BGF <a href="https://curl.se/bug/?i=3645">examples: only include &lt;curl/curl.h&gt;</a>
  BGF <a href="https://curl.se/bug/?i=3537">examples: remove recursive calls to curl_multi_socket_action</a>
  BGF examples: remove superfluous null-pointer checks
- BGF <a href="https://curl.se/bug/?i=3672">file: fix "Checking if unsigned variable &apos;readcount&apos; is less than zero."</a>
+ BGF <a href="https://curl.se/bug/?i=3672">file: fix "Checking if unsigned variable &#39;readcount&#39; is less than zero."</a>
  BGF <a href="https://curl.se/bug/?i=3551">fnmatch: disable if FTP is disabled</a>
  BGF <a href="https://curl.se/bug/?i=3636">gnutls: remove call to deprecated gnutls_compression_get_name</a>
  BGF <a href="https://curl.se/bug/?i=3617">gopher: remove check for path == NULL</a>
@@ -1527,7 +1527,7 @@ SUBTITLE(Fixed in 7.64.1 - March 27 2019)
  BGF <a href="https://curl.se/bug/?i=2431">http: send payload when (proxy) authentication is done</a>
  BGF <a href="https://curl.se/mail/archive-2019-02/0023.html">http: set state.infilesize when sending multipart formposts</a>
  BGF <a href="https://curl.se/bug/?i=3681">makefile: make checksrc and hugefile commands "silent"</a>
- BGF <a href="https://curl.se/bug/?i=3553">mbedtls: make it build even if MBEDTLS_VERSION_C isn&apos;t set</a>
+ BGF <a href="https://curl.se/bug/?i=3553">mbedtls: make it build even if MBEDTLS_VERSION_C isn&#39;t set</a>
  BGF <a href="https://curl.se/bug/?i=3574">mbedtls: release sessionid resources on error</a>
  BGF <a href="https://curl.se/bug/?i=3671">memdebug: log pointer before freeing its data</a>
  BGF <a href="https://curl.se/bug/?i=3656">memdebug: make debug-specific functions use curl_dbg_ prefix</a>
@@ -1539,16 +1539,16 @@ SUBTITLE(Fixed in 7.64.1 - March 27 2019)
  BGF <a href="https://curl.se/bug/?i=1261">negotiate: fix for HTTP POST with Negotiate</a>
  BGF <a href="https://curl.se/bug/?i=3591">openssl: add support for TLS ASYNC state</a>
  BGF <a href="https://curl.se/bug/?i=3692">openssl: if cert type is ENG and no key specified, key is ENG too</a>
- BGF <a href="https://curl.se/bug/?i=3548">pretransfer: don&apos;t strlen() POSTFIELDS set for GET requests</a>
+ BGF <a href="https://curl.se/bug/?i=3548">pretransfer: don&#39;t strlen() POSTFIELDS set for GET requests</a>
  BGF <a href="https://curl.se/bug/?i=3584">rand: Fix a mismatch between comments in source and header</a>
  BGF <a href="https://curl.se/bug/?i=3609">runtests: detect "schannel" as an alias for "winssl"</a>
  BGF <a href="https://curl.se/bug/?i=3552">schannel: be quiet - remove verbose output</a>
  BGF <a href="https://curl.se/bug/?i=3412">schannel: close TLS before removing conn from cache</a>
  BGF <a href="https://curl.se/bug/?i=3608">schannel: support CALG_ECDH_EPHEM algorithm</a>
  BGF <a href="https://curl.se/bug/?i=3545">scripts/completion.pl: also generate fish completion file</a>
- BGF <a href="https://curl.se/bug/?i=3585">singlesocket: fix the &apos;sincebefore&apos; placement</a>
- BGF <a href="https://curl.se/bug/?i=3546">source: fix two &apos;nread&apos; may be used uninitialized warnings</a>
- BGF <a href="https://curl.se/bug/?i=3628">ssh: fix Condition &apos;!status&apos; is always true</a>
+ BGF <a href="https://curl.se/bug/?i=3585">singlesocket: fix the &#39;sincebefore&#39; placement</a>
+ BGF <a href="https://curl.se/bug/?i=3546">source: fix two &#39;nread&#39; may be used uninitialized warnings</a>
+ BGF <a href="https://curl.se/bug/?i=3628">ssh: fix Condition &#39;!status&#39; is always true</a>
  BGF <a href="https://curl.se/bug/?i=3506">ssh: loop the state machine if not done and not blocking</a>
  BGF <a href="https://curl.se/bug/?i=3612">strerror: make the strerror function use local buffers</a>
  BGF <a href="https://curl.se/bug/?i=3625">system_win32: move win32_init here from easy.c</a>
@@ -1569,18 +1569,18 @@ SUBTITLE(Fixed in 7.64.1 - March 27 2019)
  BGF <a href="https://curl.se/bug/?i=3670">travis: use updated compiler versions: clang 7 and gcc 8</a>
  BGF <a href="https://curl.se/bug/?i=3565">unit1307: require FTP support</a>
  BGF unit1651: survive curl_easy_init() fails
- BGF <a href="https://curl.se/bug/?i=3539">url/idnconvert: remove scan for <= 32 ascii values</a>
+ BGF <a href="https://curl.se/bug/?i=3539">url/idnconvert: remove scan for &lt;= 32 ascii values</a>
  BGF <a href="https://curl.se/mail/lib-2019-02/0101.html">url: change conn shutdown order to ensure SOCKETFUNCTION callbacks</a>
- BGF <a href="https://curl.se/bug/?i=3540">urlapi: reduce variable scope, remove unreachable &apos;break&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=3540">urlapi: reduce variable scope, remove unreachable &#39;break&#39;</a>
  BGF <a href="https://curl.se/bug/?i=3610">urldata: convert bools to bitfields and move to end</a>
  BGF <a href="https://curl.se/bug/?i=3627">urldata: simplify bytecounters</a>
- BGF urlglob: Argument with &apos;nonnull&apos; attribute passed null
+ BGF urlglob: Argument with &#39;nonnull&#39; attribute passed null
  BGF version.c: silent scan-build even when librtmp is not enabled
  BGF <a href="https://curl.se/bug/?i=3677">vtls: rename some of the SSL functions</a>
  BGF <a href="https://curl.se/bug/?i=3599">wolfssl: stop custom-adding curves</a>
  BGF x509asn1: "Dereference of null pointer"
  BGF <a href="https://curl.se/bug/?i=3582">x509asn1: cleanup and unify code layout</a>
- BGF <a href="https://bugs.debian.org/921452">zsh.pl: escape &apos;:&apos; character</a>
+ BGF <a href="https://bugs.debian.org/921452">zsh.pl: escape &#39;:&#39; character</a>
  BGF <a href="https://bugs.debian.org/921452">zsh.pl: update regex to better match curl -h output</a>
 </ul>
 
@@ -1604,8 +1604,8 @@ SUBTITLE(Fixed in 7.64.0 - February 6 2019)
  BGF OS400: upgrade ILE/RPG binding.
  BGF README: add codacy code quality badge
  BGF <a href="https://curl.se/bug/?i=3384">Revert http_negotiate: do not close connection</a>
- BGF THANKS: added several missing names from year <= 2000
- BGF build: make &apos;tidy&apos; target work for metalink builds
+ BGF THANKS: added several missing names from year &lt;= 2000
+ BGF build: make &#39;tidy&#39; target work for metalink builds
  BGF <a href="https://curl.se/bug/?i=3459">cmake: added checks for variadic macros</a>
  BGF <a href="https://curl.se/bug/?i=3292">cmake: updated check for HAVE_POLL_FINE to match autotools</a>
  BGF <a href="https://curl.se/bug/?i=3196">cmake: use lowercase for function name like the rest of the code</a>
@@ -1620,7 +1620,7 @@ SUBTITLE(Fixed in 7.64.0 - February 6 2019)
  BGF <a href="https://curl.se/bug/?i=3423">curl --xattr: strip credentials from any URL that is stored</a>
  BGF <a href="https://curl.se/bug/?i=3380">curl -J: refuse to append to the destination file</a>
  BGF <a href="https://curl.se/bug/?i=3438">curl/urlapi.h: include "curl.h" first</a>
- BGF <a href="https://curl.se/bug/?i=3371">curl_multi_remove_handle() don&apos;t block terminating c-ares requests</a>
+ BGF <a href="https://curl.se/bug/?i=3371">curl_multi_remove_handle() don&#39;t block terminating c-ares requests</a>
  BGF <a href="https://curl.se/bug/?i=3367">darwinssl: accept setting max-tls with default min-tls</a>
  BGF <a href="https://curl.se/bug/?i=3400">disconnect: separate connections and easy handles better</a>
  BGF disconnect: set conn->data for protocol disconnect
@@ -1686,7 +1686,7 @@ SUBTITLE(Fixed in 7.63.0 - December 12 2018)
 <ul class="bugfixes">
  BGF <a href="https://curl.se/bug/?i=3348">(lib)curl.rc: fixup for minor bugs</a>
  BGF <a href="https://curl.se/bug/?i=3340">CURLINFO_REDIRECT_URL: extract the Location: header field unvalidated</a>
- BGF <a href="https://curl.se/bug/?i=3295">CURLOPT_HEADERFUNCTION.3: match &apos;nitems&apos; name in synopsis and description</a>
+ BGF <a href="https://curl.se/bug/?i=3295">CURLOPT_HEADERFUNCTION.3: match &#39;nitems&#39; name in synopsis and description</a>
  BGF CURLOPT_WRITEFUNCTION.3: spell out that it gets called many times
  BGF <a href="https://curl.se/bug/?i=3210">Curl_follow: accept non-supported schemes for "fake" redirects</a>
  BGF <a href="https://curl.se/bug/?i=876">KNOWN_BUGS: add --proxy-any connection issue</a>
@@ -1720,7 +1720,7 @@ SUBTITLE(Fixed in 7.63.0 - December 12 2018)
  BGF <a href="https://curl.se/bug/?i=3225">ftp: avoid two unsigned int overflows in FTP listing parser</a>
  BGF <a href="https://curl.se/bug/?i=3022">host names: allow trailing dot in name resolve, then strip it</a>
  BGF <a href="https://curl.se/bug/?i=3349">http2: Upon HTTP_1_1_REQUIRED, retry the request with HTTP/1.1</a>
- BGF <a href="https://curl.se/bug/?i=3359">http: don&apos;t set CURLINFO_CONDITION_UNMET for http status code 204</a>
+ BGF <a href="https://curl.se/bug/?i=3359">http: don&#39;t set CURLINFO_CONDITION_UNMET for http status code 204</a>
  BGF <a href="https://curl.se/bug/?i=3353">http: fix HTTP Digest auth to include query in URI</a>
  BGF <a href="https://curl.se/bug/?i=3275">http_negotiate: do not close connection until negotiation is completed</a>
  BGF <a href="https://curl.se/bug/?i=3276">impacket: add LICENSE</a>
@@ -1728,7 +1728,7 @@ SUBTITLE(Fixed in 7.63.0 - December 12 2018)
  BGF <a href="https://curl.se/bug/?i=3362">ldap: fix LDAP URL parsing regressions</a>
  BGF <a href="https://curl.se/bug/?i=3240">libcurl: stop reading from paused transfers</a>
  BGF <a href="https://curl.se/bug/?i=3184">mprintf: avoid unsigned integer overflow warning</a>
- BGF <a href="https://curl.se/bug/?i=3213">netrc: don&apos;t ignore the login name specified with "--user"</a>
+ BGF <a href="https://curl.se/bug/?i=3213">netrc: don&#39;t ignore the login name specified with "--user"</a>
  BGF <a href="https://curl.se/bug/?i=3261">nss: Fall back to latest supported SSL version</a>
  BGF <a href="https://curl.se/bug/?i=3337">nss: Fix compatibility with nss versions 3.14 to 3.15</a>
  BGF nss: fix fallthrough comment to fix picky compiler warning
@@ -1762,7 +1762,7 @@ SUBTITLE(Fixed in 7.63.0 - December 12 2018)
  BGF <a href="https://curl.se/bug/?i=3198">travis: remove curl before a normal build</a>
  BGF <a href="https://curl.se/bug/?i=3220">url: a short host name + port is not a scheme</a>
  BGF <a href="https://curl.se/bug/?i=3218">url: fix IPv6 numeral address parser</a>
- BGF <a href="https://curl.se/bug/?i=3231">urlapi: only skip encoding the first &apos;=&apos; with APPENDQUERY set</a>
+ BGF <a href="https://curl.se/bug/?i=3231">urlapi: only skip encoding the first &#39;=&#39; with APPENDQUERY set</a>
 </ul>
 
 <a name="7_62_0"></a>
@@ -1806,7 +1806,7 @@ SUBTITLE(Fixed in 7.62.0 - October 31 2018)
  BGF <a href="https://curl.se/bug/?i=2849">cmake: Improve config installation</a>
  BGF <a href="https://curl.se/bug/?i=3123">cmake: add support for transitive ZLIB target</a>
  BGF <a href="https://curl.se/bug/?i=3120">cmake: disable -Wpedantic-ms-format</a>
- BGF <a href="https://curl.se/bug/?i=3001">cmake: don&apos;t require OpenSSL if USE_OPENSSL=OFF</a>
+ BGF <a href="https://curl.se/bug/?i=3001">cmake: don&#39;t require OpenSSL if USE_OPENSSL=OFF</a>
  BGF <a href="https://curl.se/bug/?i=3056">cmake: fixed path used in generation of docs/tests</a>
  BGF <a href="https://curl.se/bug/?i=3166">cmake: remove unused *SOCKLEN_T variables</a>
  BGF cmake: suppress MSVC warning C4127 for libtest
@@ -1865,7 +1865,7 @@ SUBTITLE(Fixed in 7.62.0 - October 31 2018)
  BGF <a href="https://curl.se/bug/?i=3026">openssl: enable TLS 1.3 post-handshake auth</a>
  BGF <a href="https://curl.se/bug/?i=2980">openssl: fix gcc8 warning</a>
  BGF <a href="https://curl.se/bug/?i=3023">openssl: load built-in engines too</a>
- BGF <a href="https://curl.se/bug/?i=3176">openssl: make &apos;done&apos; a proper boolean</a>
+ BGF <a href="https://curl.se/bug/?i=3176">openssl: make &#39;done&#39; a proper boolean</a>
  BGF <a href="https://curl.se/bug/?i=3178">openssl: output the correct cipher list on TLS 1.3 error</a>
  BGF <a href="https://curl.se/bug/?i=2901">openssl: return CURLE_PEER_FAILED_VERIFICATION on failure to parse issuer</a>
  BGF <a href="https://curl.se/bug/?i=2989">openssl: show "proper" version number for libressl builds</a>
@@ -1912,7 +1912,7 @@ SUBTITLE(Fixed in 7.61.1 - September 5 2018)
  BGF <a href="https://curl.se/bug/?i=2915">CURLOPT_SSL_CTX_FUNCTION.3: might cause accidental connection reuse</a>
  BGF <a href="https://curl.se/bug/?i=2733">Curl_getoff_all_pipelines: improved for multiplexed</a>
  BGF DEPRECATE: remove release date from 7.62.0
- BGF <a href="https://curl.se/bug/?i=2798">HTTP: Don&apos;t attempt to needlessly decompress redirect body</a>
+ BGF <a href="https://curl.se/bug/?i=2798">HTTP: Don&#39;t attempt to needlessly decompress redirect body</a>
  BGF <a href="https://curl.se/bug/?i=2890">INTERNALS: require GnuTLS >= 2.11.3</a>
  BGF <a href="https://curl.se/bug/?i=2857">README.md: add LGTM.com code quality grade for C/C++</a>
  BGF SSLCERTS: improve the openssl command line
@@ -1928,7 +1928,7 @@ SUBTITLE(Fixed in 7.61.1 - September 5 2018)
  BGF <a href="https://curl.se/bug/?i=2753">cmake: link curl to the OpenSSL targets instead of lib absolute paths</a>
  BGF <a href="https://curl.se/bug/?i=2747">configure: conditionally enable pedantic-errors</a>
  BGF <a href="https://curl.se/bug/?i=2848">configure: fix for -lpthread detection with OpenSSL and pkg-config</a>
- BGF <a href="https://curl.se/bug/?i=2733">conn: remove the boolean &apos;inuse&apos; field</a>
+ BGF <a href="https://curl.se/bug/?i=2733">conn: remove the boolean &#39;inuse&#39; field</a>
  BGF <a href="https://curl.se/bug/?i=2719">content_encoding: accept up to 4 unknown trailer bytes after raw deflate data</a>
  BGF cookie tests: treat files as text
  BGF <a href="https://curl.se/bug/?i=2524">cookies: support creation-time attribute for cookies</a>
@@ -1948,7 +1948,7 @@ SUBTITLE(Fixed in 7.61.1 - September 5 2018)
  BGF <a href="https://curl.se/bug/?i=2868">docs: improved the manual pages of some callbacks</a>
  BGF <a href="https://curl.se/bug/?i=2837">docs: mention NULL is fine input to several functions</a>
  BGF <a href="https://curl.se/bug/?i=2852">formdata: Remove unused macro HTTPPOST_CONTENTTYPE_DEFAULT</a>
- BGF <a href="https://curl.se/bug/?i=2910">gopher: Do not translate `?&apos; to `%09&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=2910">gopher: Do not translate `?&#39; to `%09&#39;</a>
  BGF <a href="https://curl.se/bug/?i=2736">header output: switch off all styles, not just unbold</a>
  BGF hostip: fix unused variable warning
  BGF <a href="https://curl.se/bug/?i=2928">http2: Use correct format identifier for stream_id</a>
@@ -1964,17 +1964,17 @@ SUBTITLE(Fixed in 7.61.1 - September 5 2018)
  BGF <a href="https://curl.se/bug/?i=2861">lib1502: fix memory leak in torture test</a>
  BGF lib1522: fix curl_easy_setopt argument type
  BGF <a href="https://curl.se/bug/?i=2904">libcurl-thread.3: expand somewhat on the NO_SIGNAL motivation</a>
- BGF <a href="https://curl.se/bug/?i=2795">mime: check Curl_rand_hex&apos;s return code</a>
+ BGF <a href="https://curl.se/bug/?i=2795">mime: check Curl_rand_hex&#39;s return code</a>
  BGF <a href="https://curl.se/bug/?i=2733">multi: always do the COMPLETED procedure/state</a>
  BGF <a href="https://curl.se/bug/?i=2732">openssl: assume engine support in 1.0.0 or later</a>
  BGF <a href="https://curl.se/bug/?i=2806">openssl: fix debug messages</a>
  BGF <a href="https://curl.se/bug/?i=2865">projects: Improve Windows perl detection in batch scripts</a>
- BGF <a href="https://curl.se/bug/?i=2801">retry: return error if rewind was necessary but didn&apos;t happen</a>
+ BGF <a href="https://curl.se/bug/?i=2801">retry: return error if rewind was necessary but didn&#39;t happen</a>
  BGF <a href="https://curl.se/bug/?i=2790">reuse_conn(): memory leak - free old_conn->options</a>
  BGF <a href="https://curl.se/mail/lib-2018-08/0198.html">schannel: client certificate store opening fix</a>
  BGF schannel: enable CALG_TLS1PRF for w32api >= 5.1
  BGF <a href="https://github.com/curl/curl/pull/2721#issuecomment-403636043">schannel: fix MinGW compile break</a>
- BGF <a href="https://curl.se/bug/?i=2939">sftp: don&apos;t send post-quote sequence when retrying a connection</a>
+ BGF <a href="https://curl.se/bug/?i=2939">sftp: don&#39;t send post-quote sequence when retrying a connection</a>
  BGF <a href="https://curl.se/bug/?i=2769">smb: fix memory leak on early failure</a>
  BGF <a href="https://curl.se/bug/?i=2740">smb: fix memory-leak in URL parse error path</a>
  BGF <a href="https://curl.se/bug/?i=2768">smb_getsock: always wait for write socket too</a>
@@ -1985,21 +1985,21 @@ SUBTITLE(Fixed in 7.61.1 - September 5 2018)
  BGF <a href="https://curl.se/bug/?i=2808">sws: handle EINTR when calling select()</a>
  BGF <a href="https://curl.se/bug/?i=2792">system_win32: fix version checking</a>
  BGF <a href="https://curl.se/bug/?i=2852">telnet: Remove unused macros TELOPTS and TELCMDS</a>
- BGF <a href="https://curl.se/bug/?i=2765">test1143: disable MSYS2&apos;s POSIX path conversion</a>
+ BGF <a href="https://curl.se/bug/?i=2765">test1143: disable MSYS2&#39;s POSIX path conversion</a>
  BGF <a href="https://curl.se/bug/?i=2786">test1148: disable if decimal separator is not point</a>
  BGF <a href="https://curl.se/bug/?i=2825">test1307: (fnmatch testing) disabled</a>
  BGF <a href="https://curl.se/bug/?i=2741">test1422: add required file feature</a>
  BGF <a href="https://curl.se/bug/?i=2853">test1531: Add timeout</a>
  BGF <a href="https://curl.se/bug/?i=2852">test1540: Remove unused macro TEST_HANG_TIMEOUT</a>
- BGF test214: disable MSYS2&apos;s POSIX path conversion for URL
+ BGF test214: disable MSYS2&#39;s POSIX path conversion for URL
  BGF <a href="https://curl.se/bug/?i=2776">test320: treat curl320.out file as binary</a>
  BGF tests/http_pipe.py: Use /usr/bin/env to find python
- BGF <a href="https://curl.se/bug/?i=2920">tests: Don&apos;t use Windows path %PWD for SSH tests</a>
+ BGF <a href="https://curl.se/bug/?i=2920">tests: Don&#39;t use Windows path %PWD for SSH tests</a>
  BGF <a href="https://curl.se/bug/?i=2772">tests: fixes for Windows line endlings</a>
  BGF tool_operate: Fix setting proxy TLS 1.3 ciphers
  BGF <a href="https://curl.se/bug/?i=2835">travis: build darwinssl on macos 10.12 to fix linker errors</a>
  BGF <a href="https://curl.se/bug/?i=2862">travis: execute "set -eo pipefail" for coverage build</a>
- BGF <a href="https://curl.se/bug/?i=2811">travis: run a &apos;make checksrc&apos; too</a>
+ BGF <a href="https://curl.se/bug/?i=2811">travis: run a &#39;make checksrc&#39; too</a>
  BGF <a href="https://curl.se/bug/?i=2869">travis: update to GCC-8</a>
  BGF <a href="https://curl.se/bug/?i=2856">travis: verify that man pages can be regenerated</a>
  BGF <a href="https://curl.se/bug/?i=2892">upload: allocate upload buffer on-demand</a>
@@ -2028,7 +2028,7 @@ SUBTITLE(Fixed in 7.61.0 - July 11 2018)
  BGF schannel: disable manual verify if APIs not available
  BGF <a href="https://curl.se/bug/?i=2576">tests/libtest/Makefile: Do not unconditionally add gcc-specific flags</a>
  BGF <a href="https://curl.se/bug/?i=2571">openssl: acknowledge --tls-max for default version too</a>
- BGF stub_gssapi: fix &apos;unused parameter&apos; warnings
+ BGF stub_gssapi: fix &#39;unused parameter&#39; warnings
  BGF <a href="https://curl.se/bug/?i=2584">examples/progressfunc: make it build on both new and old libcurls</a>
  BGF <a href="https://curl.se/bug/?i=2579">docs: mention it is HA Proxy protocol "version 1"</a>
  BGF <a href="https://curl.se/bug/?i=2587">curl_fnmatch: only allow two asterisks for matching</a>
@@ -2198,7 +2198,7 @@ SUBTITLE(Fixed in 7.60.0 - May 16 2018)
  BGF <a href="https://curl.se/bug/?i=2514">http2: convert an assert to run-time check</a>
  BGF <a href="https://curl.se/bug/?i=2499">curl_global_sslset: always provide available backends</a>
  BGF <a href="https://curl.se/bug/?i=2445">ftplistparser: keep state between invokes</a>
- BGF Curl_memchr: zero length input can&apos;t match
+ BGF Curl_memchr: zero length input can&#39;t match
  BGF examples/sftpuploadresume: typecast fseek argument to long
  BGF examples/http2-upload: expand buffer to avoid silly warning
  BGF <a href="https://curl.se/bug/?i=2494">ctype: restore character classification for non-ASCII platforms</a>
@@ -2211,19 +2211,19 @@ SUBTITLE(Fixed in 7.60.0 - May 16 2018)
  BGF <a href="https://curl.se/bug/?i=2532">checksrc: force indentation of lines after an else</a>
  BGF <a href="https://curl.se/bug/?i=2537">cookies: remove unused macro</a>
  BGF CURLINFO_PROTOCOL.3: mention the existing defined names
- BGF <a href="https://curl.se/bug/?i=2533">tests: provide &apos;manual&apos; as a feature to optionally require</a>
+ BGF <a href="https://curl.se/bug/?i=2533">tests: provide &#39;manual&#39; as a feature to optionally require</a>
  BGF <a href="https://curl.se/bug/?i=2541">travis: enable libssh2 on both macos and Linux</a>
  BGF CURLOPT_URL.3: added ENCODING section
  BGF <a href="https://curl.se/bug/?i=2542">wolfssl: Fix non-blocking connect</a>
- BGF vtls: don&apos;t define MD5_DIGEST_LENGTH for wolfssl
+ BGF vtls: don&#39;t define MD5_DIGEST_LENGTH for wolfssl
  BGF <a href="https://curl.se/bug/?i=2544">docs: remove extraneous commas in man pages</a>
  BGF <a href="https://curl.se/bug/?i=2535">URL: fix ASCII dependency in strcpy_url and strlen_url</a>
  BGF ssh-libssh.c: fix left shift compiler warning
  BGF <a href="https://curl.se/bug/?i=2180">configure: only check for CA bundle for file-using SSL backends</a>
  BGF <a href="https://curl.se/bug/?i=2531">travis: add an mbedtls build</a>
- BGF <a href="https://curl.se/bug/?i=2546">http: don&apos;t set the "rewind" flag when not uploading anything</a>
+ BGF <a href="https://curl.se/bug/?i=2546">http: don&#39;t set the "rewind" flag when not uploading anything</a>
  BGF <a href="https://curl.se/bug/?i=2548">configure: put CURLDEBUG and DEBUGBUILD in lib/curl_config.h</a>
- BGF <a href="https://curl.se/bug/?i=2520">transfer: don&apos;t unset writesockfd on setup of multiplexed conns</a>
+ BGF <a href="https://curl.se/bug/?i=2520">transfer: don&#39;t unset writesockfd on setup of multiplexed conns</a>
  BGF <a href="https://curl.se/bug/?i=2547">vtls: use unified "supports" bitfield member in backends</a>
  BGF <a href="https://curl.se/bug/?i=2550">URLs: fix one more http url</a>
  BGF <a href="https://curl.se/bug/?i=2528">travis: add a build using WolfSSL</a>
@@ -2251,17 +2251,17 @@ SUBTITLE(Fixed in 7.59.0 - March 14 2018)
 <ul class="bugfixes">
  BGF <a href="https://curl.se/docs/CVE-2018-1000121.html">openldap: check ldap_get_attribute_ber() results for NULL before using</a>
  BGF <a href="https://curl.se/docs/CVE-2018-1000120.html">FTP: reject path components with control codes</a>
- BGF <a href="https://curl.se/docs/CVE-2018-1000122.html">readwrite: make sure excess reads don&apos;t go beyond buffer end</a>
+ BGF <a href="https://curl.se/docs/CVE-2018-1000122.html">readwrite: make sure excess reads don&#39;t go beyond buffer end</a>
  BGF <a href="https://curl.se/bug/?i=1872">lib555: drop text conversion and encode data as ascii codes</a>
  BGF lib517: make variable static to avoid compiler warning
  BGF <a href="https://curl.se/bug/?i=1872">lib544: sync ascii code data with textual data</a>
  BGF <a href="https://curl.se/bug/?i=2263">GSKit: restore pinnedpubkey functionality</a>
- BGF <a href="https://curl.se/bug/?i=2085">darwinssl: Don&apos;t import client certificates into Keychain on macOS</a>
+ BGF <a href="https://curl.se/bug/?i=2085">darwinssl: Don&#39;t import client certificates into Keychain on macOS</a>
  BGF <a href="https://curl.se/bug/?i=2250">parsedate: fix date parsing for systems with 32 bit long</a>
  BGF <a href="https://curl.se/bug/?i=2258">openssl: fix pinned public key build error in FIPS mode</a>
  BGF <a href="https://curl.se/bug/?i=1429">SChannel/WinSSL: Implement public key pinning</a>
  BGF cookies: remove verbose "cookie size:" output
- BGF <a href="https://github.com/curl/curl/commit/993dd5651a6c853bfe3870f6a69c7b329fa4e8ce#commitcomment-27070080">progress-bar: don&apos;t use stderr explicitly, use bar->out</a>
+ BGF <a href="https://github.com/curl/curl/commit/993dd5651a6c853bfe3870f6a69c7b329fa4e8ce#commitcomment-27070080">progress-bar: don&#39;t use stderr explicitly, use bar->out</a>
  BGF Fixes for MSDOS
  BGF build: open VC15 projects with VS 2017
  BGF <a href="https://curl.se/bug/?i=2269">curl_ctype: private is*() type macros and functions</a>
@@ -2279,14 +2279,14 @@ SUBTITLE(Fixed in 7.59.0 - March 14 2018)
  BGF <a href="https://curl.se/bug/?i=2164">time-cond: fix reading the file modification time on Windows</a>
  BGF build-openssl.bat: Extend VC15 support to include Enterprise and Professional
  BGF build-wolfssl.bat: Extend VC15 support to include Enterprise and Professional
- BGF openssl: Don&apos;t add verify locations when verifypeer==0
+ BGF openssl: Don&#39;t add verify locations when verifypeer==0
  BGF <a href="https://curl.se/bug/?i=2291">fnmatch: optimize processing of consecutive *s and ?s pattern characters</a>
  BGF <a href="https://curl.se/bug/?i=2296">schannel: fix compiler warnings</a>
  BGF <a href="https://curl.se/bug/?i=2298">content_encoding: Add "none" alias to "identity"</a>
  BGF get_posix_time: only check for overflows if they can happen
- BGF <a href="https://curl.se/bug/?i=2303">http_chunks: don&apos;t write chunks twice with CURLOPT_HTTP_TRANSFER_DECODING</a>
+ BGF <a href="https://curl.se/bug/?i=2303">http_chunks: don&#39;t write chunks twice with CURLOPT_HTTP_TRANSFER_DECODING</a>
  BGF <a href="https://curl.se/bug/?i=2300">README: language fix</a>
- BGF <a href="https://curl.se/bug/?i=2305">sha256: build with OpenSSL < 0.9.8</a>
+ BGF <a href="https://curl.se/bug/?i=2305">sha256: build with OpenSSL &lt; 0.9.8</a>
  BGF <a href="https://curl.se/bug/?i=2304">smtp: fix processing of initial dot in data</a>
  BGF <a href="https://bugzilla.redhat.com/1542256">--tlsauthtype: works only if libcurl is built with TLS-SRP support</a>
  BGF <a href="https://curl.se/bug/?i=2303">tests: new tests for http raw mode</a>
@@ -2298,7 +2298,7 @@ SUBTITLE(Fixed in 7.59.0 - March 14 2018)
  BGF <a href="https://curl.se/bug/?i=2312">ssh: add two missing state names</a>
  BGF CURLOPT_HEADERFUNCTION.3: mention folded headers
  BGF <a href="https://curl.se/mail/lib-2018-02/0056.html">http: fix the max header length detection logic</a>
- BGF <a href="https://curl.se/bug/?i=2314">header callback: don&apos;t chop headers into smaller pieces</a>
+ BGF <a href="https://curl.se/bug/?i=2314">header callback: don&#39;t chop headers into smaller pieces</a>
  BGF CURLOPT_HEADER.3: clarify problems with different data sizes
  BGF curl --version: show PSL if the run-time lib has it enabled
  BGF <a href="https://curl.se/mail/lib-2018-02/0072.html">examples/sftpuploadresume: resume upload via CURLOPT_APPEND</a>
@@ -2322,7 +2322,7 @@ SUBTITLE(Fixed in 7.59.0 - March 14 2018)
  BGF <a href="https://curl.se/bug/?i=2371">limit-rate: kick in even before "limit" data has been received</a>
  BGF <a href="https://curl.se/bug/?i=2357">HTTP: allow "header;" to replace an internal header with a blank one</a>
  BGF http2: verbose output new MAX_CONCURRENT_STREAMS values
- BGF SECURITY: distros&apos; max embargo time is 14 days
+ BGF SECURITY: distros&#39; max embargo time is 14 days
  BGF curl tool: accept --compressed also if Brotli is enabled and zlib is not
  BGF <a href="https://curl.se/bug/?i=2349">WolfSSL: adding TLSv1.3</a>
  BGF checksrc.pl: add -i and -m options
@@ -2341,9 +2341,9 @@ SUBTITLE(Fixed in 7.58.0 - January 24 2018)
  BGF <a href="https://curl.se/docs/CVE-2018-1000005.html">http2: fix incorrect trailer buffer size</a>
  BGF <a href="https://curl.se/docs/CVE-2018-1000007.html">http: prevent custom Authorization headers in redirects</a>
  BGF <a href="https://curl.se/bug/?i=2118">travis: add boringssl build</a>
- BGF <a href="https://curl.se/mail/lib-2017-12/0000.html">examples/xmlstream.c: don&apos;t switch off CURL_GLOBAL_SSL</a>
+ BGF <a href="https://curl.se/mail/lib-2017-12/0000.html">examples/xmlstream.c: don&#39;t switch off CURL_GLOBAL_SSL</a>
  BGF <a href="https://curl.se/bug/?i=2119">SSL: Avoid magic allocation of SSL backend specific data</a>
- BGF <a href="https://curl.se/bug/?i=2127">lib: don&apos;t export all symbols, just everything curl_*</a>
+ BGF <a href="https://curl.se/bug/?i=2127">lib: don&#39;t export all symbols, just everything curl_*</a>
  BGF libssh2: send the correct CURLE error code on scp file not found
  BGF libssh2: return CURLE_UPLOAD_FAILED on failure to upload
  BGF <a href="https://curl.se/bug/?i=2134">openssl: enable pkcs12 in boringssl builds</a>
@@ -2393,7 +2393,7 @@ SUBTITLE(Fixed in 7.58.0 - January 24 2018)
  BGF <a href="https://curl.se/bug/?i=2179">curl: Support size modifiers for --max-filesize</a>
  BGF <a href="https://curl.se/mail/lib-2017-12/0057.html">examples/cacertinmem: ignore cert-already-exists error</a>
  BGF <a href="https://curl.se/bug/?i=2194">brotli: data at the end of content can be lost</a>
- BGF <a href="https://curl.se/mail/lib-2017-12/0074.html">curl_version_info.3: call the argument &apos;age&apos;</a>
+ BGF <a href="https://curl.se/mail/lib-2017-12/0074.html">curl_version_info.3: call the argument &#39;age&#39;</a>
  BGF openssl: fix memory leak of SSLKEYLOGFILE filename
  BGF <a href="https://curl.se/bug/?i=2215">build: remove HAVE_LIMITS_H check</a>
  BGF --mail-rcpt: fix short-text description
@@ -2412,11 +2412,11 @@ SUBTITLE(Fixed in 7.58.0 - January 24 2018)
  BGF <a href="https://curl.se/bug/?i=2239">CURLOPT_TCP_NODELAY.3: fix typo</a>
  BGF <a href="https://curl.se/bug/?i=2211">SMB: fix numeric constant suffix and variable types</a>
  BGF <a href="https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=5251">ftp-wildcard: fix matching an empty string with "*[^a]"</a>
- BGF curl_fnmatch: only allow 5 &apos;*&apos; sections in a single pattern
+ BGF curl_fnmatch: only allow 5 &#39;*&#39; sections in a single pattern
  BGF openssl: fix potential memory leak in SSLKEYLOGFILE logic
  BGF <a href="https://curl.se/bug/?i=2248">SSH: Fix state machine for ssh-agent authentication</a>
  BGF <a href="https://curl.se/bug/?i=2245">examples/url2file.c: add missing curl_global_cleanup() call</a>
- BGF <a href="https://curl.se/bug/?i=2237">http2: don&apos;t close connection when single transfer is stopped</a>
+ BGF <a href="https://curl.se/bug/?i=2237">http2: don&#39;t close connection when single transfer is stopped</a>
  BGF libcurl-env.3: first version
  BGF <a href="https://curl.se/bug/?i=2242">curl: progress bar refresh, get width using ioctl()</a>
  BGF <a href="https://curl.se/mail/lib-2018-01/0087.html">CONNECT_TO: fail attempt to set an IPv6 numerical without IPv6 support</a>
@@ -2440,7 +2440,7 @@ SUBTITLE(Fixed in 7.57.0 - November 29 2017)
  BGF <a href="https://curl.se/bug/?i=2004">fix time diffs for systems using unsigned time_t</a>
  BGF <a href="https://curl.se/bug/?i=2013">ftplistparser: memory leak fix: free temporary memory always</a>
  BGF <a href="https://curl.se/bug/?i=1982">multi: allow table handle sizes to be overridden</a>
- BGF <a href="https://curl.se/bug/?i=2016">wildcards: don&apos;t use with non-supported protocols</a>
+ BGF <a href="https://curl.se/bug/?i=2016">wildcards: don&#39;t use with non-supported protocols</a>
  BGF <a href="https://curl.se/bug/?i=2015">curl_fnmatch: return error on illegal wildcard pattern</a>
  BGF <a href="https://curl.se/bug/?i=2001">transfer: Fix chunked-encoding upload too early exit</a>
  BGF <a href="https://curl.se/bug/?i=2025">curl_setup: Improve detection of CURL_WINDOWS_APP</a>
@@ -2487,10 +2487,10 @@ SUBTITLE(Fixed in 7.57.0 - November 29 2017)
  BGF <a href="https://curl.se/bug/?i=2096">examples/curlx: Fix code style</a>
  BGF <a href="https://curl.se/bug/?i=2098">ntlm: remove unnecessary NULL-check to please scan-build</a>
  BGF <a href="https://curl.se/bug/?i=2098">Curl_llist_remove: fix potential NULL pointer deref</a>
- BGF <a href="https://curl.se/bug/?i=2098">mime: fix "Value stored to &apos;sz&apos; is never read" scan-build error</a>
- BGF <a href="https://curl.se/bug/?i=2098">openssl: fix "Value stored to &apos;rc&apos; is never read" scan-build error</a>
- BGF <a href="https://curl.se/bug/?i=2098">http2: fix "Value stored to &apos;hdbuf&apos; is never read" scan-build error</a>
- BGF <a href="https://curl.se/bug/?i=2098">http2: fix "Value stored to &apos;end&apos; is never read" scan-build error</a>
+ BGF <a href="https://curl.se/bug/?i=2098">mime: fix "Value stored to &#39;sz&#39; is never read" scan-build error</a>
+ BGF <a href="https://curl.se/bug/?i=2098">openssl: fix "Value stored to &#39;rc&#39; is never read" scan-build error</a>
+ BGF <a href="https://curl.se/bug/?i=2098">http2: fix "Value stored to &#39;hdbuf&#39; is never read" scan-build error</a>
+ BGF <a href="https://curl.se/bug/?i=2098">http2: fix "Value stored to &#39;end&#39; is never read" scan-build error</a>
  BGF <a href="https://curl.se/bug/?i=2098">Curl_open: fix OOM return error correctly</a>
  BGF <a href="https://curl.se/bug/?i=2073">url: reject ASCII control characters and space in host names</a>
  BGF <a href="https://curl.se/bug/?i=2106">examples/rtsp: clear RANGE again after use</a>
@@ -2500,15 +2500,15 @@ SUBTITLE(Fixed in 7.57.0 - November 29 2017)
  BGF <a href="https://curl.se/bug/?i=2109">metalink: fix memory-leak and NULL pointer dereference</a>
  BGF <a href="https://curl.se/bug/?i=2110">URL: update "file:" URL handling</a>
  BGF <a href="https://curl.se/bug/?i=2111">ssh: remove check for a NULL pointer</a>
- BGF <a href="https://curl.se/bug/?i=2083">global_init: ignore CURL_GLOBAL_SSL&apos;s absence</a>
+ BGF <a href="https://curl.se/bug/?i=2083">global_init: ignore CURL_GLOBAL_SSL&#39;s absence</a>
 </ul>
 
 <a name="7_56_1"></a>
 SUBTITLE(Fixed in 7.56.1 - October 23 2017)
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF <a href="https://curl.se/docs/CVE-2017-1000257.html">imap: if a FETCH response has no size, don&apos;t call write callback</a>
- BGF <a href="https://curl.se/bug/?i=1939">ftp: UBsan fixup &apos;pointer index expression overflowed</a>
+ BGF <a href="https://curl.se/docs/CVE-2017-1000257.html">imap: if a FETCH response has no size, don&#39;t call write callback</a>
+ BGF <a href="https://curl.se/bug/?i=1939">ftp: UBsan fixup &#39;pointer index expression overflowed</a>
  BGF <a href="https://curl.se/bug/?i=1936">failf: skip the sprintf() if there are no consumers</a>
  BGF <a href="https://curl.se/bug/?i=1923">fuzzer: move to using external curl-fuzzer</a>
  BGF <a href="https://curl.se/bug/?i=1942">lib/Makefile.m32: allow customizing dll suffixes</a>
@@ -2524,10 +2524,10 @@ SUBTITLE(Fixed in 7.56.1 - October 23 2017)
  BGF <a href="https://curl.se/bug/?i=1960">remove_handle: call multi_done() first, then clear dns cache pointer</a>
  BGF mime: be tolerant about setting the same header list twice in a part
  BGF mime: improve unbinding top multipart from easy handle
- BGF mime: avoid resetting a part&apos;s encoder when part&apos;s contents change
+ BGF mime: avoid resetting a part&#39;s encoder when part&#39;s contents change
  BGF <a href="https://curl.se/bug/?i=1962">mime: refuse to add subparts to one of their own descendants</a>
  BGF <a href="https://curl.se/bug/?i=1969">RTSP: avoid integer overflow on funny RTSP responses</a>
- BGF <a href="https://curl.se/bug/?i=1964">curl: don&apos;t pass semicolons when parsing Content-Disposition</a>
+ BGF <a href="https://curl.se/bug/?i=1964">curl: don&#39;t pass semicolons when parsing Content-Disposition</a>
  BGF <a href="https://curl.se/bug/?i=1948">openssl: enable PKCS12 support for !BoringSSL</a>
  BGF FAQ: s/CURLOPT_PROGRESSFUNCTION/CURLOPT_XFERINFOFUNCTION
  BGF CURLOPT_NOPROGRESS.3: also refer to xferinfofunction
@@ -2537,7 +2537,7 @@ SUBTITLE(Fixed in 7.56.1 - October 23 2017)
  BGF <a href="https://curl.se/bug/?i=1977">smtp_done: fix memory leak on send failure</a>
  BGF ftpserver: support case insensitive commands
  BGF test950; verify SMTP with custom request
- BGF <a href="https://curl.se/bug/?i=1979">openssl: don&apos;t use old BORINGSSL_YYYYMM macros</a>
+ BGF <a href="https://curl.se/bug/?i=1979">openssl: don&#39;t use old BORINGSSL_YYYYMM macros</a>
  BGF <a href="https://curl.se/bug/?i=1941">setopt: update current connection SSL verify params</a>
  BGF winbuild/BUILD.WINDOWS.txt: mention WITH_NGHTTP2
  BGF <a href="https://curl.se/bug/?i=1985">curl: reimplement stdin buffering in -F option</a>
@@ -2552,7 +2552,7 @@ SUBTITLE(Fixed in 7.56.1 - October 23 2017)
  BGF <a href="https://curl.se/bug/?i=1938">setopt: range check most long options</a>
  BGF <a href="https://curl.se/bug/?i=1997">ftp: reject illegal IP/port in PASV 227 response</a>
  BGF <a href="https://curl.se/bug/?i=1999">mime: do not reuse previously computed multipart size</a>
- BGF vtls: change struct Curl_ssl `close&apos; field name to `close_one&apos;
+ BGF vtls: change struct Curl_ssl `close&#39; field name to `close_one&#39;
  BGF os400: add missing symbols in config file
  BGF mime: limit bas64-encoded lines length to 76 characters
  BGF <a href="https://curl.se/bug/?i=1998">mk-ca-bundle: Remove URL for aurora</a>
@@ -2589,7 +2589,7 @@ SUBTITLE(Fixed in 7.56.0 - October 4 2017)
  BGF examples/ftpuploadresume: checksrc compliance
  BGF <a href="https://curl.se/bug/?i=1782">ftp: fix CWD when doing multicwd then nocwd on same connection</a>
  BGF <a href="https://curl.se/bug/?i=1767">system.h: remove all CURL_SIZEOF_* defines</a>
- BGF <a href="https://curl.se/bug/?i=1803">http: Don&apos;t wait on CONNECT when there is no proxy</a>
+ BGF <a href="https://curl.se/bug/?i=1803">http: Don&#39;t wait on CONNECT when there is no proxy</a>
  BGF <a href="https://curl.se/bug/?i=1797">system.h: check for __ppc__ as well</a>
  BGF <a href="https://curl.se/bug/?i=1021">http2_recv: return error better on fatal h2 errors</a>
  BGF scripts/contri*sh: use "git log --use-mailmap"
@@ -2597,7 +2597,7 @@ SUBTITLE(Fixed in 7.56.0 - October 4 2017)
  BGF <a href="https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872502#10">system.h: fix build for hppa</a>
  BGF <a href="https://curl.se/bug/?i=1799">cmake: enable picky compiler options with clang and gcc</a>
  BGF <a href="https://curl.se/bug/?i=1815">makefile.m32: add support for libidn2</a>
- BGF <a href="https://curl.se/bug/?i=1751">curl: turn off MinGW CRT&apos;s globbing</a>
+ BGF <a href="https://curl.se/bug/?i=1751">curl: turn off MinGW CRT&#39;s globbing</a>
  BGF request-target.d: mention added in 7.55.0
  BGF <a href="https://curl.se/bug/?i=1810">curl: shorten and clean up CA cert verification error message</a>
  BGF <a href="https://curl.se/bug/?i=1818">imap: support PREAUTH</a>
@@ -2618,13 +2618,13 @@ SUBTITLE(Fixed in 7.56.0 - October 4 2017)
  BGF <a href="https://curl.se/bug/?i=1858">schannel: return CURLE_SSL_CACERT on failed verification</a>
  BGF MAIL-ETIQUETTE: added "1.9 Your emails are public"
  BGF <a href="https://curl.se/bug/?i=1859">http-proxy: treat all 2xx as CONNECT success</a>
- BGF <a href="https://curl.se/bug/?i=1846">openssl: use OpenSSL&apos;s default ciphers by default</a>
+ BGF <a href="https://curl.se/bug/?i=1846">openssl: use OpenSSL&#39;s default ciphers by default</a>
  BGF runtests.pl: support attribute "nonewline" in part verify/upload
  BGF <a href="https://curl.se/bug/?i=1861">configure: remove --enable-soname-bump and SONAME_BUMP</a>
  BGF <a href="https://curl.se/bug/?i=1868">travis: add c-ares enabled builds linux + osx</a>
  BGF <a href="https://curl.se/bug/?i=1865">vtls: fix WolfSSL 3.12 build problems</a>
  BGF <a href="https://curl.se/bug/?i=1853">http-proxy: when not doing CONNECT, that phase is done immediately</a>
- BGF <a href="https://curl.se/bug/?i=1870">configure: fix curl_off_t check&apos;s include order</a>
+ BGF <a href="https://curl.se/bug/?i=1870">configure: fix curl_off_t check&#39;s include order</a>
  BGF configure: use -Wno-varargs on clang 3.9[.X] debug builds
  BGF <a href="https://curl.se/bug/?i=1874">rtsp: do not call fwrite() with NULL pointer FILE *</a>
  BGF <a href="https://curl.se/bug/?i=1877">mbedtls: enable CA path processing</a>
@@ -2634,14 +2634,14 @@ SUBTITLE(Fixed in 7.56.0 - October 4 2017)
  BGF <a href="https://curl.se/bug/?i=1687">tests: add initial gssapi test using stub implementation</a>
  BGF <a href="https://curl.se/bug/?i=1880">rtsp: Segfault when using WRITEDATA</a>
  BGF docs: clarify the CURLOPT_INTERLEAVE* options behavior
- BGF <a href="https://curl.se/mail/lib-2017-09/0031.html">non-ascii: use iconv() with &apos;char **&apos; argument</a>
+ BGF <a href="https://curl.se/mail/lib-2017-09/0031.html">non-ascii: use iconv() with &#39;char **&#39; argument</a>
  BGF server/getpart: provide dummy function to build conversion enabled
  BGF conversions: fix several compiler warnings
  BGF <a href="https://curl.se/bug/?i=1891">openssl: add missing includes</a>
  BGF <a href="https://curl.se/bug/?i=1890">schannel: Support partial send for when data is too large</a>
  BGF <a href="https://curl.se/bug/?i=1892">socks: fix incorrect port number in SOCKS4 error message</a>
  BGF <a href="https://curl.se/bug/?i=1893">curl: fix integer overflow in timeout options</a>
- BGF <a href="https://curl.se/bug/?i=1895">travis: on mac, don&apos;t install openssl or libidn</a>
+ BGF <a href="https://curl.se/bug/?i=1895">travis: on mac, don&#39;t install openssl or libidn</a>
  BGF <a href="https://curl.se/bug/?i=1894">cookies: reject oversized cookies instead of truncating</a>
  BGF <a href="https://curl.se/bug/?i=1896">cookies: use lock when using CURLINFO_COOKIELIST</a>
  BGF curl: check fseek() return code and bail on error
@@ -2651,8 +2651,8 @@ SUBTITLE(Fixed in 7.56.0 - October 4 2017)
  BGF <a href="https://curl.se/bug/?i=1902">imap: quote atoms properly when escaping characters</a>
  BGF tests: fix a compiler warning in test 643
  BGF <a href="https://curl.se/bug/?i=1908">file_range: avoid integer overflow when figuring out byte range</a>
- BGF <a href="https://curl.se/bug/?i=1925">curl.h: include <sys/select.h> on cygwin too</a>
- BGF <a href="https://curl.se/bug/?i=1918">reuse_conn: don&apos;t copy flags that are known to be equal</a>
+ BGF <a href="https://curl.se/bug/?i=1925">curl.h: include &lt;sys/select.h&gt; on cygwin too</a>
+ BGF <a href="https://curl.se/bug/?i=1918">reuse_conn: don&#39;t copy flags that are known to be equal</a>
  BGF <a href="https://curl.se/bug/?i=1920">http: fix adding custom empty headers to repeated requests</a>
  BGF <a href="https://curl.se/bug/?i=1921">docs: clarify the use of environment variables for proxy</a>
  BGF <a href="https://curl.se/bug/?i=1922">docs: link CURLOPT_CONNECTTIMEOUT and CURLOPT_CONNECTTIMEOUT_MS</a>
@@ -2666,11 +2666,11 @@ SUBTITLE(Fixed in 7.56.0 - October 4 2017)
 SUBTITLE(Fixed in 7.55.1 - August 14 2017)
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF build: fix &apos;make install&apos; with configure, install docs/libcurl/&#42; too
+ BGF build: fix &#39;make install&#39; with configure, install docs/libcurl/&#42; too
  BGF make install: add 8 missing man pages to the installation
  BGF <a href="https://curl.se/bug/?i=1750">curl: do bounds check using a double comparison</a>
  BGF <a href="https://curl.se/bug/?i=1744">dist: Add dictserver.py/negtelnetserver.py to release</a>
- BGF <a href="https://curl.se/bug/?i=1742">digest_sspi: Don&apos;t reuse context if the user/passwd has changed</a>
+ BGF <a href="https://curl.se/bug/?i=1742">digest_sspi: Don&#39;t reuse context if the user/passwd has changed</a>
  BGF <a href="https://curl.se/bug/?i=1746">gitignore: ignore top-level .vs folder</a>
  BGF <a href="https://curl.se/bug/?i=1746">build: check out *.sln files with Windows line endings</a>
  BGF <a href="https://curl.se/bug/?i=1753">travis: verify "make install"</a>
@@ -2710,7 +2710,7 @@ SUBTITLE(Fixed in 7.55.0 - August 9 2017)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF <a href="https://curl.se/docs/CVE-2017-1000101.html">glob: do not parse after a strtoul() overflow range (CVE-2017-1000101)</a>
- BGF <a href="https://curl.se/docs/CVE-2017-1000100.html">tftp: reject file name lengths that don&apos;t fit (CVE-2017-1000100)</a>
+ BGF <a href="https://curl.se/docs/CVE-2017-1000100.html">tftp: reject file name lengths that don&#39;t fit (CVE-2017-1000100)</a>
  BGF <a href="https://curl.se/docs/CVE-2017-1000099.html">file: output the correct buffer to the user (CVE-2017-1000099)</a>
  BGF <a href="https://daniel.haxx.se/blog/2017/06/15/target-independent-libcurl-headers/">includes: remove curl/curlbuild.h and curl/curlrules.h</a>
  BGF <a href="https://curl.se/bug/?i=1565">dist: make the hugehelp.c not get regenerated unnecessarily</a>
@@ -2720,10 +2720,10 @@ SUBTITLE(Fixed in 7.55.0 - August 9 2017)
  BGF <a href="https://curl.se/bug/?i=1538">lib/curl_setup.h: remove CURL_WANTS_CA_BUNDLE_ENV</a>
  BGF <a href="https://curl.se/bug/?i=1476">fuzz: bring oss-fuzz initial code converted to C89</a>
  BGF configure: disable nghttp2 too if HTTP has been disabled
- BGF <a href="https://curl.se/bug/?i=1577">mk-ca-bundle.pl: Check curl&apos;s exit code after certdata download</a>
+ BGF <a href="https://curl.se/bug/?i=1577">mk-ca-bundle.pl: Check curl&#39;s exit code after certdata download</a>
  BGF <a href="https://curl.se/bug/?i=1569">test1148: verify the -# progressbar</a>
  BGF <a href="https://curl.se/bug/?i=1576">tests: stabilize test 2032 and 2033</a>
- BGF <a href="https://curl.se/bug/?i=1546">HTTPS-Proxy: don&apos;t offer h2 for https proxy connections</a>
+ BGF <a href="https://curl.se/bug/?i=1546">HTTPS-Proxy: don&#39;t offer h2 for https proxy connections</a>
  BGF <a href="https://curl.se/bug/?i=1505">http-proxy: only attempt FTP over HTTP proxy</a>
  BGF <a href="https://curl.se/bug/?i=1578">curl-compilers.m4: enable vla warning for clang</a>
  BGF <a href="https://curl.se/bug/?i=1578">curl-compilers.m4: enable double-promotion warning</a>
@@ -2756,7 +2756,7 @@ SUBTITLE(Fixed in 7.55.0 - August 9 2017)
  BGF <a href="https://curl.se/bug/?i=1615">test1450: add simple testing for DICT</a>
  BGF <a href="https://curl.se/bug/?i=1591">make: build the docs subdir only from within src</a>
  BGF <a href="https://curl.se/bug/?i=1621">cmake: Added compatibility options for older Windows versions</a>
- BGF <a href="https://curl.se/bug/?i=1617">gtls: fix build when sizeof(long) < sizeof(void *)</a>
+ BGF <a href="https://curl.se/bug/?i=1617">gtls: fix build when sizeof(long) &lt; sizeof(void *)</a>
  BGF <a href="https://curl.se/bug/?i=1631">url: make the original string get used on subsequent transfers</a>
  BGF <a href="https://curl.se/mail/lib-2017-07/0003.html">timeval.c: Use long long constant type for timeval assignment</a>
  BGF tool_sleep: typecast to avoid macos compiler warning
@@ -2776,14 +2776,14 @@ SUBTITLE(Fixed in 7.55.0 - August 9 2017)
  BGF test506: skip if threaded-resolver
  BGF <a href="https://curl.se/bug/?i=1552">cmake: remove spurious "-l" from linker flags</a>
  BGF cmake: add CURL_WERROR for enabling "warning as errors"
- BGF <a href="https://github.com/curl/curl/issues/828#issuecomment-313475151">memdebug: don&apos;t setbuf() if the file open failed</a>
+ BGF <a href="https://github.com/curl/curl/issues/828#issuecomment-313475151">memdebug: don&#39;t setbuf() if the file open failed</a>
  BGF <a href="https://curl.se/bug/?i=1612">curl_easy_escape.3: mention the (lack of) encoding</a>
  BGF <a href="https://curl.se/bug/?i=1645">test1452: add telnet negotiation</a>
  BGF CURLOPT_POSTFIELDS.3: explain the 100-continue magic better
  BGF <a href="https://curl.se/bug/?i=1649">cmake: offer CMAKE_DEBUG_POSTFIX when building with MSVC</a>
  BGF <a href="https://curl.se/bug/?i=1653">tests/valgrind.supp: suppress OpenSSL false positive seen on travis</a>
  BGF <a href="https://curl.se/bug/?i=1589">curl_setup_once: Remove ERRNO/SET_ERRNO macros</a>
- BGF <a href="https://curl.se/bug/?i=1665">curl-compilers.m4: disable warning spam with Cygwin&apos;s clang</a>
+ BGF <a href="https://curl.se/bug/?i=1665">curl-compilers.m4: disable warning spam with Cygwin&#39;s clang</a>
  BGF <a href="https://curl.se/bug/?i=1664">ldap: fix MinGW compiler warning</a>
  BGF <a href="https://curl.se/bug/?i=1591">make: fix docs build on OpenBSD</a>
  BGF <a href="https://curl.se/bug/?i=1672">curl_setup: always define WIN32_LEAN_AND_MEAN on Windows</a>
@@ -2812,14 +2812,14 @@ SUBTITLE(Fixed in 7.55.0 - August 9 2017)
  BGF travis: build on osx with libressl
  BGF CURLOPT_NETRC.3: mention the file name on windows
  BGF <a href="https://curl.se/bug/?i=1711">cmake: set MSVC warning level to 4</a>
- BGF <a href="https://curl.se/mail/lib-2017-08/0008.html">netrc: skip lines starting with &apos;#&apos;</a>
+ BGF <a href="https://curl.se/mail/lib-2017-08/0008.html">netrc: skip lines starting with &#39;#&#39;</a>
  BGF darwinssl: fix curlssl_sha256sum() compiler warnings on first argument
  BGF BUILD.WINDOWS: mention buildconf.bat for builds off git
  BGF <a href="https://curl.se/bug/?i=1722">darwinssl: silence compiler warnings</a>
  BGF travis: build on osx with darwinssl
  BGF <a href="https://curl.se/bug/?i=1718">FTP: skip unnecessary CWD when in nocwd mode</a>
  BGF <a href="https://curl.se/bug/?i=1733">gssapi: fix memory leak of output token in multi round context</a>
- BGF <a href="https://curl.se/bug/?i=1728">getparameter: avoid returning uninitialized &apos;usedarg&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=1728">getparameter: avoid returning uninitialized &#39;usedarg&#39;</a>
  BGF curl (debug build) easy_events: make event data static
  BGF <a href="https://curl.se/bug/?i=1730">curl: detect and bail out early on parameter integer overflows</a>
  BGF <a href="https://curl.se/bug/?i=1738">configure: fix recv/send/select detection on Android</a>
@@ -2842,10 +2842,10 @@ SUBTITLE(Fixed in 7.54.1 - June 14 2017)
  BGF gnutls: removed some code when --disable-verbose is configured
  BGF lib: fix maybe-uninitialized warnings
  BGF <a href="https://curl.se/bug/?i=1439">multi: clarify condition in curl_multi_wait</a>
- BGF <a href="https://curl.se/bug/?i=1392">schannel: Don&apos;t treat encrypted partial record as pending data</a>
+ BGF <a href="https://curl.se/bug/?i=1392">schannel: Don&#39;t treat encrypted partial record as pending data</a>
  BGF <a href="https://curl.se/bug/?i=1427">configure: fix the -ldl check for openssl, add -lpthread check</a>
  BGF <a href="https://curl.se/bug/?i=1440">configure: accept -Og and -Ofast GCC flags</a>
- BGF <a href="https://curl.se/bug/?i=1432">Makefile: avoid use of GNU-specific form of $<</a>
+ BGF <a href="https://curl.se/bug/?i=1432">Makefile: avoid use of GNU-specific form of $&lt;</a>
  BGF if2ip: fix -Wcast-align warning
  BGF <a href="https://curl.se/bug/?i=1420">configure: stop prepending to LDFLAGS, CPPFLAGS</a>
  BGF <a href="https://curl.se/bug/?i=1446">curl: set a 100K buffer size by default</a>
@@ -2892,13 +2892,13 @@ SUBTITLE(Fixed in 7.54.1 - June 14 2017)
  BGF <a href="https://curl.se/bug/?i=1472">multi: use a fixed array of timers instead of malloc</a>
  BGF <a href="https://curl.se/bug/?i=1475">mbedtls: Support server renegotiation request</a>
  BGF <a href="https://curl.se/bug/?i=1481">pipeline: fix mistakenly trying to pipeline POSTs</a>
- BGF lib510: don&apos;t write past the end of the buffer if it&apos;s too small
+ BGF lib510: don&#39;t write past the end of the buffer if it&#39;s too small
  BGF CURLOPT_HTTPPROXYTUNNEL.3: clarify, add example
  BGF <a href="https://curl.se/bug/?i=1400">SecureTransport/DarwinSSL: Implement public key pinning</a>
  BGF curl.1: clarify --config
  BGF <a href="https://curl.se/bug/?i=1487">curl_sasl: fix build error with CURL_DISABLE_CRYPTO_AUTH + USE_NTLM</a>
  BGF <a href="https://curl.se/bug/?i=1450">darwinssl: Fix exception when processing a client-side certificate</a>
- BGF curl.1: mention --oauth2-bearer&apos;s <token> argument
+ BGF curl.1: mention --oauth2-bearer&#39;s &lt;token&gt; argument
  BGF <a href="https://curl.se/bug/?i=1490">mkhelp.pl: do not add current time into curl binary</a>
  BGF <a href="https://curl.se/bug/?i=1253">asiohiper.cpp / evhiperfifo.c: deal with negative timerfunction input</a>
  BGF <a href="https://curl.se/bug/?i=1479">ssh: fix memory leak in disconnect due to timeout</a>
@@ -2989,7 +2989,7 @@ SUBTITLE(Fixed in 7.54.0 - April 19 2017)
  BGF <a href="https://curl.se/mail/lib-2017-03/0004.html">ares: return error at once if timed out before name resolve starts</a>
  BGF BINDINGS: added C++, perl, go and Scilab bindings
  BGF URL: return error on malformed URLs with junk after port number
- BGF <a href="https://curl.se/bug/?i=1308">KNOWN_BUGS: Add DarwinSSL won&apos;t import PKCS#12 without a password</a>
+ BGF <a href="https://curl.se/bug/?i=1308">KNOWN_BUGS: Add DarwinSSL won&#39;t import PKCS#12 without a password</a>
  BGF <a href="https://curl.se/bug/?i=1286">http2: Fix assertion error on redirect with CL=0</a>
  BGF <a href="https://curl.se/bug/?i=1058">updatemanpages.pl: Update man pages to use current date and versions</a>
  BGF <a href="https://curl.se/mail/lib-2017-03/0002.html">--insecure: clarify that this option is for server connections</a>
@@ -3015,7 +3015,7 @@ SUBTITLE(Fixed in 7.54.0 - April 19 2017)
  BGF <a href="https://curl.se/bug/?i=1288">cmake: build manual pages</a>
  BGF <a href="https://curl.se/bug/?i=1288">cmake: add support for building HTML and PDF docs</a>
  BGF <a href="https://curl.se/bug/?i=1272">mbedtls: add support for CURLOPT_SSL_CTX_FUNCTION</a>
- BGF make: introduce &apos;test-nonflaky&apos; target
+ BGF make: introduce &#39;test-nonflaky&#39; target
  BGF CURLINFO_PRIMARY_IP.3: add example
  BGF <a href="https://curl.se/bug/?i=1342">tests/README: mention nroff for --manual tests</a>
  BGF mkhelp: disable compression if the perl gzip module is unavailable
@@ -3050,7 +3050,7 @@ SUBTITLE(Fixed in 7.54.0 - April 19 2017)
  BGF easy: silence compiler warning
  BGF <a href="https://curl.se/bug/?i=1381">llist: replace Curl_llist_alloc with Curl_llist_init</a>
  BGF <a href="https://curl.se/bug/?i=1376">hash: move key into hash struct to reduce mallocs</a>
- BGF <a href="https://curl.se/bug/?i=1380">url: don&apos;t free postponed data on connection reuse</a>
+ BGF <a href="https://curl.se/bug/?i=1380">url: don&#39;t free postponed data on connection reuse</a>
  BGF curl_sasl: declare mechtable static
  BGF curl: fix Windows Unicode build
  BGF <a href="https://curl.se/bug/?i=1358">multi: fix queueing of pending easy handles</a>
@@ -3065,8 +3065,8 @@ SUBTITLE(Fixed in 7.54.0 - April 19 2017)
  BGF <a href="https://curl.se/mail/lib-2017-04/0044.html">libcurl-thread.3: also mention threaded-resolver</a>
  BGF <a href="https://curl.se/bug/?i=851">nss: load CA certificates even with --insecure</a>
  BGF <a href="https://curl.se/bug/?i=1402">openssl: fix this statement may fall through</a>
- BGF <a href="https://curl.se/bug/?i=1406">poll: prefer <poll.h> over <sys/poll.h></a>
- BGF <a href="https://curl.se/bug/?i=1401">polarssl: unbreak build with versions < 1.3.8</a>
+ BGF <a href="https://curl.se/bug/?i=1406">poll: prefer &lt;poll.h&gt; over &lt;sys/poll.h&gt;</a>
+ BGF <a href="https://curl.se/bug/?i=1401">polarssl: unbreak build with versions &lt; 1.3.8</a>
  BGF <a href="https://curl.se/mail/lib-2017-04/0030.html">Curl_expire_latest: ignore already expired timers</a>
  BGF <a href="https://curl.se/bug/?i=1409">configure: turn implicit function declarations into errors</a>
  BGF <a href="https://curl.se/bug/?i=1417">mbedtls: fix memory leak in error path</a>
@@ -3076,7 +3076,7 @@ SUBTITLE(Fixed in 7.54.0 - April 19 2017)
  BGF <a href="https://curl.se/bug/?i=1422">extern-scan.pl: strip trailing CR</a>
  BGF <a href="https://curl.se/bug/?i=1424">openssl: make SSL_ERROR_to_str more future-proof</a>
  BGF <a href="https://curl.se/bug/?i=1424">openssl: fix thread-safety bugs in error-handling</a>
- BGF <a href="https://curl.se/bug/?i=1425">openssl: don&apos;t try to print nonexistent peer private keys</a>
+ BGF <a href="https://curl.se/bug/?i=1425">openssl: don&#39;t try to print nonexistent peer private keys</a>
  BGF <a href="https://curl.se/bug/?i=1393">nss: fix MinGW compiler warnings</a>
 </ul>
 
@@ -3135,18 +3135,18 @@ SUBTITLE(Fixed in 7.53.0 - February 22 2017)
  BGF <a href="https://curl.se/mail/lib-2017-01/0009.html">tests/sws: retry send() on EWOULDBLOCK</a>
  BGF <a href="https://curl.se/bug/?i=1195">cmake: Fix passing _WINSOCKAPI_ macro to compiler</a>
  BGF smtp: Fix STARTTLS denied error message
- BGF <a href="https://curl.se/bug/?i=1203">imap/pop3: don&apos;t print response character in STARTTLS denied messages</a>
+ BGF <a href="https://curl.se/bug/?i=1203">imap/pop3: don&#39;t print response character in STARTTLS denied messages</a>
  BGF <a href="https://curl.se/mail/lib-2017-01/0055.html">rand: make it work without TLS backing</a>
- BGF <a href="https://curl.se/bug/?i=1124">url: fix parsing for when &apos;file&apos; is the default protocol</a>
+ BGF <a href="https://curl.se/bug/?i=1124">url: fix parsing for when &#39;file&#39; is the default protocol</a>
  BGF <a href="https://curl.se/bug/?i=1187">url: allow file://X:/path URLs on windows again</a>
  BGF <a href="https://curl.se/bug/?i=1204">gnutls: check for alpn and ocsp in configure</a>
- BGF <a href="https://curl.se/bug/?i=1207">IDN: Use TR46 &apos;non-transitional&apos; for toASCII translations</a>
+ BGF <a href="https://curl.se/bug/?i=1207">IDN: Use TR46 &#39;non-transitional&#39; for toASCII translations</a>
  BGF <a href="https://curl.se/bug/?i=1140">url: Fix NO_PROXY env var to work properly with --proxy option</a>
  BGF <a href="https://curl.se/bug/?i=1169">CURLOPT_PREQUOTE.3: takes a struct curl_slist*, not a char*</a>
  BGF <a href="https://curl.se/bug/?i=1169">docs: Add note about libcurl copying strings to CURLOPT_* manpages</a>
  BGF curl: reset the easy handle at --next
  BGF --next docs: --trace and --trace-ascii are also global
- BGF --write-out docs: &apos;time_total&apos; is not always shown with ms precision
+ BGF --write-out docs: &#39;time_total&#39; is not always shown with ms precision
  BGF http: print correct HTTP string in verbose output when using HTTP/2
  BGF <a href="https://curl.se/bug/?i=1211">docs: improved language in README.md HISTORY.md CONTRIBUTE.md</a>
  BGF <a href="https://curl.se/bug/?i=1160">http2: disable server push if not requested</a>
@@ -3164,7 +3164,7 @@ SUBTITLE(Fixed in 7.53.0 - February 22 2017)
  BGF <a href="https://curl.se/bug/?i=1109">gnutls: disable TLS session tickets</a>
  BGF <a href="https://curl.se/bug/?i=1109">mbedtls: disable TLS session tickets</a>
  BGF <a href="https://curl.se/bug/?i=1227">mbedtls: implement CTR-DRBG and HAVEGE random generators</a>
- BGF <a href="https://curl.se/bug/?i=1236">openssl: Don&apos;t use certificate after transferring ownership</a>
+ BGF <a href="https://curl.se/bug/?i=1236">openssl: Don&#39;t use certificate after transferring ownership</a>
  BGF <a href="https://curl.se/bug/?i=1176">cmake: Support curl --xattr when built with cmake</a>
  BGF <a href="https://curl.se/bug/?i=1237">OS400: Fix symbols</a>
  BGF <a href="https://github.com/curl/curl/commit/cb4e2be">docs: Add more HTTPS proxy documentation</a>
@@ -3190,13 +3190,13 @@ SUBTITLE(Fixed in 7.53.0 - February 22 2017)
  BGF <a href="https://curl.se/bug/?i=1220">axtls: adapt to API changes</a>
  BGF <a href="https://curl.se/bug/?i=1238">tool_urlglob: Allow a glob range with the same start and stop</a>
  BGF <a href="https://curl.se/bug/?i=1265">winbuild: add note on auto-detection of MACHINE in Makefile.vc</a>
- BGF <a href="https://curl.se/bug/?i=1242">http: fix missing &apos;Content-Length: 0&apos; while negotiating auth</a>
+ BGF <a href="https://curl.se/bug/?i=1242">http: fix missing &#39;Content-Length: 0&#39; while negotiating auth</a>
  BGF <a href="https://curl.se/bug/?i=1248">proxy: fix hostname resolution and IDN conversion</a>
  BGF docs: fix timeout handling in multi-uv example
  BGF <a href="https://curl.se/bug/?i=1251">digest_sspi: Fix nonce-count generation in HTTP digest</a>
  BGF <a href="https://curl.se/bug/?i=1269">sftp: improved checks for create dir failures</a>
  BGF <a href="https://github.com/Microsoft/vcpkg/blob/7676b8780db1e1e591c4fc7eba4f96f73c428cb4/ports/curl/0002_fix_uwp.patch">smb: use getpid replacement for windows UWP builds</a>
- BGF <a href="https://github.com/curl/curl/issues/928">digest_sspi: Handle &apos;stale=TRUE&apos; directive in HTTP digest</a>
+ BGF <a href="https://github.com/curl/curl/issues/928">digest_sspi: Handle &#39;stale=TRUE&#39; directive in HTTP digest</a>
 </ul>
 
 <a name="7_52_1"></a>
@@ -3231,12 +3231,12 @@ SUBTITLE(Fixed in 7.52.0 - December 21 2016)
  BGF <a href="https://curl.se/bug/?i=1098">winbuild: remove strcase.obj from curl build</a>
  BGF examples: bugfixed multi-uv.c
  BGF <a href="https://curl.se/bug/?i=1104">configure: verify that compiler groks -Werror=partial-availability</a>
- BGF <a href="https://curl.se/bug/?i=1087">mbedtls: fix build with mbedtls versions < 2.4.0</a>
+ BGF <a href="https://curl.se/bug/?i=1087">mbedtls: fix build with mbedtls versions &lt; 2.4.0</a>
  BGF dist: add unit test CMakeLists.txt to the tarball
  BGF <a href="https://curl.se/bug/?i=1106">curl -w: added more decimal digits to timing counters</a>
  BGF <a href="https://curl.se/bug/?i=1103">easy: Initialize info variables on easy init and duphandle</a>
  BGF <a href="https://curl.se/bug/?i=1089">cmake: disable poll for macOS</a>
- BGF <a href="https://curl.se/bug/?i=1092">http2: Don&apos;t send header fields prohibited by HTTP/2 spec</a>
+ BGF <a href="https://curl.se/bug/?i=1092">http2: Don&#39;t send header fields prohibited by HTTP/2 spec</a>
  BGF <a href="https://github.com/curl/curl/commit/ce8d09483eea2fcb1b50e323e1a8ed1f3613b2e3#commitcomment-19666146">ssh: check md5 fingerprints case insensitively (regression)</a>
  BGF openssl: initial TLS 1.3 adaptions
  BGF curl_formadd.3: *_FILECONTENT and *_FILE need the file to be kept
@@ -3253,7 +3253,7 @@ SUBTITLE(Fixed in 7.52.0 - December 21 2016)
  BGF curl.1: Clarify --dump-header only writes received headers
  BGF http2: Fix address sanitizer memcpy warning
  BGF <a href="https://curl.se/bug/?i=1102">http2: Use huge HTTP/2 windows</a>
- BGF connects: Don&apos;t mix unix domain sockets with regular ones
+ BGF connects: Don&#39;t mix unix domain sockets with regular ones
  BGF <a href="https://curl.se/mail/lib-2016-11/0137.html">url: Fix conn reuse for local ports and interfaces</a>
  BGF x509: Limit ASN.1 structure sizes to 256K
  BGF checksrc: add more checks
@@ -3265,7 +3265,7 @@ SUBTITLE(Fixed in 7.52.0 - December 21 2016)
  BGF CONNECT: reject TE or CL in 2xx responses
  BGF <a href="https://curl.se/bug/?i=1132">CONNECT: read responses one byte at a time</a>
  BGF <a href="https://curl.se/bug/?i=1152">curl: support zero-length argument strings in config files</a>
- BGF <a href="https://curl.se/bug/?i=1157">openssl: don&apos;t use OpenSSL&apos;s ERR_PACK</a>
+ BGF <a href="https://curl.se/bug/?i=1157">openssl: don&#39;t use OpenSSL&#39;s ERR_PACK</a>
  BGF <a href="https://github.com/curl/curl/blob/master/docs/cmdline-opts/MANPAGE.md">curl.1: generated with the new man page system</a>
  BGF <a href="https://curl.se/bug/?i=1134">curl_easy_recv: Improve documentation and example program</a>
  BGF <a href="https://curl.se/bug/?i=1134">Curl_getconnectinfo: avoid checking if the connection is closed</a>
@@ -3290,7 +3290,7 @@ SUBTITLE(Fixed in 7.51.0 - November 2 2016)
  BGF <a href="https://curl.se/docs/CVE-2016-8621.html">CVE-2016-8621: curl_getdate read out of bounds</a>
  BGF <a href="https://curl.se/docs/CVE-2016-8622.html">CVE-2016-8622: URL unescape heap overflow via integer truncation</a>
  BGF <a href="https://curl.se/docs/CVE-2016-8623.html">CVE-2016-8623: Use-after-free via shared cookies</a>
- BGF <a href="https://curl.se/docs/CVE-2016-8624.html">CVE-2016-8624: invalid URL parsing with &apos;#&apos;</a>
+ BGF <a href="https://curl.se/docs/CVE-2016-8624.html">CVE-2016-8624: invalid URL parsing with &#39;#&#39;</a>
  BGF <a href="https://curl.se/docs/CVE-2016-8625.html">CVE-2016-8625: IDNA 2003 makes curl use wrong host</a>
  BGF <a href="https://curl.se/bug/?i=964">openssl: fix per-thread memory leak using 1.0.1 or 1.0.2</a>
  BGF <a href="https://curl.se/bug/?i=1013">http: accept "Transfer-Encoding: chunked" for HTTP/2 as well</a>
@@ -3302,7 +3302,7 @@ SUBTITLE(Fixed in 7.51.0 - November 2 2016)
  BGF <a href="https://curl.se/mail/lib-2016-09/0045.html">openssl: don’t call CRYTPO_cleanup_all_ex_data</a>
  BGF <a href="https://curl.se/bug/?i=1029">libressl: fix version output</a>
  BGF <a href="https://curl.se/bug/?i=1017">easy: Reset all statistical session info in curl_easy_reset</a>
- BGF <a href="https://curl.se/bug/?i=997">curl_global_cleanup.3: don&apos;t unload the lib with sub threads running</a>
+ BGF <a href="https://curl.se/bug/?i=997">curl_global_cleanup.3: don&#39;t unload the lib with sub threads running</a>
  BGF dist: add CurlSymbolHiding.cmake to the tarball
  BGF <a href="https://curl.se/bug/?i=1031">docs: Remove that --proto is just used for initial retrieval</a>
  BGF configure: Fixed builds with libssh2 in a custom location
@@ -3340,7 +3340,7 @@ SUBTITLE(Fixed in 7.51.0 - November 2 2016)
  BGF <a href="https://curl.se/bug/?i=1087">mbedtls: stop using deprecated include file</a>
  BGF <a href="https://curl.se/bug/?i=1088">docs: fix req->data in multi-uv example</a>
  BGF configure: Fix test syntax for monotonic clock_gettime
- BGF <a href="https://curl.se/bug/?i=1059">CURLMOPT_MAX_PIPELINE_LENGTH.3: Clarify it&apos;s not for HTTP/2</a>
+ BGF <a href="https://curl.se/bug/?i=1059">CURLMOPT_MAX_PIPELINE_LENGTH.3: Clarify it&#39;s not for HTTP/2</a>
 </ul>
     
 <a name="7_50_3"></a>
@@ -3356,7 +3356,7 @@ SUBTITLE(Fixed in 7.50.3 - September 14 2016)
  BGF <a href="https://curl.se/bug/?i=981">CMake: hide private library symbols</a>
  BGF <a href="https://curl.se/bug/?i=973">http: refuse to pass on response body when NO_NODY is set</a>
  BGF <a href="https://curl.se/bug/?i=841">cmake: fix curl-config --static-libs</a>
- BGF <a href="https://curl.se/bug/?i=1004">mbedtls: switch off NTLM in build if md4 isn&apos;t available</a>
+ BGF <a href="https://curl.se/bug/?i=1004">mbedtls: switch off NTLM in build if md4 isn&#39;t available</a>
  BGF <a href="https://curl.se/bug/?i=1007">curl: --create-dirs on windows groks both forward and backward slashes</a>
 </ul>
     
@@ -3392,7 +3392,7 @@ SUBTITLE(Fixed in 7.50.2 - September 7 2016)
  BGF SOCKS: improve verbose output of SOCKS5 connection sequence
  BGF SOCKS: display the hostname returned by the SOCKS5 proxy server
  BGF http/sasl: Query authentication mechanism supported by SSPI before using
- BGF <a href="https://curl.se/bug/?i=718">sasl: Don&apos;t use GSSAPI authentication when domain name not specified</a>
+ BGF <a href="https://curl.se/bug/?i=718">sasl: Don&#39;t use GSSAPI authentication when domain name not specified</a>
  BGF <a href="https://curl.se/bug/?i=820">win: Basic support for Universal Windows Platform apps</a>
  BGF nss: fix incorrect use of a previously loaded certificate from file
  BGF <a href="https://bugzilla.mozilla.org/1297397">nss: work around race condition in PK11_FindSlotByName()</a>
@@ -3400,9 +3400,9 @@ SUBTITLE(Fixed in 7.50.2 - September 7 2016)
  BGF openssl: build warning-free with 1.1.0 (again)
  BGF <a href="https://curl.se/bug/?i=899">HTTP: stop parsing headers when switching to unknown protocols</a>
  BGF test219: Add http as a required feature
- BGF TLS: random file/egd doesn&apos;t have to match for conn reuse
+ BGF TLS: random file/egd doesn&#39;t have to match for conn reuse
  BGF <a href="https://curl.se/bug/?i=983">schannel: Disable ALPN for Wine since it is causing problems</a>
- BGF <a href="https://curl.se/bug/?i=941">http2: make sure stream errors don&apos;t needlessly close the connection</a>
+ BGF <a href="https://curl.se/bug/?i=941">http2: make sure stream errors don&#39;t needlessly close the connection</a>
  BGF <a href="https://curl.se/bug/?i=986">http2: return CURLE_HTTP2_STREAM for unexpected stream close</a>
  BGF darwinssl: --cainfo is intended for backward compatibility only
  BGF <a href="https://curl.se/bug/?i=971">speed caps: not based on average speeds anymore</a>
@@ -3453,7 +3453,7 @@ SUBTITLE(Fixed in 7.50.0 - July 21 2016)
  BGF <a href="https://curl.se/bug/?i=815">vtls: fix ssl session cache race condition</a>
  BGF <a href="https://curl.se/bug/?i=855">http: Fix HTTP/2 connection reuse [regression]</a>
  BGF checksrc: Add LoadLibrary to the banned functions list
- BGF <a href="https://curl.se/bug/?i=840">schannel: Disable ALPN on Windows < 8.1</a>
+ BGF <a href="https://curl.se/bug/?i=840">schannel: Disable ALPN on Windows &lt; 8.1</a>
  BGF configure: occasional ignorance of --enable-symbol-hiding with GCC
  BGF http2: test17xx are the first real HTTP/2 tests
  BGF <a href="https://curl.se/bug/?i=863">resolve: add support for IPv6 DNS64/NAT64 Networks on OS X + iOS</a>
@@ -3462,14 +3462,14 @@ SUBTITLE(Fixed in 7.50.0 - July 21 2016)
  BGF <a href="https://curl.se/bug/?i=874">cmake: Fix build with winldap</a>
  BGF <a href="https://curl.se/bug/?i=875">openssl: fix cert check with non-DNS name fields present</a>
  BGF <a href="https://curl.se/bug/?i=883">curl.1: mention the units for the progress meter</a>
- BGF openssl: use more &apos;const&apos; to fix build warnings with 1.1.0 branch
+ BGF openssl: use more &#39;const&#39; to fix build warnings with 1.1.0 branch
  BGF <a href="https://curl.se/bug/?i=882">cmake: now using BUILD_TESTING=ON/OFF</a>
  BGF vtls: Only call add/getsession if session id is enabled
  BGF <a href="https://curl.se/mail/lib-2016-06/0100.html">headers: forward declare CURL, CURLM and CURLSH as structs</a>
  BGF <a href="https://curl.se/bug/?i=894">configure: improve detection of CA bundle path on FreeBSD</a>
  BGF <a href="https://curl.se/mail/lib-2016-06/0052.html">SFTP: set a generic error when no SFTP one exists</a>
  BGF <a href="https://curl.se/mail/lib-2016-06/0136.html">curl_global_init.3: expand on the SSL and WIN32 bits purpose</a>
- BGF <a href="https://curl.se/mail/lib-2016-06/0139.html">conn: don&apos;t free easy handle data in handler->disconnect</a>
+ BGF <a href="https://curl.se/mail/lib-2016-06/0139.html">conn: don&#39;t free easy handle data in handler->disconnect</a>
  BGF <a href="https://curl.se/bug/?i=911">cookie.c: Fix misleading indentation</a>
  BGF <a href="https://curl.se/bug/?i=913">library: Fix memory leaks found during static analysis</a>
  BGF <a href="https://curl.se/bug/?i=914">CURLMOPT_SOCKETFUNCTION.3: fix typo</a>
@@ -3526,7 +3526,7 @@ SUBTITLE(Fixed in 7.49.0 - May 18 2016)
  BGF <a href="https://twitter.com/xtraemeat/status/712564874098917376">openssl: fix ERR_remove_thread_state() for boringssl/libressl</a>
  BGF openssl: boringssl provides the same numbering as openssl
  BGF <a href="https://curl.se/bug/?i=619">multi: fix "Operation timed out after" timer</a>
- BGF <a href="https://curl.se/bug/?i=731">url: don&apos;t use bad offset in tld_check_name to show error</a>
+ BGF <a href="https://curl.se/bug/?i=731">url: don&#39;t use bad offset in tld_check_name to show error</a>
  BGF sshserver.pl: use quotes for given options
  BGF <a href="https://curl.se/bug/?i=620">Makefile.am: skip the scripts dir</a>
  BGF <a href="https://curl.se/bug/?i=492">curl: warn for --capath use if not supported by libcurl</a>
@@ -3536,8 +3536,8 @@ SUBTITLE(Fixed in 7.49.0 - May 18 2016)
  BGF <a href="https://github.com/wolfSSL/wolfssl/issues/366">wolfssl: Use ECC supported curves extension</a>
  BGF openssl: Fix compilation warnings
  BGF Curl_add_buffer_send: avoid possible NULL dereference
- BGF SOCKS5_gssapi_negotiate: don&apos;t assume little-endian ints
- BGF <a href="https://curl.se/bug/?i=744">strerror: don&apos;t bit shift a signed integer</a>
+ BGF SOCKS5_gssapi_negotiate: don&#39;t assume little-endian ints
+ BGF <a href="https://curl.se/bug/?i=744">strerror: don&#39;t bit shift a signed integer</a>
  BGF url: Corrected get protocol family for FTP and LDAP
  BGF curl/mprintf.h: remove support for _MPRINTF_REPLACE
  BGF <a href="https://curl.se/bug/?i=741">upload: missing rewind call could make libcurl hang</a>
@@ -3577,7 +3577,7 @@ SUBTITLE(Fixed in 7.49.0 - May 18 2016)
  BGF PolarSSL: implement public key pinning
  BGF <a href="https://curl.se/mail/lib-2016-04/0084.html">multi: accidentally used resolved host name instead of proxy</a>
  BGF CURLINFO_TLS_SESSION.3: clarify TLS library support before 7.48.0
- BGF <a href="https://curl.se/bug/?i=655">CONNECT_ONLY: don&apos;t close connection on GSS 401/407 responses</a>
+ BGF <a href="https://curl.se/bug/?i=655">CONNECT_ONLY: don&#39;t close connection on GSS 401/407 responses</a>
  BGF <a href="https://curl.se/bug/?i=779">opts: Fix some syntax errors in example code fragments</a>
  BGF <a href="https://curl.se/mail/lib-2016-04/0095.html">mbedtls: Fix session resume</a>
  BGF test1139: verifies libcurl option man page presence
@@ -3637,8 +3637,8 @@ SUBTITLE(Fixed in 7.48.0 - March 23 2016)
  BGF <a href="https://curl.se/bug/?i=653">CURLOPT_CONNECTTIMEOUT_MS.3: Fix example to use milliseconds option</a>
  BGF <a href="https://curl.se/bug/?i=658">cookie: do not refuse cookies to localhost</a>
  BGF <a href="https://curl.se/bug/?i=650">openssl: avoid direct PKEY access with OpenSSL 1.1.0</a>
- BGF <a href="https://curl.se/bug/?i=659">http: Don&apos;t break the header into chunks if HTTP/2</a>
- BGF <a href="https://curl.se/bug/?i=661">http2: don&apos;t decompress gzip decoding automatically</a>
+ BGF <a href="https://curl.se/bug/?i=659">http: Don&#39;t break the header into chunks if HTTP/2</a>
+ BGF <a href="https://curl.se/bug/?i=661">http2: don&#39;t decompress gzip decoding automatically</a>
  BGF curlx.c: i2s_ASN1_IA5STRING() clashes with an openssl function
  BGF curl.1: add a missing dash
  BGF <a href="https://curl.se/bug/?i=666">curl.1: HTTP headers for --cookie must be Set-Cookie style</a>
@@ -3657,7 +3657,7 @@ SUBTITLE(Fixed in 7.48.0 - March 23 2016)
  BGF <a href="https://curl.se/bug/?i=689">makefile.m32: allow to pass .dll/.exe-specific LDFLAGS</a>
  BGF <a href="https://curl.se/bug/?i=690">url: if Curl_done is premature then pipeline not in use</a>
  BGF <a href="https://curl.se/bug/?i=695">cookie: remove redundant check</a>
- BGF <a href="https://curl.se/bug/?i=697">cookie: Don&apos;t expire session cookies in remove_expired</a>
+ BGF <a href="https://curl.se/bug/?i=697">cookie: Don&#39;t expire session cookies in remove_expired</a>
  BGF <a href="https://curl.se/bug/?i=692">makefile.m32: fix to allow -ssh2-winssl combination</a>
  BGF checksrc.bat: Fixed cannot find perl if installed but not in path
  BGF build-openssl.bat: Fixed cannot find perl if installed but not in path
@@ -3669,7 +3669,7 @@ SUBTITLE(Fixed in 7.48.0 - March 23 2016)
  BGF <a href="https://curl.se/bug/?i=701">ftp_done: clear tunnel_state when secondary socket closes</a>
  BGF <a href="https://curl.se/bug/?i=705">opt-docs: fix heading macros</a>
  BGF <a href="https://curl.se/bug/?i=422">imap/pop3/smtp: Fixed connections upgraded with TLS are not reused</a>
- BGF <a href="https://curl.se/bug/?i=707">curl_multi_wait: never return -1 in &apos;numfds&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=707">curl_multi_wait: never return -1 in &#39;numfds&#39;</a>
  BGF url.c: fix clang warning: no newline at end of file
  BGF krb5: improved type handling to avoid clang compiler warnings
  BGF <a href="https://curl.se/bug/?i=709">cookies: first n/v pair in Set-Cookie: is the cookie, then parameters</a>
@@ -3702,7 +3702,7 @@ SUBTITLE(Fixed in 7.47.1 - February 8 2016)
  BGF <a href="https://github.com/curl/curl/pull/616">tool_doswin: silence unused function warning</a>
  BGF <a href="https://curl.se/bug/?i=617">cmake: fixed when OpenSSL enabled on Windows and schannel detected</a>
  BGF curl.1: Explain remote-name behavior if file already exists
- BGF <a href="https://curl.se/bug/?i=624">tool_operate: Don&apos;t sanitize --output path (Windows)</a>
+ BGF <a href="https://curl.se/bug/?i=624">tool_operate: Don&#39;t sanitize --output path (Windows)</a>
  BGF URLs: change all http:// URLs to https:// in documentation & comments
  BGF <a href="https://github.com/curl/curl/issues/635">sasl_sspi: Fix memory leak in domain populate</a>
  BGF COPYING: clarify that Daniel is not the sole author
@@ -3728,10 +3728,10 @@ SUBTITLE(Fixed in 7.47.0 - January 27 2016)
  BGF <a href="https://curl.se/docs/CVE-2016-0754.html">curl: avoid local drive traversal when saving file on Windows</a>
  BGF <a href="https://curl.se/docs/CVE-2016-0755.html">NTLM: do not resuse proxy connections without diff proxy credentials</a>
  BGF <a href="https://curl.se/mail/lib-2015-12/0003.html">tests: Disable the OAUTHBEARER tests when using a non-default port number</a>
- BGF curl: remove keepalive #ifdef checks done on libcurl&apos;s behalf
+ BGF curl: remove keepalive #ifdef checks done on libcurl&#39;s behalf
  BGF <a href="https://github.com/curl/curl/issues/425#issuecomment-154518679">formdata: Check if length is too large for memory</a>
  BGF <a href="https://curl.se/mail/lib-2015-12/0023.html">lwip: Fix compatibility issues with later versions</a>
- BGF openssl: BoringSSL doesn&apos;t have CONF_modules_free
+ BGF openssl: BoringSSL doesn&#39;t have CONF_modules_free
  BGF config-win32: Fix warning HAVE_WINSOCK2_H undefined
  BGF <a href="https://curl.se/bug/?i=558">build: fix compilation error with CURL_DISABLE_VERBOSE_STRINGS</a>
  BGF <a href="https://curl.se/mail/lib-2015-11/0103.html">http2: Fix hanging paused stream</a>
@@ -3773,7 +3773,7 @@ SUBTITLE(Fixed in 7.47.0 - January 27 2016)
  BGF <a href="https://curl.se/bug/?i=596">IDN host names: Remove the port number before converting to ACE</a>
  BGF zsh.pl: fail if no curl is found
  BGF scripts: fix zsh completion generation
- BGF <a href="https://curl.se/bug/?i=582">scripts: don&apos;t generate and install zsh completion when cross-compiling</a>
+ BGF <a href="https://curl.se/bug/?i=582">scripts: don&#39;t generate and install zsh completion when cross-compiling</a>
  BGF <a href="https://curl.se/bug/?i=597">lib: Prefix URLs with lower-case protocol names/schemes</a>
  BGF <a href="https://curl.se/bug/?i=584">ConnectionExists: only do pipelining/multiplexing when asked</a>
  BGF <a href="https://curl.se/bug/?i=594">configure: assume IPv6 works when cross-compiled</a>
@@ -3811,7 +3811,7 @@ SUBTITLE(Fixed in 7.46.0 - December 2 2015)
  BGF test1531: case the size to fix the test on non-largefile builds
  BGF <a href="https://curl.se/bug/?i=346">fread_func: move callback pointer from set to state struct</a>
  BGF test1601: fix compilation with --enable-debug and --disable-crypto-auth
- BGF <a href="https://curl.se/bug/?i=493">http2: Don&apos;t pass uninitialized name+len pairs to nghttp2_submit_request</a>
+ BGF <a href="https://curl.se/bug/?i=493">http2: Don&#39;t pass uninitialized name+len pairs to nghttp2_submit_request</a>
  BGF curlbuild.h: Fix non-configure compiling to mips and sh4 targets
  BGF <a href="https://curl.se/bug/?i=452">tool: Generate easysrc with last cache linked-list</a>
  BGF cmake: Fix for add_subdirectory(curl) use-case
@@ -3833,9 +3833,9 @@ SUBTITLE(Fixed in 7.46.0 - December 2 2015)
  BGF curl_ntlm_core: fix 2 curl_off_t constant overflows.
  BGF getinfo: CURLINFO_ACTIVESOCKET: fix bad socket value
  BGF tftp tests: verify sent options too
- BGF imap: Don&apos;t call imap_atom() when no mailbox specified in LIST command
+ BGF imap: Don&#39;t call imap_atom() when no mailbox specified in LIST command
  BGF imap: Fixed double quote in LIST command when mailbox contains spaces
- BGF <a href="https://curl.se/bug/?i=486">imap: Don&apos;t check for continuation when executing a CUSTOMREQUEST</a>
+ BGF <a href="https://curl.se/bug/?i=486">imap: Don&#39;t check for continuation when executing a CUSTOMREQUEST</a>
  BGF acinclude: Remove check for 16-bit curl_off_t
  BGF <a href="https://curl.se/bug/?i=524">BoringSSL: Work with stricter BIO_get_mem_data()</a>
  BGF <a href="https://curl.se/bug/?i=523">cmake: Add missing feature macros in config header</a>
@@ -3844,19 +3844,19 @@ SUBTITLE(Fixed in 7.46.0 - December 2 2015)
  BGF unit1602: Fixed failure in torture test
  BGF unit1603: Added unit tests for hash functions
  BGF vtls/openssl: remove unused traces of yassl ifdefs
- BGF openssl: remove #ifdefs for < 0.9.7 support
+ BGF openssl: remove #ifdefs for &lt; 0.9.7 support
  BGF typecheck-gcc.h: add some missing options
  BGF curl: mark two more options strings for --libcurl output
  BGF <a href="https://curl.se/bug/?i=526">openssl: Free modules on cleanup</a>
  BGF CURLMOPT_PUSHFUNCTION.3: *_byname() returns only the first header
- BGF getconnectinfo: Don&apos;t call recv(2) if socket == -1
- BGF http2: http_done: don&apos;t free already-freed push headers
+ BGF getconnectinfo: Don&#39;t call recv(2) if socket == -1
+ BGF http2: http_done: don&#39;t free already-freed push headers
  BGF <a href="https://curl.se/bug/?i=532">zsh completion: Preserve single quotes in output</a>
  BGF os400: Provide options for libssh2 use in compile scripts.
  BGF <a href="https://curl.se/bug/?i=535">build: Fix theoretical infinite loops</a>
  BGF pop3: Differentiate between success and continuation responses
  BGF examples: Fixed compilation warnings
- BGF schannel: Use GetVersionEx() when VerifyVersionInfo() isn&apos;t available
+ BGF schannel: Use GetVersionEx() when VerifyVersionInfo() isn&#39;t available
  BGF CURLOPT_HEADERFUNCTION.3: fix typo
  BGF curl: expanded the -XHEAD warning text
  BGF <a href="https://curl.se/bug/?i=538">done: make sure the final progress update is made</a>
@@ -3901,20 +3901,20 @@ SUBTITLE(Fixed in 7.45.0 - October 7 2015)
  BGF <a href="https://android.googlesource.com/platform/external/curl/+/f551028d5caab">configure: change functions to detect openssl (clones)</a>
  BGF <a href="https://android.googlesource.com/platform/external/curl/+/f551028d5caab">configure: detect latest boringssl</a>
  BGF runtests: Allow for spaces in server-verify curl custom path
- BGF http2: on_frame_recv: get a proper &apos;conn&apos; for the debug logging
+ BGF http2: on_frame_recv: get a proper &#39;conn&#39; for the debug logging
  BGF ntlm: mark deliberate switch case fall-through
  BGF http2: remove dead code
  BGF <a href="https://curl.se/bug/?i=395">curl_easy_{escape,unescape}.3: "char *" vs. "const char *"</a>
  BGF curl: point out the conflicting HTTP methods if used
  BGF <a href="https://curl.se/bug/?i=399">cmake: added Windows SSL support</a>
  BGF curl_easy_{escape,setopt}.3: fix example
- BGF <a href="https://curl.se/bug/?i=398">curl_easy_escape.3: escape &apos;\n&apos;</a>
+ BGF <a href="https://curl.se/bug/?i=398">curl_easy_escape.3: escape &#39;\n&#39;</a>
  BGF <a href="https://curl.se/bug/?i=402">libcurl.m4: Put braces around empty if body</a>
- BGF buildconf.bat: Fixed double blank line in &apos;curl manual&apos; warning output
+ BGF buildconf.bat: Fixed double blank line in &#39;curl manual&#39; warning output
  BGF sasl: Only define Curl_sasl_digest_get_pair() when CRYPTO_AUTH enabled
  BGF inet_pton.c: Fix MSVC run-time check failure
  BGF CURLOPT_FOLLOWLOCATION.3: mention methods for redirects
- BGF <a href="https://curl.se/bug/?i=401">http2: don&apos;t pass on Connection: headers</a>
+ BGF <a href="https://curl.se/bug/?i=401">http2: don&#39;t pass on Connection: headers</a>
  BGF <a href="https://lists.fedoraproject.org/pipermail/devel/2015-September/214117.html">nss: do not directly access SSL_ImplementedCiphers</a>
  BGF docs: numerous cleanups and spelling fixes
  BGF <a href="https://curl.se/bug/?i=405">FTP: do_more: add check for wait_data_conn in upload case</a>
@@ -3925,10 +3925,10 @@ SUBTITLE(Fixed in 7.45.0 - October 7 2015)
  BGF <a href="https://curl.se/bug/?i=411">curl_sspi: fix possibly undefined CRYPT_E_REVOKED</a>
  BGF <a href="https://bugzilla.mozilla.org/1202264">nss: prevent NSS from incorrectly re-using a session</a>
  BGF libcurl-errors.3: add two missing error codes
- BGF openssl: fix build with < 0.9.8
+ BGF openssl: fix build with &lt; 0.9.8
  BGF <a href="https://curl.se/bug/?i=427">openssl: refactor certificate parsing to use OpenSSL memory BIO</a>
  BGF <a href="https://curl.se/bug/?i=440">openldap: only part of LDAP query results received</a>
- BGF <a href="https://curl.se/bug/?i=410">ssl: add server cert&apos;s "sha256//" hash to verbose</a>
+ BGF <a href="https://curl.se/bug/?i=410">ssl: add server cert&#39;s "sha256//" hash to verbose</a>
  BGF <a href="https://curl.se/bug/?i=435">NTLM: Reset auth-done when using a fresh connection</a>
  BGF <a href="https://curl.se/bug/?i=429">curl: generate easysrc only on --libcurl</a>
  BGF <a href="https://curl.se/bug/?i=380">tests: disable 1801 until fixed</a>
@@ -3938,17 +3938,17 @@ SUBTITLE(Fixed in 7.45.0 - October 7 2015)
  BGF tests: disable 1510 due to CI-problems on github
  BGF cmake: Put "winsock2.h" before "windows.h" during configure checks
  BGF cmake: Ensure discovered include dirs are considered
- BGF <a href="https://curl.se/bug/?i=456">configure: Add missing &apos;)&apos; for CURL_CHECK_OPTION_RT</a>
+ BGF <a href="https://curl.se/bug/?i=456">configure: Add missing &#39;)&#39; for CURL_CHECK_OPTION_RT</a>
  BGF <a href="https://curl.se/bug/?i=457">build: fix failures with -Wcast-align and -Werror</a>
  BGF FTP: fix uploading ASCII with unknown size
  BGF readwrite_data: set a max number of loops
  BGF http2: avoid superfluous Curl_expire() calls
  BGF <a href="https://curl.se/mail/lib-2015-09/0097.html">http2: set TCP_NODELAY unconditionally</a>
- BGF docs: fix unescaped &apos;\n&apos; in man pages
+ BGF docs: fix unescaped &#39;\n&#39; in man pages
  BGF <a href="https://curl.se/bug/?i=447">openssl: Fix algorithm init to make (gost) engines work</a>
  BGF win32: make recent Borland compilers use long long
  BGF runtests: Fix pid check in checkdied
- BGF <a href="https://curl.se/bug/?i=466">gopher: don&apos;t send NUL byte</a>
+ BGF <a href="https://curl.se/bug/?i=466">gopher: don&#39;t send NUL byte</a>
  BGF <a href="https://curl.se/bug/?i=469">tool_setopt: fix c_escape truncated octal</a>
  BGF <a href="https://curl.se/bug/?i=471">hiperfifo: fix the pointer passed to WRITEDATA</a>
  BGF <a href="https://curl.se/bug/?i=468">getinfo: Fix return code for unknown CURLINFO options</a>
@@ -3971,16 +3971,16 @@ SUBTITLE(Fixed in 7.44.0 - August 12 2015)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF <a href="https://github.com/curl/curl/issues/278">FTP: fix HTTP CONNECT logic regression</a>
- BGF openssl: Fix build with openssl < ~ 0.9.8f
+ BGF openssl: Fix build with openssl &lt; ~ 0.9.8f
  BGF openssl: fix build with BoringSSL
- BGF curl_easy_setopt.3: option order doesn&apos;t matter
+ BGF curl_easy_setopt.3: option order doesn&#39;t matter
  BGF <a href="https://github.com/curl/curl/issues/318">openssl: fix use of uninitialized buffer</a>
  BGF RTSP: removed dead code
  BGF Makefile.m32: add support for CURL_LDFLAG_EXTRAS
  BGF curl: always provide negotiate/kerberos options
  BGF cookie: Fix bug in export if any-domain cookie is present
  BGF curl_easy_setopt.3: mention CURLOPT_PIPEWAIT
- BGF INSTALL: Advise use of non-native SSL for Windows <= XP
+ BGF INSTALL: Advise use of non-native SSL for Windows &lt;= XP
  BGF tool_help: fix --tlsv1 help text to use >= for TLSv1
  BGF <a href="https://curl.se/mail/lib-2015-06/0122.html">HTTP: POSTFIELDSIZE set after added to multi handle</a>
  BGF SSL-PROBLEMS: mention WinSSL problems in WinXP
@@ -4006,7 +4006,7 @@ SUBTITLE(Fixed in 7.44.0 - August 12 2015)
  BGF <a href="https://curl.se/mail/lib-2015-07/0149.html">libcurl-thread.3: Warn memory functions must be thread safe</a>
  BGF <a href="https://curl.se/mail/lib-2015-07/0149.html">curl_global_init_mem.3: Warn threaded resolver needs thread safe funcs</a>
  BGF <a href="https://curl.se/bug/?i=360">docs: formpost needs the full size at start of upload</a>
- BGF curl_gssapi: remove &apos;const&apos; to fix compiler warnings
+ BGF curl_gssapi: remove &#39;const&#39; to fix compiler warnings
  BGF <a href="https://curl.se/bug/?i=357">SSH: three state machine fixups</a>
  BGF <a href="https://github.com/curl/curl/issues/361">libcurl.3: fix a single typo</a>
  BGF generate.bat: Only clean prerequisite files when in ALL mode
@@ -4015,7 +4015,7 @@ SUBTITLE(Fixed in 7.44.0 - August 12 2015)
  BGF generate.bat: Use buildconf.bat for prerequisite file clean-up
  BGF <a href="https://github.com/curl/curl/issues/363">NTLM: handle auth for only a single request</a>
  BGF <a href="https://github.com/curl/curl/issues/366">curl_multi_remove_handle.3: fix formatting</a>
- BGF checksrc.bat: Fixed error when [directory] isn&apos;t a curl source directory
+ BGF checksrc.bat: Fixed error when [directory] isn&#39;t a curl source directory
  BGF checksrc.bat: Fixed error when missing *.c and *.h files
  BGF <a href="https://curl.se/mail/lib-2015-08/0019.html">CURLOPT_RESOLVE.3: Note removal support was added in 7.42</a>
  BGF test46: update cookie expire time
@@ -4048,12 +4048,12 @@ SUBTITLE(Fixed in 7.43.0 - June 17 2015)
  BGF <a href="https://curl.se/docs/CVE-2015-3236.html">CVE-2015-3236: lingering HTTP credentials in connection re-use</a>
  BGF <a href="https://curl.se/docs/CVE-2015-3237.html">CVE-2015-3237: SMB send off unrelated memory contents</a>
  BGF <a href="https://curl.se/mail/lib-2015-04/0095.html">nss: fix compilation failure with old versions of NSS</a>
- BGF curl_easy_getinfo.3: document &apos;internals&apos; in CURLINFO_TLS_SESSION
+ BGF curl_easy_getinfo.3: document &#39;internals&#39; in CURLINFO_TLS_SESSION
  BGF schannel.c: Fix possible SEC_E_BUFFER_TOO_SMALL error
  BGF <a href="https://github.com/curl/curl/pull/206">Curl_ossl_init: load builtin modules</a>
  BGF <a href="https://github.com/curl/curl/commit/5b668606527613179d0349f21b4ab0df2971e3d2#commitcomment-10473445">configure: follow-up fix for krb5-config</a>
  BGF <a href="https://github.com/curl/curl/pull/141">sasl_sspi: Populate domain from the realm in the challenge</a>
- BGF netrc: support &apos;default&apos; token
+ BGF netrc: support &#39;default&#39; token
  BGF README: convert to UTF-8
  BGF cyassl: Implement public key pinning
  BGF nss: implement public key pinning for NSS backend
@@ -4070,12 +4070,12 @@ SUBTITLE(Fixed in 7.43.0 - June 17 2015)
  BGF FTP: Make EPSV use the control IP address rather than the original host
  BGF FTP: fix dangling conn->ip_addr dereference on verbose EPSV
  BGF conncache: keep bundles on host+port bases, not only host names
- BGF runtests.pl: use &apos;h2c&apos; now, no -14 anymore
+ BGF runtests.pl: use &#39;h2c&#39; now, no -14 anymore
  BGF curlver: introducing new version number (checking) macros
  BGF <a href="https://github.com/curl/curl/issues/275">openssl: boringssl build brekage, use SSL_CTX_set_msg_callback</a>
  BGF <a href="https://github.com/curl/curl/issues/281">CURLOPT_POSTFIELDS.3: correct variable names</a>
  BGF <a href="https://github.com/curl/curl/issues/282">curl_easy_unescape.3: update RFC reference</a>
- BGF gnutls: don&apos;t fail on non-fatal alerts during handshake
+ BGF gnutls: don&#39;t fail on non-fatal alerts during handshake
  BGF testcurl.pl: allow source to be in an arbitrary directory
  BGF CURLOPT_HTTPPROXYTUNNEL.3: only works with a HTTP proxy
  BGF <a href="https://github.com/curl/curl/issues/267">SSPI-error: Change SEC_E_ILLEGAL_MESSAGE description</a>
@@ -4083,7 +4083,7 @@ SUBTITLE(Fixed in 7.43.0 - June 17 2015)
  BGF share_init: fix OOM crash
  BGF perl: remove subdir, not touched in 9 years
  BGF CURLOPT_COOKIELIST.3: Add example
- BGF <a href="https://curl.se/mail/lib-2015-05/0115.html">CURLOPT_COOKIE.3: Explain that the cookies won&apos;t be modified</a>
+ BGF <a href="https://curl.se/mail/lib-2015-05/0115.html">CURLOPT_COOKIE.3: Explain that the cookies won&#39;t be modified</a>
  BGF <a href="https://curl.se/mail/lib-2015-05/0137.html">CURLOPT_COOKIELIST.3: Explain Set-Cookie without a domain</a>
  BGF FAQ: How do I port libcurl to my OS?
  BGF openssl: Use TLS_client_method for OpenSSL 1.1.0+
@@ -4122,7 +4122,7 @@ SUBTITLE(Fixed in 7.42.1 - April 29 2015)
  BGF docs: distribute the <a href="/libcurl/c/CURLOPT_PINNEDPUBLICKEY.html">CURLOPT_PINNEDPUBLICKEY</a> man page, too
  BGF <a href="https://github.com/curl/curl/issues/237">curl -z: do not write empty file on unmet condition</a>
  BGF <a href="https://github.com/curl/curl/issues/235">openssl: fix serial number output</a>
- BGF <a href="https://curl.se/libcurl/c/curl_easy_getinfo.html">curl_easy_getinfo.3</a>: document &apos;internals&apos; in CURLINFO_TLS_SESSION
+ BGF <a href="https://curl.se/libcurl/c/curl_easy_getinfo.html">curl_easy_getinfo.3</a>: document &#39;internals&#39; in CURLINFO_TLS_SESSION
  BGF sws: init http2 state properly
  BGF curl.1: fix typo
 </ul>
@@ -4169,14 +4169,14 @@ SUBTITLE(Fixed in 7.42.0 - April 22 2015)
  BGF http2: use CURL_HTTP_VERSION_* symbols instead of NPN_*
  BGF conncontrol: only log changes to the connection bit
  BGF <a href="https://curl.se/mail/lib-2015-01/0170.html">multi: fix *getsock() with CONNECT</a>
- BGF <a href="https://curl.se/mail/lib-2015-03/0052.html">symbols.pl: handle &apos;-&apos; in the deprecated field</a>
+ BGF <a href="https://curl.se/mail/lib-2015-03/0052.html">symbols.pl: handle &#39;-&#39; in the deprecated field</a>
  BGF <a href="https://curl.se/bug/?i=157">MacOSX-Framework: use @rpath instead of @executable_path</a>
  BGF GnuTLS: add support for CURLOPT_CAPATH
  BGF GnuTLS: print negotiated TLS version and full cipher suite name
- BGF GnuTLS: don&apos;t print double newline after certificate dates
+ BGF GnuTLS: don&#39;t print double newline after certificate dates
  BGF memanalyze.pl: handle free(NULL)
  BGF <a href="https://curl.se/bug/view.cgi?id=1492">proxy: re-use proxy connections (regression)</a>
- BGF mk-ca-bundle: Don&apos;t report SHA1 numbers with "-q"
+ BGF mk-ca-bundle: Don&#39;t report SHA1 numbers with "-q"
  BGF <a href="https://curl.se/bug/view.cgi?id=1491">http: always send Host: header as first header</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1487">openssl: sort ciphers to use based on strength</a>
  BGF openssl: use colons properly in the ciphers list
@@ -4186,21 +4186,21 @@ SUBTITLE(Fixed in 7.42.0 - April 22 2015)
  BGF mksymbolsmanpage.pl: use std header and generate better nroff header
  BGF <a href="https://curl.se/bug/?i=168">connect: Fix happy eyeballs logic for IPv4-only builds</a>
  BGF curl_easy_perform.3: remove superfluous close brace from example
- BGF <a href="https://curl.se/bug/?i=169">HTTP: don&apos;t use Expect: headers when on HTTP/2</a>
- BGF Curl_sh_entry: remove unused &apos;timestamp&apos;
+ BGF <a href="https://curl.se/bug/?i=169">HTTP: don&#39;t use Expect: headers when on HTTP/2</a>
+ BGF Curl_sh_entry: remove unused &#39;timestamp&#39;
  BGF docs/libcurl: makefile portability fix
  BGF mkhelp: Remove trailing carriage return from every line of input
  BGF nss: explicitly tell NSS to disable NPN/ALPN when libcurl disables it
  BGF curl_easy_setopt.3: added a few missing options
  BGF metalink: fix resource leak in OOM
  BGF axtls: version 1.5.2 now requires that config.h be manually included
- BGF HTTP: don&apos;t switch to HTTP/2 from 1.1 until we get the 101
+ BGF HTTP: don&#39;t switch to HTTP/2 from 1.1 until we get the 101
  BGF cyassl: detect the library as renamed wolfssl
  BGF <a href="https://curl.se/libcurl/c/CURLOPT_HTTPHEADER.html">CURLOPT_HTTPHEADER</a>.3: add a "SECURITY CONCERNS" section
  BGF <a href="https://curl.se/libcurl/c/CURLOPT_URL.html">CURLOPT_URL</a>.3: Added SECURITY CONCERNS
  BGF openssl: try to avoid accessing OCSP structs when possible
  BGF test938: added missing closing tags
- BGF testcurl: Allow &apos;=&apos; in values given on command line
+ BGF testcurl: Allow &#39;=&#39; in values given on command line
  BGF tests/certs: added make target to rebuild certificates
  BGF tests/certs: rebuild certificates with modified key usage bits
  BGF gtls: avoid uninitialized variable
@@ -4211,7 +4211,7 @@ SUBTITLE(Fixed in 7.42.0 - April 22 2015)
  BGF <a href="https://curl.se/libcurl/c/curl_easy_recv.html">curl_easy_recv</a>/<a href="https://curl.se/libcurl/c/curl_easy_send.html">send</a>: make them work with the multi interface
  BGF vtls: fix compile with --disable-crypto-auth but with SSL
  BGF openssl: adapt to ASN1/X509 things gone opaque in 1.1
- BGF <a href="https://curl.se/mail/lib-2015-03/0205.html">openssl: verifystatus: only use the OCSP work-around <= 1.0.2a</a>
+ BGF <a href="https://curl.se/mail/lib-2015-03/0205.html">openssl: verifystatus: only use the OCSP work-around &lt;= 1.0.2a</a>
  BGF curl_memory: make curl_memory.h the second-last header file loaded
  BGF testcurl.pl: add the --notes option to supply more info about a build
  BGF cyassl: If wolfSSL then identify as such in version string
@@ -4224,8 +4224,8 @@ SUBTITLE(Fixed in 7.42.0 - April 22 2015)
  BGF globbing: fix url number calculation when using range with step
  BGF <a href="https://curl.se/bug/view.cgi?id=1465">multi: on a request completion, check all CONNECT_PEND transfers</a>
  BGF build: link curl to openssl libraries when openssl support is enabled
- BGF url: Don&apos;t accept CURLOPT_SSLVERSION unless USE_SSL is defined
- BGF vtls: Don&apos;t accept unknown CURLOPT_SSLVERSION values
+ BGF url: Don&#39;t accept CURLOPT_SSLVERSION unless USE_SSL is defined
+ BGF vtls: Don&#39;t accept unknown CURLOPT_SSLVERSION values
  BGF build: Fix libcurl.sln erroneous mixed configurations
  BGF cyassl: remove undefined reference to CyaSSL_no_filesystem_verify
  BGF cyassl: add SSL context callback support for CyaSSL
@@ -4243,7 +4243,7 @@ SUBTITLE(Fixed in 7.42.0 - April 22 2015)
  BGF DNS: fix refreshing of obsolete dns cache entries
  BGF <a href="https://curl.se/libcurl/c/CURLOPT_RESOLVE.html">CURLOPT_RESOLVE</a>: actually implement removals
  BGF checksrc.bat: quotes to support an SRC_DIR with spaces
- BGF cyassl: Remove &apos;Connecting to&apos; message from cyassl_connect_step2
+ BGF cyassl: Remove &#39;Connecting to&#39; message from cyassl_connect_step2
  BGF cyassl: Use CYASSL_MAX_ERROR_SZ for error buffer size
  BGF lib/transfer.c: Remove factor of 8 from sleep time calculation
  BGF lib/makefile.m32: add missing libs to build libcurl.dll
@@ -4258,7 +4258,7 @@ SUBTITLE(Fixed in 7.42.0 - April 22 2015)
  BGF configure --with-nss: drop redundant if statement
  BGF <a href="https://curl.se/mail/lib-2015-04/0069.html">cyassl: Fix include order</a>
  BGF <a href="https://curl.se/bug/?i=223">HTTP: fix PUT regression with Negotiate</a>
- BGF <a href="https://curl.se/bug/?i=225">curl_version_info.3: fixed the &apos;protocols&apos; variable type</a>
+ BGF <a href="https://curl.se/bug/?i=225">curl_version_info.3: fixed the &#39;protocols&#39; variable type</a>
 </ul>
 
 <a name="7_41_0"></a>
@@ -4315,15 +4315,15 @@ SUBTITLE(Fixed in 7.41.0 - February 25 2015)
  BGF build: Renamed top level Visual Studio solution files
  BGF build: Removed Visual Studio SuppressStartupBanner directive for VC8+
  BGF libcurl-symbols: first basic shot for autogenerated docs
- BGF Makefile.am: fix &apos;make distcheck&apos;
+ BGF Makefile.am: fix &#39;make distcheck&#39;
  BGF <a href="https://curl.se/bug/view.cgi?id=1476">getpass_r: read from stdin, not stdout!</a>
  BGF getpass: protect include with proper #ifdef
  BGF opts: CURLOPT_CAINFO availability depends on SSL engine
- BGF more cleanup of &apos;CURLcode result&apos; return code
+ BGF more cleanup of &#39;CURLcode result&#39; return code
  BGF MD4: replace implementation
  BGF MD5: replace implementation
  BGF <a href="https://curl.se/mail/lib-2015-02/0034.html">openssl: SSL_SESSION->ssl_version no longer exist</a>
- BGF md5: use axTLS&apos;s own MD5 functions when available
+ BGF md5: use axTLS&#39;s own MD5 functions when available
  BGF schannel: Removed curl_ prefix from source files
  BGF curl.1: add warning when using -H and redirects
  BGF curl.1: clarify that -X is used for all requests
@@ -4387,8 +4387,8 @@ SUBTITLE(Fixed in 7.40.0 - January 8 2015)
  BGF CMake: Restore order-dependent header checks
  BGF CMake: Restore order-dependent library checks
  BGF tool: Removed krb4 from the supported features
- BGF http2: Don&apos;t send Upgrade headers when we already do HTTP/2
- BGF <a href="https://curl.se/mail/lib-2014-11/0221.html">examples: Don&apos;t call select() to sleep on windows</a>
+ BGF http2: Don&#39;t send Upgrade headers when we already do HTTP/2
+ BGF <a href="https://curl.se/mail/lib-2014-11/0221.html">examples: Don&#39;t call select() to sleep on windows</a>
  BGF <a href="https://sourceforge.net/p/curl/feature-requests/82/">win32: Updated some legacy APIs to use the newer extended versions</a>
  BGF easy.c: Fixed compilation warning when no verbose string support
  BGF connect.c: Fixed compilation warning when no verbose string support
@@ -4405,7 +4405,7 @@ SUBTITLE(Fixed in 7.40.0 - January 8 2015)
  BGF cmake: add Kerberos to the supported feature
  BGF CURLOPT_POSTFIELDS.3: mention the COPYPOSTFIELDS option
  BGF http: Disable pipelining for HTTP/2 and upgraded connections
- BGF ntlm: Fixed static&apos;ness of local decode function
+ BGF ntlm: Fixed static&#39;ness of local decode function
  BGF sasl: Reduced the need for two sets of NTLM messaging functions
  BGF multi.c: Fixed compilation warnings when no verbose string support
  BGF <a href="https://curl.se/bug/view.cgi?id=1455">select.c: fix compilation for VxWorks</a>
@@ -4414,9 +4414,9 @@ SUBTITLE(Fixed in 7.40.0 - January 8 2015)
  BGF http.c: Fixed compilation warnings from features being disabled
  BGF <a href="https://curl.se/bug/view.cgi?id=1457">NSS: enable the CAPATH option</a>
  BGF docs: Fix FAILONERROR typos
- BGF HTTP: don&apos;t abort connections with pending Negotiate authentication
+ BGF HTTP: don&#39;t abort connections with pending Negotiate authentication
  BGF HTTP: Free (proxy)userpwd for NTLM/Negotiate after sending a request
- BGF http_perhapsrewind: don&apos;t abort CONNECT requests
+ BGF http_perhapsrewind: don&#39;t abort CONNECT requests
  BGF build: updated dependencies in makefiles
  BGF multi.c: Fixed compilation warning
  BGF ftp.c: Fixed compilation warnings when proxy support disabled
@@ -4469,13 +4469,13 @@ SUBTITLE(Fixed in 7.40.0 - January 8 2015)
  BGF vtls: Use bool for Curl_ssl_getsessionid() return type
  BGF sockfilt.c: Replace 100ms sleep with thread throttle
  BGF sockfilt.c: Reduce the number of individual memory allocations
- BGF vtls: Don&apos;t set cert info count until memory allocation is successful
- BGF nss: Don&apos;t ignore Curl_ssl_init_certinfo() OOM failure
- BGF nss: Don&apos;t ignore Curl_extract_certinfo() OOM failure
+ BGF vtls: Don&#39;t set cert info count until memory allocation is successful
+ BGF nss: Don&#39;t ignore Curl_ssl_init_certinfo() OOM failure
+ BGF nss: Don&#39;t ignore Curl_extract_certinfo() OOM failure
  BGF vtls: Fixed compilation warning and an ignored return code
  BGF sockfilt.c: Fixed compilation warnings
  BGF darwinssl: Fixed compilation warning
- BGF vtls: Use &apos;(void) arg&apos; for unused parameters
+ BGF vtls: Use &#39;(void) arg&#39; for unused parameters
  BGF sepheaders.c: Fixed resource leak on failure
  BGF <a href="https://curl.se/bug/?i=133">lib1900.c: Fixed cppcheck error</a>
  BGF ldap: Fixed Unicode connection details in Win32 initialsation / bind calls
@@ -4503,7 +4503,7 @@ SUBTITLE(Fixed in 7.39.0 - November 5 2014)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF <a href="https://curl.se/docs/CVE-2014-3707.html">curl_easy_duphandle: CURLOPT_COPYPOSTFIELDS read out of bounds</a>
- BGF <a href="https://curl.se/mail/lib-2014-09/0064.html">openssl: build fix for versions < 0.9.8e</a>
+ BGF <a href="https://curl.se/mail/lib-2014-09/0064.html">openssl: build fix for versions &lt; 0.9.8e</a>
  BGF <a href="https://curl.se/mail/lib-2014-09/0075.html">newlines: fix mixed newlines to LF-only</a>
  BGF <a href="https://curl.se/mail/lib-2014-08/0273.html">ntlm: Fixed HTTP proxy authentication when using Windows SSPI</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1422">sasl_sspi: Fixed Unicode build</a>
@@ -4535,7 +4535,7 @@ SUBTITLE(Fixed in 7.39.0 - November 5 2014)
  BGF cmake: use LIBCURL_VERSION from curlver.h
  BGF cmake: generate pkg-config and curl-config
  BGF fixed several superfluous variable assignments identified by cppcheck
- BGF cleanup of &apos;CURLcode result&apos; return code
+ BGF cleanup of &#39;CURLcode result&#39; return code
  BGF pipelining: only output "is not blacklisted" in debug builds
  BGF SSL: Remove SSLv3 from SSL default due to POODLE attack
  BGF gskit.c: remove SSLv3 from SSL default
@@ -4573,7 +4573,7 @@ SUBTITLE(Fixed in 7.38.0 - September 10 2014)
  CHG CURL_VERSION_GSSAPI is a new capability bit
  CHG no longer use fbopenssl for anything
  CHG schannel: use CryptGenRandom for random numbers
- CHG axtls: define curlssl_random using axTLS&apos;s PRNG
+ CHG axtls: define curlssl_random using axTLS&#39;s PRNG
  CHG cyassl: use RNG_GenerateBlock to generate a good random number
  CHG findprotocol: show unsupported protocol within quotes
  CHG version: detect and show LibreSSL
@@ -4606,7 +4606,7 @@ SUBTITLE(Fixed in 7.38.0 - September 10 2014)
  BGF HTTP/2: Support expect: 100-continue
  BGF HTTP/2: Fix infinite loop in readwrite_data()
  BGF parsedate: fix the return code for an overflow edge condition
- BGF darwinssl: don&apos;t use strtok()
+ BGF darwinssl: don&#39;t use strtok()
  BGF <a href="https://curl.se/mail/lib-2014-06/0224.html">http_negotiate_sspi: Fixed specific username and password not working</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1401">openssl: replace call to OPENSSL_config</a>
  BGF http2: show the received header for better debugging
@@ -4627,11 +4627,11 @@ SUBTITLE(Fixed in 7.38.0 - September 10 2014)
  BGF openssl: fix version report for the 0.9.8 branch
  BGF <a href="https://curl.se/bug/view.cgi?id=1409">mk-ca-bundle.pl: switched to using hg.mozilla.org</a>
  BGF <a href="https://curl.se/mail/lib-2014-06/0221.html">http: fix the Content-Range: parser</a>
- BGF <a href="https://curl.se/mail/lib-2014-08/0148.html">Curl_disconnect: don&apos;t free the URL</a>
+ BGF <a href="https://curl.se/mail/lib-2014-08/0148.html">Curl_disconnect: don&#39;t free the URL</a>
  BGF <a href="https://curl.se/mail/lib-2014-08/0155.html">win32: Fixed WinSock 2 #if</a>
  BGF NTLM: ignore CURLOPT_FORBID_REUSE during NTLM HTTP auth
- BGF <a href="https://curl.se/bug/view.cgi?id=1414">curl.1: clarify --limit-rate&apos;s effect on both directions</a>
- BGF <a href="https://curl.se/mail/lib-2014-08/0148.html">disconnect: don&apos;t touch easy-related state on disconnects</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1414">curl.1: clarify --limit-rate&#39;s effect on both directions</a>
+ BGF <a href="https://curl.se/mail/lib-2014-08/0148.html">disconnect: don&#39;t touch easy-related state on disconnects</a>
  BGF cmake: big cleanup and numerous fixes
  BGF HTTP/2: supports draft-14 - moved :headers before the non-psuedo headers
  BGF HTTP/2: Reset promised stream, not its associated stream
@@ -4661,13 +4661,13 @@ SUBTITLE(Fixed in 7.37.1 - July 16 2014)
 <ul class="bugfixes">
  BGF <a href="https://curl.se/mail/lib-2014-05/0235.html">build: Fixed incorrect reference to curl_setup.h in Visual Studio files</a>
  BGF build: Use $(TargetDir) and $(TargetName) macros for .pdb and .lib output
- BGF curl.1: clarify that -u can&apos;t specify a user with colon
+ BGF curl.1: clarify that -u can&#39;t specify a user with colon
  BGF openssl: Fix uninitialized variable use in NPN callback
  BGF curl_easy_reset: reset the URL
  BGF curl_version_info.3: returns a pointer to a static struct
  BGF <a href="https://curl.se/mail/lib-2014-05/0260.html">url-parser: only use if_nametoindex if detected by configure</a>
  BGF <a href="https://curl.se/mail/lib-2014-05/0278.html">select: with winsock, avoid passing unsupported arguments to select()</a>
- BGF gnutls: don&apos;t use deprecated type names anymore
+ BGF gnutls: don&#39;t use deprecated type names anymore
  BGF gnutls: allow building with nghttp2 but without ALPN support
  BGF tests: Fix portability issue with the tftpd server
  BGF curl_sasl_sspi: Fixed corrupt hostname in DIGEST-MD5 SPN
@@ -4675,7 +4675,7 @@ SUBTITLE(Fixed in 7.37.1 - July 16 2014)
  BGF <a href="https://curl.se/mail/lib-2014-06/0001.html">random: use Curl_rand() for proper random data</a>
  BGF <a href="https://curl.se/mail/lib-2014-06/0003.html">Curl_ossl_init: call OPENSSL_config for initing engines</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1378">config-win32.h: Updated for VC12</a>
- BGF winbuild: Don&apos;t USE_WINSSL when WITH_SSL is being used
+ BGF winbuild: Don&#39;t USE_WINSSL when WITH_SSL is being used
  BGF <a href="https://curl.se/bug/view.cgi?id=1380">getinfo: HTTP CONNECT code not reset between transfers</a>
  BGF Curl_rand: Use a fake entropy for debug builds when CURL_ENTROPY set
  BGF http2: avoid segfault when using the plain-text http2
@@ -4698,10 +4698,10 @@ SUBTITLE(Fixed in 7.37.1 - July 16 2014)
  BGF gnutls: ignore invalid certificate dates with VERIFYPEER disabled
  BGF gnutls: fix SRP support with versions of GnuTLS from 2.99.0
  BGF gnutls: fixed a couple of uninitialized variable references
- BGF gnutls: fixed compilation against versions < 2.12.0
+ BGF gnutls: fixed compilation against versions &lt; 2.12.0
  BGF build: Fixed overridden compiler PDB settings in VC7 to VC12
  BGF <a href="https://curl.se/mail/lib-2014-07/0103.html">ntlm_wb: Fixed buffer size not being large enough for NTLMv2 sessions</a>
- BGF netrc: don&apos;t abort if home dir cannot be found
+ BGF netrc: don&#39;t abort if home dir cannot be found
  BGF netrc: fixed thread safety problem by using getpwuid_r if available
  BGF <a href="https://curl.se/mail/lib-2014-02/0184.html">cookie: avoid mutex deadlock</a>
  BGF configure: respect host tool prefix for krb5-config
@@ -4732,17 +4732,17 @@ SUBTITLE(Fixed in 7.37.0 - May 21 2014)
  BGF hostcheck: added a system include to define struct in_addr
  BGF winbuild: added warnless.c to fix build
  BGF Makefile.vc6: added warnless.c to fix build
- BGF smtp: Fixed login denied when server doesn&apos;t support AUTH capability
+ BGF smtp: Fixed login denied when server doesn&#39;t support AUTH capability
  BGF <a href="https://curl.se/mail/lib-2014-03/0173.html">smtp: Fixed login denied with a RFC-821 based server</a>
  BGF curl: stop interpreting IPv6 literals as glob patterns
  BGF http2: remove _DRAFT09 from the NPN_HTTP2 enum
  BGF http2: let openssl mention the exact protocol negotiated
  BGF http2+openssl: fix compiler warnings in ALPN using code
  BGF <a href="https://curl.se/mail/lib-2014-02/0135.html (ruined)">ftp: in passive data connect wait for happy eyeballs sockets</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1349">HTTP: don&apos;t send Content-Length: 0 _and_ Expect: 100-continue</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1349">HTTP: don&#39;t send Content-Length: 0 _and_ Expect: 100-continue</a>
  BGF <a href="https://curl.se/mail/lib-2014-04/0053.html">http2: Compile with current nghttp2, which supports h2-11</a>
  BGF http_negotiate_sspi: Fixed compilation when USE_HTTP_NEGOTIATE not defined
- BGF <a href="https://curl.se/mail/lib-2014-04/0063.html">strerror: fix comment about vxworks&apos; strerror_r buffer size</a>
+ BGF <a href="https://curl.se/mail/lib-2014-04/0063.html">strerror: fix comment about vxworks&#39; strerror_r buffer size</a>
  BGF url: only use if_nametoindex() if IFNAMSIZ is available
  BGF imap: Fixed untagged response detection when no data after command
  BGF various: fix possible dereference of null pointer
@@ -4759,7 +4759,7 @@ SUBTITLE(Fixed in 7.37.0 - May 21 2014)
  BGF <a href="https://curl.se/bug/view.cgi?id=1362">curl_global_init_mem: bump initialized even if already initialized</a>
  BGF <a href="https://curl.se/mail/lib-2014-04/0145.html">gtls: fix NULL pointer dereference</a>
  BGF cyassl: Use error-ssl.h when available
- BGF <a href="https://curl.se/bug/?i=97">handler: make &apos;protocol&apos; always specified as a single bit</a>
+ BGF <a href="https://curl.se/bug/?i=97">handler: make &#39;protocol&#39; always specified as a single bit</a>
  BGF INFILESIZE: fields in UserDefined must not be changed run-time
  BGF openssl: biomem->data is not zero terminated
  BGF config-win32.h: Fixed HAVE_LONGLONG for Visual Studio .NET 2003 and up
@@ -4768,15 +4768,15 @@ SUBTITLE(Fixed in 7.37.0 - May 21 2014)
  BGF curl: bail on cookie use when built with disabled cookies
  BGF curl_easy_setopt.3: added the proto for CURLOPT_SSH_KNOWNHOSTS
  BGF <a href="http://thread.gmane.org/gmane.comp.version-control.git/238242">curl_multi_cleanup: ignore SIGPIPE better</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1352">schannel: don&apos;t use the connect-timeout during send</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1352">schannel: don&#39;t use the connect-timeout during send</a>
  BGF mprintf: allow %.s with data not being zero terminated
  BGF tool_help: Fixed missing --login-options option
- BGF configure: Don&apos;t set LD_LIBRARY_PATH when cross-compiling
- BGF <a href="https://bugzilla.redhat.com/1093348">http: auth failure on duplicated &apos;WWW-Authenticate: Negotiate&apos; header</a>
+ BGF configure: Don&#39;t set LD_LIBRARY_PATH when cross-compiling
+ BGF <a href="https://bugzilla.redhat.com/1093348">http: auth failure on duplicated &#39;WWW-Authenticate: Negotiate&#39; header</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1368">cacertinmem: fix memory leak</a>
  BGF <a href="https://curl.se/mail/lib-2014-05/0081.html">lib1506: make sure the transfers are not within the same ms</a>
  BGF <a href="https://curl.se/mail/lib-2014-05/0025.html">Makefile.b32: Fixed for vtls changes</a>
- BGF sasl: Fixed missing qop in the client&apos;s challenge-response message
+ BGF sasl: Fixed missing qop in the client&#39;s challenge-response message
  BGF <a href="https://curl.se/bug/view.cgi?id=1371">openssl: unbreak PKCS12 support</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1369">darwinssl: fix potential crash with a P12 file</a>
  BGF <a href="https://curl.se/mail/lib-2014-05/0147.html">timers: fix timer regression involving redirects / reconnects</a>
@@ -4805,9 +4805,9 @@ align="right" alt="Release contains security-related bug fixes" border="0">
  CHG winssl: enable TLSv1.1 and TLSv1.2 by default
  CHG winssl: TLSv1.2 disables certificate signatures using MD5 hash
  CHG <a href="https://curl.se/mail/lib-2014-02/0243.html">winssl: enable hostname verification of IP address using SAN or CN</a>
- CHG <a href="https://curl.se/bug/?i=93">darwinssl: Don&apos;t omit CN verification when an IP address is used</a>
+ CHG <a href="https://curl.se/bug/?i=93">darwinssl: Don&#39;t omit CN verification when an IP address is used</a>
  CHG http2: build with current nghttp2 version
- CHG polarssl: dropped support for PolarSSL < 1.3.0
+ CHG polarssl: dropped support for PolarSSL &lt; 1.3.0
  CHG openssl: info message with SSL version used
 </ul>
 <p> Bugfixes:
@@ -4861,7 +4861,7 @@ align="right" alt="Release contains security-related bug fixes" border="0">
  BGF http2: free resources on disconnect
  BGF polarssl: avoid extra newlines in debug messages
  BGF <a href="https://curl.se/mail/lib-2014-03/0134.html">rtsp: parse "Session:" header properly</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1337">trynextip: don&apos;t store &apos;ai&apos; on failed connects</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1337">trynextip: don&#39;t store &#39;ai&#39; on failed connects</a>
  BGF Curl_cert_hostcheck: strip trailing dots in host name and wildcard
 </ul>
 
@@ -4883,12 +4883,12 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF <a href="https://curl.se/bug/view.cgi?id=1313">curl_easy_setopt: Fixed OAuth 2.0 Bearer option name</a>
  BGF pop3: Fixed APOP being determined by CAPA response rather than by timestamp
  BGF <a href="https://curl.se/mail/lib-2013-12/0113.html">Curl_pp_readresp: zero terminate line</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1312">FILE: don&apos;t wait due to CURLOPT_MAX_RECV_SPEED_LARGE</a>
- BGF docs: mention CURLOPT_MAX_RECV/SEND_SPEED_LARGE don&apos;t work for FILE://
+ BGF <a href="https://curl.se/bug/view.cgi?id=1312">FILE: don&#39;t wait due to CURLOPT_MAX_RECV_SPEED_LARGE</a>
+ BGF docs: mention CURLOPT_MAX_RECV/SEND_SPEED_LARGE don&#39;t work for FILE://
  BGF pop3: Fixed auth preference not being honored when CAPA not supported
  BGF imap: Fixed auth preference not being honored when CAPABILITY not supported
  BGF <a href="https://curl.se/bug/view.cgi?id=1314">threaded resolver: Use pthread_t * for curl_thread_t</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1286">FILE: we don&apos;t support paused transfers using this protocol</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1286">FILE: we don&#39;t support paused transfers using this protocol</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1315">connect: Try all addresses in first connection attempt</a>
  BGF curl_easy_setopt.3: Added SMTP information to CURLOPT_INFILESIZE_LARGE
  BGF <a href="https://curl.se/mail/lib-2014-01/0002.html">OpenSSL: Fix forcing SSLv3 connections</a>
@@ -4899,14 +4899,14 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF mk-ca-bundle: introduces -d and warns about using this script
  BGF <a href="https://curl.se/mail/lib-2014-01/0046.html">ConnectionExists: fix NTLM check for new connection</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1322">trynextip: fix build for non-IPV6 capable systems</a>
- BGF <a href="https://curl.se/mail/archive-2014-01/0016.html">Curl_updateconninfo: don&apos;t do anything for UDP "connections"</a>
+ BGF <a href="https://curl.se/mail/archive-2014-01/0016.html">Curl_updateconninfo: don&#39;t do anything for UDP "connections"</a>
  BGF <a href="https://curl.se/mail/lib-2013-12/0150.html">darwinssl: un-break Leopard build after PKCS#12 change</a>
  BGF <a href="https://curl.se/mail/lib-2014-01/0061.html">threaded-resolver: never use NULL hints with getaddrinf</a>
- BGF multi_socket: remind app if timeout didn&apos;t run
+ BGF multi_socket: remind app if timeout didn&#39;t run
  BGF <a href="https://curl.se/bug/view.cgi?id=1323">OpenSSL: deselect weak ciphers by default</a>
  BGF <a href="https://curl.se/mail/lib-2014-01/0115.html">error message: Sensible message on timeout when transfer size unknown</a>
  BGF curl_easy_setopt.3: mention how to unset CURLOPT_INFILESIZE*
- BGF <a href="https://curl.se/mail/lib-2014-01/0134.html">win32: Fixed use of deprecated function &apos;GetVersionInfoEx&apos; for VC12</a>
+ BGF <a href="https://curl.se/mail/lib-2014-01/0134.html">win32: Fixed use of deprecated function &#39;GetVersionInfoEx&#39; for VC12</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1321">configure: fix gssapi linking on HP-UX</a>
  BGF chunked-parser: abort on overflows, allow 64 bit chunks
  BGF <a href="https://curl.se/mail/archive-2014-01/0000.html">chunked parsing: relax the CR strictness</a>
@@ -4922,7 +4922,7 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF netrc: Fixed a memory and file descriptor leak on OOM
  BGF <a href="https://curl.se/bug/?i=87">getpass: fix password parsing from console</a>
  BGF <a href="https://curl.se/mail/lib-2014-01/0246.html">TFTP: fix crash on time-out</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1327">hostip: don&apos;t remove DNS entries that are in use</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1327">hostip: don&#39;t remove DNS entries that are in use</a>
  BGF tests: lots of tests fixed to pass the OOM torture tests
 </ul>
 
@@ -4959,14 +4959,14 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF ssh: initialize per-handle data in ssh_connect()
  BGF glob: fix broken URLs
  BGF configure: check for long long when building with cyassl
- BGF <a href="https://curl.se/mail/lib-2013-10/0062.html">CURLOPT_RESOLVE: mention they don&apos;t time-out</a>
+ BGF <a href="https://curl.se/mail/lib-2013-10/0062.html">CURLOPT_RESOLVE: mention they don&#39;t time-out</a>
  BGF docs/examples/httpput.c: fix build for MSVC
  BGF FTP: make the data connection work when going through proxy
  BGF NSS: support for CERTINFO feature
  BGF curl_multi_wait: accept 0 from multi_timeout() as valid timeout
  BGF glob_range: pass the closing bracket for a-z ranges
  BGF tool_help: Updated --list-only description to include POP3
- BGF <a href="https://curl.se/bug/view.cgi?id=1295">Curl_ssl_push_certinfo_len: don&apos;t %.*s non-zero-terminated string</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1295">Curl_ssl_push_certinfo_len: don&#39;t %.*s non-zero-terminated string</a>
  BGF <a href="https://sourceforge.net/p/curl/bugs/1064">cmake: fix Windows build with IPv6 support</a>
  BGF <a href="https://curl.se/mail/lib-2013-11/0057.html">ares: Fixed compilation under Visual Studio 2012</a>
  BGF <a href="https://curl.se/bug/?i=83">curl_easy_setopt.3: clarify CURLOPT_SSL_VERIFYHOST documentation</a>
@@ -4977,15 +4977,15 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF sigpipe: factor out sigpipe_reset from easy.c
  BGF curl_multi_cleanup: ignore SIGPIPE
  BGF <a href="https://curl.se/bug/view.cgi?id=1305">globbing: curl glob counter mismatch with {} list use</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1297">parseconfig: dash options can&apos;t specified with colon or equals</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1297">parseconfig: dash options can&#39;t specified with colon or equals</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1308">digest: fix CURLAUTH_DIGEST_IE</a>
- BGF <a href="https://curl.se/mail/lib-2013-12/0017.html">curl.h: <sys/select.h> for OpenBSD</a>
+ BGF <a href="https://curl.se/mail/lib-2013-12/0017.html">curl.h: &lt;sys/select.h&gt; for OpenBSD</a>
  BGF darwinssl: Fix #if 10.6.0 for SecKeychainSearch
  BGF <a href="https://curl.se/bug/view.cgi?id=1310">TFTP: fix return codes for connect timeout</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1311">login options: remove the ;[options] support from CURLOPT_USERPWD</a>
  BGF imap: Fixed incorrect fallback to clear text authentication
  BGF parsedate: avoid integer overflow
- BGF <a href="https://curl.se/bug/view.cgi?id=1294">curl.1: document -J doesn&apos;t %-decode</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1294">curl.1: document -J doesn&#39;t %-decode</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1298">multi: add timer inaccuracy margin to timeout/connecttimeout</a>
 </ul>
 
@@ -4995,7 +4995,7 @@ SUBTITLE(Fixed in 7.33.0 - October 14 2013)
 <ul class="changes">
  CHG <a href="https://daniel.haxx.se/blog/2013/08/20/testing-curl_multi_socket_action/">test code for testing the event based API</a>
  CHG CURLM_ADDED_ALREADY: new error code
- CHG test TFTP server: support "writedelay" within <servercmd>
+ CHG test TFTP server: support "writedelay" within &lt;servercmd&gt;
  CHG krb4 support has been removed
  CHG <a href="https://curl.se/mail/lib-2013-08/0234.html">imap/pop3/smtp: added basic SASL XOAUTH2 support</a>
  CHG darwinssl: add support for PKCS#12 files for client authentication
@@ -5011,7 +5011,7 @@ SUBTITLE(Fixed in 7.33.0 - October 14 2013)
  BGF curl: make --no-[option] work properly for several options
  BGF <a href="https://curl.se/mail/lib-2013-08/0043.html">FTP: with socket_action send better socket updates in active mode</a>
  BGF curl: fix the --sasl-ir in the --help output
- BGF tests 2032, 2033: Don&apos;t hardcode port in expected output
+ BGF tests 2032, 2033: Don&#39;t hardcode port in expected output
  BGF <a href="https://curl.se/bug/view.cgi?id=1264">urlglob: better detect unclosed braces, empty lists and overflows</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1267">urlglob: error out on range overflow</a>
  BGF <a href="https://curl.se/mail/lib-2013-08/0136.html">imap: Fixed response check for SEARCH, EXPUNGE, LSUB, UID and NOOP commands</a>
@@ -5067,11 +5067,11 @@ SUBTITLE(Fixed in 7.32.0 - August 12 2013)
  BGF test1396: invoke the correct test tool
  BGF <a href="https://curl.se/bug/view.cgi?id=1180">SIGPIPE: ignored while inside the library</a>
  BGF darwinssl: fix crash that started happening in Lion
- BGF <a href="https://curl.se/bug/view.cgi?id=1249">OpenSSL: check for read errors, don&apos;t assume</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1249">OpenSSL: check for read errors, don&#39;t assume</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1191">c-ares: improve error message on failed resolve</a>
  BGF printf: make sure %x are treated unsigned
  BGF <a href="https://curl.se/bug/view.cgi?id=1251">formpost: better random boundaries</a>
- BGF <a href="https://curl.se/mail/archive-2013-06/0052.html">url: restore the functionality of &apos;curl -u :&apos;</a>
+ BGF <a href="https://curl.se/mail/archive-2013-06/0052.html">url: restore the functionality of &#39;curl -u :&#39;</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1252">curl.1: fix typo in --xattr description</a>
  BGF digest: improve nonce generation
  BGF configure: automake 1.14 compatibility tweak
@@ -5080,7 +5080,7 @@ SUBTITLE(Fixed in 7.32.0 - August 12 2013)
  BGF setup-vms.h: sk_pop symbol tweak
  BGF tool_paramhlp: try harder to catch negatives
  BGF <a href="https://curl.se/mail/lib-2013-07/0046.html">cmake: Fix for MSVC2010 project generation</a>
- BGF asyn-ares: Don&apos;t blank ares servers if none configured
+ BGF asyn-ares: Don&#39;t blank ares servers if none configured
  BGF curl_multi_wait: set revents for extra fds
  BGF Reinstate WIN32 MemoryTracking: track wcsdup() _wcsdup() and _tcsdup()
  BGF <a href="https://curl.se/mail/lib-2013-07/0115.html">ftp_do_more: consider DO_MORE complete when server connects back</a>
@@ -5094,13 +5094,13 @@ SUBTITLE(Fixed in 7.32.0 - August 12 2013)
  BGF <a href="https://curl.se/bug/view.cgi?id=1255">md5 & metalink: use better build macros on Apple operating systems</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1255">darwinssl: fix build error in crypto authentication under Snow Leopard</a>
  BGF <a href="https://curl.se/mail/archive-2013-07/0031.html">curl: make --progress-bar update the line less frequently</a>
- BGF configure: don&apos;t error out on variable confusions (CFLAGS, LDFLAGS etc)
+ BGF configure: don&#39;t error out on variable confusions (CFLAGS, LDFLAGS etc)
  BGF mk-ca-bundle: skip more untrusted certificates
  BGF <a href="https://curl.se/bug/view.cgi?id=1262">formadd: wrong pointer for file name when CURLFORM_BUFFERPTR used</a>
  BGF FTP: when EPSV gets a 229 but fails to connect, retry with PASV
- BGF <a href="https://curl.se/mail/lib-2013-08/0057.html">mk-ca-bundle.1: don&apos;t install on make install</a>
+ BGF <a href="https://curl.se/mail/lib-2013-08/0057.html">mk-ca-bundle.1: don&#39;t install on make install</a>
  BGF VMS: lots of updates and fixes of the build procedure
- BGF global dns cache: didn&apos;t work (regression)
+ BGF global dns cache: didn&#39;t work (regression)
  BGF global dns cache: fix memory leak
 </ul>
 
@@ -5112,12 +5112,12 @@ align="right" alt="Release contains security-related bug fix" border="0">
 <ul class="changes">
  CHG darwinssl: add TLS session resumption
  CHG darwinssl: add TLS crypto authentication
- CHG imap/pop3/smtp: Added support for ;auth=<mech> in the URL
- CHG imap/pop3/smtp: Added support for ;auth=<mech> to CURLOPT_USERPWD
+ CHG imap/pop3/smtp: Added support for ;auth=&lt;mech&gt; in the URL
+ CHG imap/pop3/smtp: Added support for ;auth=&lt;mech&gt; to CURLOPT_USERPWD
  CHG usercertinmem.c: add example showing user cert in memory
  CHG url: Added smtp and pop3 hostnames to the protocol detection list
  CHG <a href="https://curl.se/mail/lib-2012-03/0114.html">imap/pop3/smtp: Added support for enabling the SASL initial response</a>
- CHG <a href="https://curl.se/bug/view.cgi?id=1196">curl -E: allow to use &apos;:&apos; in certificate nicknames</a>
+ CHG <a href="https://curl.se/bug/view.cgi?id=1196">curl -E: allow to use &#39;:&#39; in certificate nicknames</a>
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -5125,8 +5125,8 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF <a href="https://curl.se/mail/lib-2013-04/0142.html">FTP: access files in root dir correctly</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1216">configure: try pthread_create without -lpthread</a>
  BGF <a href="https://curl.se/mail/lib-2013-02/0102.html">FTP: handle a 230 welcome response</a>
- BGF curl-config: don&apos;t output static libs when they are disabled
- BGF <a href="https://curl.se/mail/lib-2013-04/0294.html">CURL_CHECK_CA_BUNDLE: don&apos;t check for paths when cross-compiling</a>
+ BGF curl-config: don&#39;t output static libs when they are disabled
+ BGF <a href="https://curl.se/mail/lib-2013-04/0294.html">CURL_CHECK_CA_BUNDLE: don&#39;t check for paths when cross-compiling</a>
  BGF Various documentation updates
  BGF <a href="https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=705783">getinfo.c: reset timecond when clearing session-info variables</a>
  BGF <a href="https://bugzilla.redhat.com/906031">FILE: prevent an artificial timeout event due to stale speed-check data</a>
@@ -5224,7 +5224,7 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF darwinssl: disable ECC ciphers under Mountain Lion by default
  BGF <a href="https://curl.se/bug/view.cgi?id=1204">CONNECT: count received headers</a>
  BGF build: fixes for VMS
- BGF <a href="https://groups.google.com/d/msg/msysgit/B31LNftR4BI/KhRTz0iuGmUJ">CONNECT: clear &apos;rewindaftersend&apos; on success</a>
+ BGF <a href="https://groups.google.com/d/msg/msysgit/B31LNftR4BI/KhRTz0iuGmUJ">CONNECT: clear &#39;rewindaftersend&#39; on success</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1206">HTTP proxy: insert slash in URL if missing</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1199">hiperfifo: updated to use current libevent API</a>
  BGF getinmemory.c: abort the transfer nicely if not enough memory
@@ -5235,7 +5235,7 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF <a href="https://curl.se/bug/view.cgi?id=1214">tcpkeepalive on Mac OS X</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1212">easy: acknowledge the CURLOPT_MAXCONNECTS option properly</a>
  BGF easy interface: restore default MAXCONNECTS to 5
- BGF <a href="https://curl.se/bug/view.cgi?id=1188">win32: don&apos;t set SO_SNDBUF for windows vista or later versions</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1188">win32: don&#39;t set SO_SNDBUF for windows vista or later versions</a>
  BGF HTTP: made cookie sort function more deterministic
  BGF winssl: Fixed memory leak if connection was not successful
  BGF <a href="https://curl.se/bug/view.cgi?id=1183">FTP: wait on both connections during active STOR state</a>
@@ -5269,8 +5269,8 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF nss: prevent NSS from crashing on client auth hook failure
  BGF darwinssl: Fixed inability to disable peer verification on Snow Leopard and Lion
  BGF curl_multi_remove_handle: fix memory leak triggered with CURLOPT_RESOLVE
- BGF <a href="https://curl.se/bug/view.cgi?id=1173">SCP: relative path didn&apos;t work as documented</a>
- BGF setup_once.h: HP-UX <sys/socket.h> issue workaround
+ BGF <a href="https://curl.se/bug/view.cgi?id=1173">SCP: relative path didn&#39;t work as documented</a>
+ BGF setup_once.h: HP-UX &lt;sys/socket.h&gt; issue workaround
  BGF configure: fix cross pkg-config detection
  BGF runtests: Do not add undefined values to @INC
  BGF build: fix compilation with CURL_DISABLE_CRYPTO_AUTH flag
@@ -5283,7 +5283,7 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF <a href="https://curl.se/mail/lib-2013-01/0191.html">fix HTTP CONNECT tunnel establishment upon delayed response</a>
  BGF --libcurl: fix for non-zero default options
  BGF FTP: reject illegal port numbers in EPSV 229 responses
- BGF build: use per-target &apos;_CPPFLAGS&apos; for those currently using default
+ BGF build: use per-target &#39;_CPPFLAGS&#39; for those currently using default
  BGF <a href="https://curl.se/mail/lib-2012-12/0246.html">configure: fix automake 1.13 compatibility</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1180">curl: ignore SIGPIPE</a>
  BGF pop3: Added support for non-blocking SSL upgrade
@@ -5315,7 +5315,7 @@ SUBTITLE(Fixed in 7.28.1 - November 20 2012)
  BGF Fix broken libmetalink-aware OpenSSL build
  BGF <a href="https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=690551">gnutls: fix the error is fatal logic</a>
  BGF darwinssl: un-broke iOS build, fix error on server disconnect
- BGF <a href="https://curl.se/bug/view.cgi?id=3577710">asyn-ares: restore functionality with c-ares < 1.6.1</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=3577710">asyn-ares: restore functionality with c-ares &lt; 1.6.1</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3578418">tlsauthtype: deal with the string case insensitively</a>
  BGF Fixed MSVC libssh2 static build
  BGF <a href="https://curl.se/bug/view.cgi?id=3582407">evhiperfifo: fix the pointer passed to WRITEDATA</a>
@@ -5326,7 +5326,7 @@ SUBTITLE(Fixed in 7.28.1 - November 20 2012)
  BGF httpcustomheader.c: free the headers after use
  BGF <a href="https://curl.se/bug/view.cgi?id=3582321">fix >2000 bytes POST over NTLM-using proxy</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3581898">redirects to URLs with fragments</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=3579813">don&apos;t send &apos;#&apos; fragments when using proxy</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=3579813">don&#39;t send &#39;#&#39; fragments when using proxy</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3579286">OpenSSL: show full issuer string</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3582718">fix HTTP auth regression</a>
  BGF <a href="https://daniel.haxx.se/blog/2012/10/25/libcurl-claimed-to-be-dangerous/">CURLOPT_SSL_VERIFYHOST: stop supporting the 1 value</a>
@@ -5339,7 +5339,7 @@ SUBTITLE(Fixed in 7.28.1 - November 20 2012)
  BGF FILE: Make upload-writes unbuffered
  BGF <a href="https://curl.se/mail/lib-2012-11/0125.html">custom memory callbacks failure with HTTP proxy (and more)</a>
  BGF TFTP: handle resends
- BGF autoconf: don&apos;t force-disable compiler debug option
+ BGF autoconf: don&#39;t force-disable compiler debug option
  BGF <a href="https://curl.se/bug/view.cgi?id=3586741">winbuild: Fix PDB file output</a>
  BGF <a href="https://curl.se/mail/lib-2012-11/0095.html">test2032: spurious failure caused by premature termination</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3575448">memory leak: CURLOPT_RESOLVE with multi interface</a>
@@ -5433,11 +5433,11 @@ SUBTITLE(Fixed in 7.27.0 - July 27 2012)
  BGF OOM fix in the curl tool when cloning cmdline options
  BGF fixed some examples to use curl_global_init() properly
  BGF cmdline: stricter numerical option parser
- BGF HTTP HEAD: don&apos;t force-close after response-headers
+ BGF HTTP HEAD: don&#39;t force-close after response-headers
  BGF test231: fix wrong -C use
  BGF docs: switch to proper UTF-8 for text file encoding
  BGF <a href="https://curl.se/bug/view.cgi?id=3546257">keepalive: DragonFly uses milliseconds</a>
- BGF HTTP Digest: Client&apos;s "qop" value should not be quoted
+ BGF HTTP Digest: Client&#39;s "qop" value should not be quoted
  BGF make distclean works again
 </ul>
 
@@ -5451,7 +5451,7 @@ SUBTITLE(Fixed in 7.26.0 - May 24 2012)
  CHG added --post303 and the CURL_REDIR_POST_303 option for CURLOPT_POSTREDIR
  CHG smtp: Add support for DIGEST-MD5 authentication
  CHG pop3: Added support for additional pop3 commands
- CHG curl: -w now supports &apos;filename_effective&apos;
+ CHG curl: -w now supports &#39;filename_effective&#39;
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -5460,7 +5460,7 @@ SUBTITLE(Fixed in 7.26.0 - May 24 2012)
  BGF <a href="https://curl.se/mail/lib-2012-04/0246.html">MD5: fix OOM memory leak</a>
  BGF OpenSSL cert: provide more details when cert check fails
  BGF <a href="https://curl.se/mail/archive-2012-04/0060.html">HTTP: empty chunked POST ended up in two zero size chunks</a>
- BGF fixed a regression when curl resolved to multiple addresses and the first isn&apos;t supported [7]
+ BGF fixed a regression when curl resolved to multiple addresses and the first isn&#39;t supported [7]
  BGF <a href="https://curl.se/bug/view.cgi?id=3517418">-# progress meter: avoid superfluous updates and duplicate lines</a>
  BGF <a href="https://curl.se/mail/lib-2012-04/0127.html">headers: surround GCC attribute names with double underscores</a>
  BGF PolarSSL: correct return code for CRL matches
@@ -5502,9 +5502,9 @@ SUBTITLE(Fixed in 7.25.0 - March 22 2012)
 <ul class="bugfixes">
  BGF <a href="https://curl.se/mail/lib-2012-02/0098.html">--max-redirs: allow negative numbers as option value</a>
  BGF <a href="https://curl.se/mail/lib-2012-02/0000.html">parse_proxy: bail out on zero-length proxy names</a>
- BGF <a href="https://curl.se/mail/lib-2012-02/0052.html">configure: don&apos;t modify LD_LIBRARY_PATH for cross compiles</a>
+ BGF <a href="https://curl.se/mail/lib-2012-02/0052.html">configure: don&#39;t modify LD_LIBRARY_PATH for cross compiles</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3481551">curl_easy_reset: reset the referer string</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=3481223">curl tool: don&apos;t abort glob-loop due to failures</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=3481223">curl tool: don&#39;t abort glob-loop due to failures</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3482093">CONNECT: send correct Host: with IPv6 numerical address</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0303.html">Explicitly link to the nettle/gcrypt libraries</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0190.html">more resilient connection times among IP addresses</a>
@@ -5517,12 +5517,12 @@ SUBTITLE(Fixed in 7.25.0 - March 22 2012)
  BGF smtp: Added support for returning SMTP response codes
  BGF <a href="https://curl.se/bug/view.cgi?id=3493129">CONNECT: fix ipv6 address in the Request-Line</a>
  BGF curl-config: only provide libraries with --libs
- BGF <a href="https://curl.se/mail/lib-2012-03/0046.html">LWIP: don&apos;t consider HAVE_ERRNO_H to be winsock</a>
+ BGF <a href="https://curl.se/mail/lib-2012-03/0046.html">LWIP: don&#39;t consider HAVE_ERRNO_H to be winsock</a>
  BGF ssh: tunnel through HTTP proxy if requested
  BGF <a href="https://curl.se/mail/lib-2012-03/0036.html">cookies: strip off [brackets] from numerical ipv6 host names</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3494091">libcurl docs: version corrections</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3494968">cmake: list_spaces_append_once failure</a>
- BGF <a href="https://curl.se/mail/lib-2012-03/0045.html">resolve with c-ares: don&apos;t resolve IPv6 when not working</a>
+ BGF <a href="https://curl.se/mail/lib-2012-03/0045.html">resolve with c-ares: don&#39;t resolve IPv6 when not working</a>
  BGF smtp: changed error code for EHLO and HELO responses
  BGF parsedate: fix a numeric overflow
 </ul>
@@ -5533,7 +5533,7 @@ SUBTITLE(Fixed in 7.24.0 - January 24 2012)
 align="right" alt="Release contains security-related bug fix" border="0">
 <p> Changes:
 <ul class="changes">
- CHG <a href="https://curl.se/mail/lib-2011-11/0205.html">CURLOPT_QUOTE: SFTP supports the &apos;*&apos;-prefix now</a>
+ CHG <a href="https://curl.se/mail/lib-2011-11/0205.html">CURLOPT_QUOTE: SFTP supports the &#39;*&#39;-prefix now</a>
  CHG <a href="https://curl.se/mail/lib-2011-11/0067.html">CURLOPT_DNS_SERVERS: set name servers if possible</a>
  CHG <a href="https://curl.se/mail/lib-2011-11/0164.html">Add support for using nettle instead of gcrypt as gnutls backend</a>
  CHG <a href="https://curl.se/mail/lib-2011-12/0107.html">CURLOPT_INTERFACE: avoid resolving interfaces names with magic prefixes</a>
@@ -5557,7 +5557,7 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF <a href="https://curl.se/bug/view.cgi?id=3442068">CyaSSL 2.0+ library initialization adjustment</a>
  BGF multi interface: only use non-NULL socker function pointer
  BGF call opensocket callback properly for active FTP
- BGF <a href="https://curl.se/mail/lib-2011-12/0018.html">don&apos;t call close socket callback for sockets created with accept()</a>
+ BGF <a href="https://curl.se/mail/lib-2011-12/0018.html">don&#39;t call close socket callback for sockets created with accept()</a>
  BGF <a href="https://curl.se/mail/archive-2011-12/0010.html">differentiate better between host/proxy errors</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3451592">SSH: fix CURLOPT_SSH_HOST_PUBLIC_KEY_MD5 and --hostpubmd5</a>
  BGF <a href="https://curl.se/mail/lib-2011-11/0371.html">multi: handle timeouts on DNS servers by checking for new sockets</a>
@@ -5565,7 +5565,7 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF <a href="https://curl.se/mail/lib-2011-11/0368.html">POP3: fixed escaped dot not being stripped out</a>
  BGF <a href="https://curl.se/mail/archive-2011-12/0012.html">OpenSSL: check for the SSLv2 function in configure</a>
  BGF <a href="https://curl.se/mail/lib-2011-12/0063.html">MakefileBuild: fix the static build</a>
- BGF <a href="https://curl.se/mail/lib-2011-12/0010.html">create_conn: don&apos;t switch to HTTP protocol if tunneling is enabled</a>
+ BGF <a href="https://curl.se/mail/lib-2011-12/0010.html">create_conn: don&#39;t switch to HTTP protocol if tunneling is enabled</a>
  BGF <a href="https://curl.se/mail/lib-2011-12/0070.html">multi interface: fix block when CONNECT_ONLY option is used</a>
  BGF <a href="https://curl.se/mail/lib-2011-11/0022.html">Fix connection reuse for TLS upgraded connections</a>
  BGF <a href="https://curl.se/mail/lib-2011-12/0121.html">multiple file upload with -F and custom type</a>
@@ -5579,12 +5579,12 @@ align="right" alt="Release contains security-related bug fix" border="0">
  BGF <a href="https://curl.se/mail/lib-2011-12/0314.html">use new host name casing for subsequent HTTP requests</a>
  BGF CURLOPT_RESOLVE: avoid adding already present host names
  BGF <a href="https://curl.se/mail/lib-2011-12/0249.html">SFTP mkdir: use correct permission</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=3463121">resolve: don&apos;t leak pre-populated dns entries</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=3463121">resolve: don&#39;t leak pre-populated dns entries</a>
  BGF --retry: Retry transfers on timeout and DNS errors
  BGF <a href="https://curl.se/bug/view.cgi?id=3466497">negotiate with SSPI backend: use the correct buffer for input</a>
  BGF <a href="https://curl.se/mail/lib-2011-12/0249.html">SFTP dir: increase buffer size counter to avoid cut off file names</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0146.html">TFTP: fix resending (again)</a>
- BGF <a href="https://curl.se/mail/lib-2012-01/0160.html">c-ares: don&apos;t include getaddrinfo-using code</a>
+ BGF <a href="https://curl.se/mail/lib-2012-01/0160.html">c-ares: don&#39;t include getaddrinfo-using code</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0096.html">FTP: CURLE_PARTIAL_FILE will not close the control channel</a>
  BGF win32-threaded-resolver: stop using a dummy socket
  BGF <a href="https://curl.se/mail/lib-2012-01/0049.html">OpenSSL: remove reference to openssl internal struct</a>
@@ -5637,20 +5637,20 @@ SUBTITLE(Fixed in 7.23.0 - November 15 2011)
  BGF TFTP timeout and unexpected block adjustments
  BGF HTTP and GOPHER test server-side connection closing adjustments
  BGF fix endless loop upon transport connection timeout
- BGF don&apos;t clobber errno on failed connect
+ BGF don&#39;t clobber errno on failed connect
  BGF typecheck: allow NULL to unset CURLOPT_ERRORBUFFER
  BGF formdata: ack read callback abort
  BGF make --show-error properly position independent
  BGF set the ipv6-connection boolean correctly on connect
  BGF SMTP: fix end-of-body string escaping
- BGF gtls: only call gnutls_transport_set_lowat with <gnutls-2.12.0
+ BGF gtls: only call gnutls_transport_set_lowat with &lt; gnutls-2.12.0
  BGF HTTP: handle multiple auths in a single WWW-Authenticate line
  BGF curl_multi_fdset: correct fdset with FTP PORT use
  BGF windbuild: fix the static build
  BGF fix builds with GnuTLS version 3
- BGF fix calling of OpenSSL&apos;s ERR_remove_state(0)
+ BGF fix calling of OpenSSL&#39;s ERR_remove_state(0)
  BGF HTTP auth: fix proxy Negotiate bug when Negotiate not requested
- BGF ftp PORT: don&apos;t hang if bind() fails
+ BGF ftp PORT: don&#39;t hang if bind() fails
  BGF -# would crash on terminals wider than 256 columns
 </ul>
 
@@ -5659,7 +5659,7 @@ SUBTITLE(Fixed in 7.22.0 - September 13 2011)
 <p> Changes:
 <ul class="changes">
  CHG Added CURLOPT_GSSAPI_DELEGATION
- CHG Added support for NTLM delegation to Samba&apos;s winbind daemon helper ntlm_auth
+ CHG Added support for NTLM delegation to Samba&#39;s winbind daemon helper ntlm_auth
  CHG Display notes from setup file in testcurl.pl
  CHG BSD-style lwIP TCP/IP stack experimental support on Windows
  CHG OpenSSL: Use SSL_MODE_RELEASE_BUFFERS if available
@@ -5694,7 +5694,7 @@ SUBTITLE(Fixed in 7.22.0 - September 13 2011)
  BGF asyn-thread: check for dotted addresses before thread starts
  BGF cmake: find winsock when building on windows
  BGF Curl_retry_request: check return code
- BGF cookies: handle &apos;secure=&apos; as if it was &apos;secure&apos;
+ BGF cookies: handle &#39;secure=&#39; as if it was &#39;secure&#39;
  BGF tests: break busy loops in tests 502, 555, and 573
  BGF FTP: fix proxy connect race condition with multi interface and SOCKS proxy
  BGF RTSP: GET_PARAMETER requests have a body
@@ -5793,18 +5793,18 @@ SUBTITLE(Fixed in 7.21.5 - April 17 2011)
  BGF only probe for working ipv6 once and then re-use that info for further
    requests
  BGF requests that are asked to bound to a local interface/port will no longer
-   wrongly re-use connections that aren&apos;t
+   wrongly re-use connections that aren&#39;t
  BGF libcurl.m4: Add missing quotes in AC_LINK_IFELSE
- BGF progress output: don&apos;t print the last update on a separate line
+ BGF progress output: don&#39;t print the last update on a separate line
  BGF POP3: the command to send is STLS, not STARTTLS
  BGF POP3: PASS command was not sent after upgrade to TLS
  BGF configure: fix libtool warning
  BGF nss: allow to use multiple client certificates for a single host
  BGF HTTP pipelining: Fix handling of zero-length responses
- BGF Don&apos;t list NTLM in curl-config when HTTP is disabled
+ BGF Don&#39;t list NTLM in curl-config when HTTP is disabled
  BGF curl_easy_setopt.3: CURLOPT_RESOLVE typo version
  BGF OpenSSL: build fine with no-sslv2 versions
- BGF checkconnection: don&apos;t call with NULL pointer with RTSP and multi interface
+ BGF checkconnection: don&#39;t call with NULL pointer with RTSP and multi interface
  BGF Borland makefile updates
  BGF configure: libssh2 link fix without pkg-config
  BGF certinfo crash
@@ -5846,7 +5846,7 @@ SUBTITLE(Fixed in 7.21.4 - February 17 2011)
  BGF Borland C++ makefile tweaks
  BGF OpenSSL: improved error message on SSL_CTX_new failures
  BGF HTTP: memory leak on multiple Location:
- BGF ares_query_completed_cb: don&apos;t touch invalid data
+ BGF ares_query_completed_cb: don&#39;t touch invalid data
  BGF ares: memory leak fix
  BGF mk-ca-bundle: use new cacert url
  BGF Curl_gmtime: added a portable gmtime and check for NULL
@@ -5879,7 +5879,7 @@ SUBTITLE(Fixed in 7.21.3 - December 15 2010)
  BGF ftp: prevent server from hanging on closed data connection when stopping
    a transfer before the end of the full transfer (ranges)
  BGF LDAP: detect non-binary attributes properly
- BGF ftp: treat server&apos;s response 421 as CURLE_OPERATION_TIMEDOUT
+ BGF ftp: treat server&#39;s response 421 as CURLE_OPERATION_TIMEDOUT
  BGF gnutls->handshake: improved timeout handling
  BGF security: Pass the right parameter to init
  BGF krb5: Use GSS_ERROR to check for error
@@ -5928,22 +5928,22 @@ align="right" alt="Release contains security-related bug fix" border="0"></a>
  BGF linking problem on Fedora 13
  BGF Link curl and the test apps with -lrt explicitly when necessary
  BGF chunky parser: only rewind stream internally if needed
- BGF remote-header-name: don&apos;t output filename when NULL
+ BGF remote-header-name: don&#39;t output filename when NULL
  BGF Curl_timeleft: avoid returning "no timeout" by mistake
  BGF timeout: use the correct start value as offset
  BGF FTP: fix wrong timeout trigger
  BGF buildconf got better output on failures
  BGF rtsp: avoid SIGSEGV on malformed header
  BGF LDAP: Support for tunnelling queries through HTTP proxy
- BGF configure&apos;s --enable-werror had a bashism
- BGF test565: Don&apos;t hardcode IP:PORT
+ BGF configure&#39;s --enable-werror had a bashism
+ BGF test565: Don&#39;t hardcode IP:PORT
  BGF configure: check for gcrypt if using GnuTLS
- BGF configure: don&apos;t enable RTMP if the lib detect fails
+ BGF configure: don&#39;t enable RTMP if the lib detect fails
  BGF curl_easy_duphandle: clone the c-ares handle correctly
  BGF MacOSX-Framework: updates for Snowleopard
  BGF support URL containing colon without trailing port number
  BGF parsedate: allow time specified without seconds
- BGF curl_easy_escape: don&apos;t escape "unreserved" characters
+ BGF curl_easy_escape: don&#39;t escape "unreserved" characters
  BGF SFTP: avoid downloading negative sizes
  BGF Lots of GSS/KRB FTP fixes
  BGF TFTP: Work around tftpd-hpa upload bug
@@ -5974,12 +5974,12 @@ SUBTITLE(Fixed in 7.21.1 - August 11 2010)
  BGF ftp wildcard: FTP LIST parser FIX
  BGF urlglobbing backslash escaping bug
  BGF build: add enable IPV6 option for the VC makefiles
- BGF multi: CURLINFO_LASTSOCKET doesn&apos;t work after remove_handle
+ BGF multi: CURLINFO_LASTSOCKET doesn&#39;t work after remove_handle
  BGF --libcurl: use *_LARGE options with typecasted constants
  BGF --libcurl: hide setopt() calls setting default options
  BGF curl: avoid setting libcurl options to its default
  BGF --libcurl: list the tricky options instead of using [REMARK]
- BGF http: don&apos;t enable chunked during authentication negotiations
+ BGF http: don&#39;t enable chunked during authentication negotiations
  BGF upload: warn users trying to upload from stdin with anyauth
  BGF configure: allow environments variable to override internals
  BGF threaded resolver: fix timeout issue
@@ -5989,7 +5989,7 @@ SUBTITLE(Fixed in 7.21.1 - August 11 2010)
  BGF ssh: Fix compile error on 64-bit systems.
  BGF remote-header-name: chop filename at next semicolon
  BGF ftp: response timeout bug in "quote" sending
- BGF CUSTOMREQUEST: shouldn&apos;t be disabled when HTTP is disabled
+ BGF CUSTOMREQUEST: shouldn&#39;t be disabled when HTTP is disabled
  BGF Watcom makefiles overhaul.
  BGF NTLM tests: boost coverage by forcing the hostname
  BGF multi: fix FTPS connecting the data connection with OpenSSL
@@ -6022,7 +6022,7 @@ SUBTITLE(Fixed in 7.21.0 - June 16 2010)
 <ul class="bugfixes">
  BGF prevent needless reverse name lookups
  BGF detect GSS on ancient Linux distros
- BGF GnuTLS: EOF caused error when it wasn&apos;t
+ BGF GnuTLS: EOF caused error when it wasn&#39;t
  BGF GnuTLS: SSL handshake phase is non-blocking
  BGF -J/--remote-header-name strips CRLF
  BGF MSVC makefiles now use ws2_32.lib instead of wsock32.lib
@@ -6043,7 +6043,7 @@ SUBTITLE(Fixed in 7.21.0 - June 16 2010)
 SUBTITLE(Fixed in 7.20.1 - April 14 2010)
 <p> Changes:
 <ul class="changes">
- CHG The &apos;ares&apos; subtree has been removed from the source repository
+ CHG The &#39;ares&#39; subtree has been removed from the source repository
  CHG smoother rate limiting
  CHG allow user+password in the URL for all protocols
  CHG POP3: Get message listing if no mailbox in URL
@@ -6079,7 +6079,7 @@ SUBTITLE(Fixed in 7.20.1 - April 14 2010)
  BGF RTSP GET_PARAMETER
  BGF timeout after last data chunk was handled
  BGF SFTP download hang
- BGF FTP quote commands prefixed with &apos;*&apos; now can fail without aborting
+ BGF FTP quote commands prefixed with &#39;*&#39; now can fail without aborting
 </ul>
 
 <a name="7_20_0"></a>
@@ -6106,13 +6106,13 @@ contains security-related bug fix" border="0"></a>
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF progress meter percentage and transfer time estimates fixes
- BGF portability enhancement for OS&apos;s without orthogonal directory tree structure
+ BGF portability enhancement for OS&#39;s without orthogonal directory tree structure
  BGF progress meter/callback during FTP connection
  BGF DNS cache timeout while transfer in progress
  BGF compilation when configured --with-gssapi having GNU GSS installed
  BGF SSL connection reused with mismatched protection level
  BGF configure --with-nss is set but not "yes"
- BGF don&apos;t store LDFLAGS in pkg-config file
+ BGF don&#39;t store LDFLAGS in pkg-config file
  BGF never-pruned DNS cached entries
  BGF HTTP proxy tunnel re-used connection even if tunnel got disabled
  BGF SSL lib post-close write
@@ -6120,8 +6120,8 @@ contains security-related bug fix" border="0"></a>
  BGF TFTP BLKSIZE
  BGF Expect: 100-continue handling when set by the application
  BGF multi interface with OpenSSL read already freed memory when closing down
- BGF --retry didn&apos;t do right for FTP transient errors
- BGF some *_proxy environment variables didn&apos;t function
+ BGF --retry didn&#39;t do right for FTP transient errors
+ BGF some *_proxy environment variables didn&#39;t function
  BGF libcurl-OpenSSL engine cleanup
  BGF header include fix for FreeBSD versions before v8
  BGF fragment part of URLs are no longer sent to the server
@@ -6151,7 +6151,7 @@ SUBTITLE(Fixed in 7.19.7 - November 4 2009)
  BGF libcurl-NSS acknowledges verifyhost
  BGF SIGSEGV when pipelined pipe unexpectedly breaks
  BGF data corruption issue with re-connected transfers
- BGF use after free if we&apos;re completed but easy_conn not NULL (pipelined)
+ BGF use after free if we&#39;re completed but easy_conn not NULL (pipelined)
  BGF missing strdup() return code check
  BGF CURLOPT_PROXY_TRANSFER_MODE could pass along wrong syntax
  BGF configure --with-gnutls=PATH fixed
@@ -6165,7 +6165,7 @@ SUBTITLE(Fixed in 7.19.7 - November 4 2009)
  BGF libcurl-OpenSSL can load CRL files with more than one certificate inside
  BGF received cookies without explicit path got saved wrong if the URL had a
    query part
- BGF don&apos;t shrink SO_SNDBUF on windows for those who have it set large already
+ BGF don&#39;t shrink SO_SNDBUF on windows for those who have it set large already
  BGF connect next bug
  BGF invalid file name characters handling on Windows
  BGF double close() on the primary socket with libcurl-NSS
@@ -6186,7 +6186,7 @@ align="right" title="Release contains security-related bug fix" alt="Release
 contains security-related bug fix" border="0"></a>
 <p> Changes:
 <ul class="changes">
- CHG CURLOPT_FTPPORT (and curl&apos;s -P/--ftpport) support port ranges
+ CHG CURLOPT_FTPPORT (and curl&#39;s -P/--ftpport) support port ranges
  CHG Added CURLOPT_SSH_KNOWNHOSTS, CURLOPT_SSH_KEYFUNCTION, CURLOPT_SSH_KEYDATA
  CHG CURLOPT_QUOTE, CURLOPT_POSTQUOTE and CURLOPT_PREQUOTE can be told to ignore
    error responses when used with FTP
@@ -6218,9 +6218,9 @@ contains security-related bug fix" border="0"></a>
  BGF with noproxy set you could still get a proxy if a proxy env was set
  BGF rand seeding on libcurl on windows built with OpenSSL was not thread-safe
  BGF fixed the zero byte inserted in cert name flaw in libcurl+OpenSSL
- BGF don&apos;t try SNI with SSLv2 or SSLv3 (OpenSSL and GnuTLS builds)
+ BGF don&#39;t try SNI with SSLv2 or SSLv3 (OpenSSL and GnuTLS builds)
  BGF libcurl+OpenSSL would wrongly acknowledge a cert if CN matched but
-   subjectAltName didn&apos;t
+   subjectAltName didn&#39;t
  BGF TFTP upload sent illegal TSIZE packets
 </ul>
 
@@ -6230,7 +6230,7 @@ SUBTITLE(Fixed in 7.19.5 - May 18 2009)
 <ul class="changes">
  CHG libcurl now closes all dead connections whenever you attempt to open a new
    connection
- CHG libssh2&apos;s version number can now be figured out run-time instead of using
+ CHG libssh2&#39;s version number can now be figured out run-time instead of using
    the build-time fixed number
  CHG CURLOPT_SEEKFUNCTION may now return CURL_SEEKFUNC_CANTSEEK
  CHG curl can now upload with resume even when reading from a pipe
@@ -6240,7 +6240,7 @@ SUBTITLE(Fixed in 7.19.5 - May 18 2009)
 <ul class="bugfixes">
  BGF NTLM authentication memory leak on SSPI enabled Windows builds
  BGF fixed the GnuTLS-using code to do correct return code checks
- BGF an alloc-related call in the OpenSSL-using code didn&apos;t check the return value
+ BGF an alloc-related call in the OpenSSL-using code didn&#39;t check the return value
  BGF curl_easy_duphandle() failed to duplicate cookies at times
  BGF missing TELNET timeout support in Windows builds
  BGF missing Curl_read() and write callback result checking in TELNET transfers
@@ -6328,7 +6328,7 @@ SUBTITLE(Fixed in 7.19.3 - January 19 2009)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF build failure when disabling FTP but enabling GSS
- BGF fixed several calls to memory functions that didn&apos;t check return codes
+ BGF fixed several calls to memory functions that didn&#39;t check return codes
  BGF memory leak for SSL connects with libcurl/NSS when CURLOPT_ISSUERCERT was
    used
  BGF re-use of connections with the multi interface when multiple handles used
@@ -6342,13 +6342,13 @@ SUBTITLE(Fixed in 7.19.3 - January 19 2009)
  BGF 550 response from SIZE no longer treated as missing file
  BGF ftps:// control connections now use explicit protection level
  BGF dotted IPv6 addresses longer than 39 bytes failed
- BGF curl_easy_duphandle() doesn&apos;t try to duplicate the connection cache pointer
+ BGF curl_easy_duphandle() doesn&#39;t try to duplicate the connection cache pointer
  BGF build failure on OS/400 when enabling IPv6
  BGF better detection of SFTP failures
  BGF improved connection re-use for subsequent SCP and SFTP transfers
  BGF multi interface does less busy-loops for SCP and SFTP transfers with libssh2
    1.0 or later
- BGF curl_multi_timeout() no longer returns timeout 0 when there&apos;s still more
+ BGF curl_multi_timeout() no longer returns timeout 0 when there&#39;s still more
    than 0 but less than 999 microseconds left
  BGF the multi_socket API and HTTP pipelining now work a lot better when combined
  BGF SFTP seek/resume beyond 32bit file sizes
@@ -6381,7 +6381,7 @@ SUBTITLE(Fixed in 7.19.1 - November 5 2008)
  CHG pkg-config can now show supported_protocols and supported_features
  CHG Added CURLOPT_CERTINFO and CURLINFO_CERTINFO
  CHG Added CURLOPT_POSTREDIR
- CHG Better detect HTTP 1.0 servers and don&apos;t do HTTP 1.1 requests on them
+ CHG Better detect HTTP 1.0 servers and don&#39;t do HTTP 1.1 requests on them
  CHG configure --disable-proxy disables proxy support
  CHG Added CURLOPT_USERNAME and CURLOPT_PASSWORD
  CHG --interface now works with IPv6 connections on glibc systems
@@ -6402,7 +6402,7 @@ SUBTITLE(Fixed in 7.19.1 - November 5 2008)
  BGF thread-safety issues addressed for NSS-powered libcurls
  BGF removed the use of mktime() and gmtime(_r)() in date parsing and conversions
  BGF HTTP Digest with a blank realm did wrong
- BGF CURLINFO_REDIRECT_URL didn&apos;t work with the multi interface
+ BGF CURLINFO_REDIRECT_URL didn&#39;t work with the multi interface
  BGF CURLOPT_RANGE now works for SFTP downloads
  BGF FTP SIZE response 550 now causes CURLE_REMOTE_FILE_NOT_FOUND
  BGF CURLINFO_PRIMARY_IP fixed for persistent connection re-use cases
@@ -6425,12 +6425,12 @@ SUBTITLE(Fixed in 7.19.0 - September 1 2008)
  CHG Added CURLINFO_PRIMARY_IP
  CHG Added CURLOPT_CRLFILE and CURLE_SSL_CRL_BADFILE
  CHG Added CURLOPT_ISSUERCERT and CURLE_SSL_ISSUER_ERROR
- CHG curl&apos;s option parser for boolean options reworked
+ CHG curl&#39;s option parser for boolean options reworked
  CHG Added --remote-name-all
  CHG Now builds for the INTEGRITY operating system
  CHG Added CURLINFO_APPCONNECT_TIME
  CHG Added test selection by key word in runtests.pl
- CHG the curl tool&apos;s -w option support the %{ssl_verify_result} variable
+ CHG the curl tool&#39;s -w option support the %{ssl_verify_result} variable
  CHG Added CURLOPT_ADDRESS_SCOPE and scope parsing of the URL according to RFC4007
  CHG Support --append on SFTP uploads (not with OpenSSH, though)
  CHG Added curlbuild.h and curlrules.h to the external library interface
@@ -6493,7 +6493,7 @@ SUBTITLE(Fixed in 7.18.2 - June 4 2008)
  BGF curl_easy_reset() resets the max redirect limit properly
  BGF configure now correctly recognizes Heimdal and MIT gssapi libraries
  BGF malloc() failure check in Negotiate
- BGF -i and -I together now work the same no matter what order they&apos;re used
+ BGF -i and -I together now work the same no matter what order they&#39;re used
  BGF the typechecker can be bypassed by defining CURL_DISABLE_TYPECHECK
  BGF a pointer mixup could make the FTP code send bad user+password under rare
    circumstances (found when using curlftpfs)
@@ -6518,7 +6518,7 @@ SUBTITLE(Fixed in 7.18.1 - March 30 2008)
 <p> Changes:
 <ul class="changes">
  CHG added support for HttpOnly cookies
- CHG &apos;make ca-bundle&apos; downloads and generates an updated ca bundle file
+ CHG &#39;make ca-bundle&#39; downloads and generates an updated ca bundle file
  CHG we no longer distribute or install a ca cert bundle
  CHG SSLv2 is now disabled by default for SSL operations
  CHG the test509-style setting URL in callback is officially no longer supported
@@ -6588,7 +6588,7 @@ SUBTITLE(Fixed in 7.18.0 - January 28 2008)
  BGF SFTP and SCP use persistent connections
  BGF segfault on bad URL
  BGF variable wrapping when using absolutely huge send buffer sizes
- BGF variable wrapping when using debug callback and the HTTP request wasn&apos;t sent
+ BGF variable wrapping when using debug callback and the HTTP request wasn&#39;t sent
    in one go
  BGF SSL connections with NSS done with the multi-interface
  BGF setting a share no longer activates cookies
@@ -6655,7 +6655,7 @@ SUBTITLE(Fixed in 7.17.1 - October 29 2007)
  BGF misuse of ares_timeout() result
  BGF --local-port on TFTP transfers
  BGF CURLOPT_POSTFIELDS could fail to send binary data
- BGF specifying a proxy with a trailing slash didn&apos;t work (unless it also
+ BGF specifying a proxy with a trailing slash didn&#39;t work (unless it also
    contained a port number)
  BGF redirect from HTTP to FTP or TFTP memory problems and leaks
  BGF re-used connections a bit too much when using non-SSL protocols tunneled
@@ -6685,13 +6685,13 @@ SUBTITLE(Fixed in 7.17.0 - September 13 2007)
 <ul class="bugfixes">
  BGF test cases 31, 46, 61, 506, 517 now work in time zones that use leap seconds
  BGF problem with closed proxy connection during HTTP CONNECT auth negotiation
- BGF transfer-encoding skipping didn&apos;t ignore the 407 response bodies properly
+ BGF transfer-encoding skipping didn&#39;t ignore the 407 response bodies properly
  BGF CURLOPT_SSL_VERIFYHOST set to 1
  BGF CONNECT endless loop
  BGF krb5 support builds with Heimdal
  BGF added returned error string for connection refused case
  BGF re-use of dead FTP control connections
- BGF login to FTP servers that don&apos;t require (nor understand) PASS after the
+ BGF login to FTP servers that don&#39;t require (nor understand) PASS after the
    USER command
  BGF bad free of memory from libssh2
  BGF the SFTP PWD command works
@@ -6824,7 +6824,7 @@ SUBTITLE(Fixed in 7.16.2 - April 11 2007)
  BGF curl_multi_remove_handle() rare crash
  BGF passive FTP transfers work with SOCKS
  BGF multi interface HTTPS connection re-use memory leak
- BGF libcurl.m4&apos;s --with-libcurl is improved
+ BGF libcurl.m4&#39;s --with-libcurl is improved
  BGF curl-config --libs and libcurl.pc no longer list unnecessary dependencies
  BGF fixed an issue with CCC not working on some servers
  BGF several HTTP pipelining problems
@@ -6859,13 +6859,13 @@ SUBTITLE(Fixed in 7.16.1 - January 29 2007)
  BGF multiple TFTP transfers on the same (easy or multi) handle could cause a
    crash
  BGF SIGSEGV when disconnecting on a transfer on a re-used handle when the
-   host name didn&apos;t resolve
+   host name didn&#39;t resolve
  BGF stack overwrite on 64bit Windows in the chunked decoding department
  BGF HTTP responses on persistent connections without Content-Length nor chunked
    encoding are now considered to be without response body
  BGF Content-Range: header parsing improved
  BGF CPU 100% load when HTTP upload connection broke
- BGF active FTP didn&apos;t work with multi interface
+ BGF active FTP didn&#39;t work with multi interface
  BGF curl_getdate() could be off one hour for TZ time zones with DST, on windows
  BGF CURLOPT_FORBID_REUSE works again
  BGF CURLOPT_MAXCONNECTS set to zero caused libcurl to SIGSEGV
@@ -6875,7 +6875,7 @@ SUBTITLE(Fixed in 7.16.1 - January 29 2007)
  BGF no more SIGPIPE when GnuTLS is used
  BGF FTP downloading 2 zero byte files in a row
  BGF using proxy and URLs without protocol prefixes
- BGF first using a proxy and then accessing a site that &apos;no_proxy&apos; matched,
+ BGF first using a proxy and then accessing a site that &#39;no_proxy&#39; matched,
    would still make libcurl use the proxy...
  BGF curl_easy_duphandle() now makes a handle that is valid for the multi
    interface since the magic number is set fine
@@ -6930,9 +6930,9 @@ SUBTITLE(Fixed in 7.16.0 - October 30 2006)
  BGF SOCKS5 proxy connects can now time-out
  BGF SOCKS5 connects that require auth no longer segfaults when auth not given
  BGF multi interface using asynch resolves could get stuck in wrong state
- BGF the &apos;running_handles&apos; counter wasn&apos;t always updated properly when
+ BGF the &#39;running_handles&#39; counter wasn&#39;t always updated properly when
    curl_multi_remove_handle() was used
- BGF (FTP) EPRT transfers with IPv6 didn&apos;t work properly
+ BGF (FTP) EPRT transfers with IPv6 didn&#39;t work properly
  BGF (FTP) SINGLECWD mode and using files in the root dir
  BGF (HTTP) Expect: header disabling work better
  BGF (HTTP) "Expect: 100-continue" disable on second POST on re-used connection
@@ -6954,7 +6954,7 @@ SUBTITLE(Fixed in 7.15.5 - August 7 2006)
  CHG added curl_formget()
  CHG added CURLOPT_MAX_SEND_SPEED_LARGE and CURLOPT_MAX_RECV_SPEED_LARGE
  CHG added configure --enable-hidden-symbols
- CHG Made -K on a file that couldn&apos;t be read cause a warning to be displayed
+ CHG Made -K on a file that couldn&#39;t be read cause a warning to be displayed
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -6966,7 +6966,7 @@ SUBTITLE(Fixed in 7.15.5 - August 7 2006)
  BGF FTP ASCII CRLF counter reset
  BGF cookie parser now compares paths case sensitive
  BGF an easy handle with shared DNS cache added to a multi handle caused a crash
- BGF couldn&apos;t override the Proxy-Connection: header for non-CONNECT requests
+ BGF couldn&#39;t override the Proxy-Connection: header for non-CONNECT requests
  BGF curl_multi_fdset() could wrongly return -1 as max_fd value
 </ul>
 
@@ -6980,7 +6980,7 @@ SUBTITLE(Fixed in 7.15.4 - June 12 2006)
  CHG curl-config got a --checkfor option to compare version numbers
  CHG line end conversions for FTP ASCII transfers
  CHG curl_multi_socket() API added (still mostly untested)
- CHG conversion callback options for EBCDIC <=> ASCII conversions
+ CHG conversion callback options for EBCDIC &lt;=&gt; ASCII conversions
  CHG added CURLINFO_FTP_ENTRY_PATH
  CHG less blocking for the multi interface during (Open)SSL connect negotiation
 </ul>
@@ -7026,7 +7026,7 @@ align="right" alt="Release contains security-related bug fix" border="0"></a>
  BGF wrong error message shown when certificate verification failed
  BGF multi-part formpost with multi interface crash
  BGF the CURLFTPSSL_CONTROL setting for CURLOPT_FTP_SSL is acknowledged
- BGF "SSL: couldn&apos;t set callback" is now treated as a less serious problem
+ BGF "SSL: couldn&#39;t set callback" is now treated as a less serious problem
  BGF Interix build fix
  BGF fixed curl "hang" when out of file handles at start
  BGF prevent FTP uploads to URLs with trailing slash
@@ -7053,7 +7053,7 @@ SUBTITLE(Fixed in 7.15.2 - February 27 2006)
  BGF minor format string mistake in the GSS/Negotiate code
  BGF cached DNS entries could remain in the cache too long
  BGF improved GnuTLS check in configure
- BGF re-used FTP connections when the second request didn&apos;t do a transfer
+ BGF re-used FTP connections when the second request didn&#39;t do a transfer
  BGF plain --limit-rate [num] means bytes
  BGF re-creating a dead connection is no longer counted internally as a followed
    redirect and thus prevents a weird error that would occur if a FTP
@@ -7092,8 +7092,8 @@ SUBTITLE(Fixed in 7.15.1 - December 7 2005)
  BGF builds fine on DJGPP
  BGF CURLOPT_ERRORBUFFER is now always filled in on errors
  BGF curl outputs error on bad --limit-rate units
- BGF fixed libcurl&apos;s use of poll() on cygwin
- BGF the GnuTLS code didn&apos;t support client certificates
+ BGF fixed libcurl&#39;s use of poll() on cygwin
+ BGF the GnuTLS code didn&#39;t support client certificates
  BGF TFTP over IPv6 works
  BGF no reverse lookups on IP addresses when ipv6-enabled
  BGF SSPI compatibility fix: using the proper DLLs
@@ -7101,7 +7101,7 @@ SUBTITLE(Fixed in 7.15.1 - December 7 2005)
  BGF Windows uploads from stdin using curl can now contain ctrl-Z bytes
  BGF -r [num] would produce an invalid HTTP Range: header
  BGF multi interface with multi IP hosts could leak socket descriptors
- BGF the GnuTLS code didn&apos;t handle rehandshakes
+ BGF the GnuTLS code didn&#39;t handle rehandshakes
  BGF re-use of a dead FTP connection
  BGF name resolve error codes fixed for Windows builds
  BGF double WWW-Authenticate Digest headers are now handled
@@ -7149,8 +7149,8 @@ SUBTITLE(Fixed in 7.14.1 - September 1 2005)
  BGF CA cert verification with GnuTLS builds
  BGF handles expiry times in cookie files that go beyond 32 bits in size
  BGF several client problems with files, such as doing -d @file when the file
-   isn&apos;t readable now gets a warning displayed
- BGF write callback abort didn&apos;t always "take"
+   isn&#39;t readable now gets a warning displayed
+ BGF write callback abort didn&#39;t always "take"
  BGF the curl -z "bad syntax" warning is now hidden when -s is used
  BGF curl -d @nonexisting no longer makes a GET
  BGF minor debug callback data size
@@ -7170,7 +7170,7 @@ SUBTITLE(Fixed in 7.14.1 - September 1 2005)
  BGF better treatment of binary zeroes in HTTP response headers
  BGF fixed the notorious FTP server failure in the test suite
  BGF better checking of text output in the test suite on windows
- BGF FTP servers&apos; TYPE command response check made less strict
+ BGF FTP servers&#39; TYPE command response check made less strict
  BGF URL-without-slash as in http://example?data
  BGF strerror_r() configure check for HP-UX 10.20 (and others)
  BGF time parse work-around on HP-UX 10.20 since its gmtime_r() is broken
@@ -7183,7 +7183,7 @@ SUBTITLE(Fixed in 7.14.0 - May 16 2005)
  CHG modified default HTTP request headers
  CHG curl --trace-time added for time stamping trace logs
  CHG curl now respects the SSL_CERT_DIR and SSL_CERT_PATH environment variables
- CHG more search paths for curl&apos;s default .curlrc config file check
+ CHG more search paths for curl&#39;s default .curlrc config file check
  CHG GnuTLS support, use configure --with-gnutls. Work on this was sponsored
    by The Written Word.
 </ul>
@@ -7204,7 +7204,7 @@ SUBTITLE(Fixed in 7.14.0 - May 16 2005)
  BGF configure fix for static libcurl build on Windows
  BGF --retry-delay
  BGF POST with read callback now uses Expect: 100-continue
- BGF CURLOPT_PORT didn&apos;t actually use the set port number
+ BGF CURLOPT_PORT didn&#39;t actually use the set port number
  BGF HTTP 304 response with Content-Length: header
  BGF time-conditioned FTP uploads
 </ul>
@@ -7224,7 +7224,7 @@ SUBTITLE(Fixed in 7.13.2 - April 4 2005)
  BGF the MSVC libcurl Makefile was fixed
  BGF libcurl on Windows crash if resolver was active when easy handle was killed
  BGF HTTP POST with auth and an initial 100 response before the 401/407
- BGF configure&apos;s SSL-detection for msys/mingw
+ BGF configure&#39;s SSL-detection for msys/mingw
  BGF better connection keep-alive when POSTing with HTTP Digest
  BGF FTP-SSL
  BGF reading FTP server response in multiple reads
@@ -7275,7 +7275,7 @@ SUBTITLE(Fixed in 7.13.0 - February 1 2005)
  CHG added --3p-url, --3p-user and --3p-quote
  CHG -Q "+[command]" was added
  CHG src/getpass.c license issue sorted (code was rewritten)
- CHG curl -w now supports &apos;http_connect&apos; for the proxy&apos;s response to CONNECT
+ CHG curl -w now supports &#39;http_connect&#39; for the proxy&#39;s response to CONNECT
  CHG introducing "curl-config --protocols"
 </ul>
 <p> Bugfixes:
@@ -7377,7 +7377,7 @@ SUBTITLE(Fixed in 7.12.2 - October 18 2004)
  BGF libcurl error message is now provided when send() fails
  BGF no more SIGPIPE on Mac OS X and other SO_NOSIGPIPE-supporting platforms
  BGF HTTP resume was refused if redirected
- BGF configure&apos;s gethostbyname check when both nsl and socket libs are required
+ BGF configure&#39;s gethostbyname check when both nsl and socket libs are required
  BGF configure --with-libidn now checks the given path before defaults
  BGF a race condition sometimes resulting in CURLE_COULDNT_RESOLVE_HOST in the
    windows threaded name resolver code
@@ -7403,9 +7403,9 @@ SUBTITLE(Fixed in 7.12.2 - October 18 2004)
  BGF no reverse DNS lookups for ip-only addresses with ipv6-enabled libcurl
  BGF file handler leak when getting an empty file:// URL
  BGF libcurl works better multi-threaded on AIX (when built with xlc)
- BGF cookies over proxy didn&apos;t match the path properly
+ BGF cookies over proxy didn&#39;t match the path properly
  BGF MSVC makefile fixes to build better
- BGF FTP response 530 on &apos;PASS&apos; now sends back a better error message
+ BGF FTP response 530 on &#39;PASS&#39; now sends back a better error message
 </ul>
 <p>
 <a name="7_12_1"></a>
@@ -7413,7 +7413,7 @@ SUBTITLE(Fixed in 7.12.1 - August 10 2004)
 <p>Changes:
 <ul class="changes">
  CHG the version string now only contains info about (sub) package versions,
-   while for example krb4 and ipv6 now only are available as &apos;features&apos;
+   while for example krb4 and ipv6 now only are available as &#39;features&#39;
  CHG added curl_easy_reset()
  CHG socks proxy support even when libcurl is built ipv6-enabled
  CHG read callbacks can stop the transfer by returning CURL_READFUNC_ABORT
@@ -7447,7 +7447,7 @@ SUBTITLE(Fixed in 7.12.1 - August 10 2004)
  BGF HTTPS POST/PUT over a proxy requiring NTLM/Digest/Negotiate
  BGF less restrictive libidn requirements, 0.4.1 or later is fine
  BGF HTTP POST or PUT with Digest/Negotiate/NTLM selected but the server
-   didn&apos;t require any authentication
+   didn&#39;t require any authentication
  BGF win32 file:// transfer free memory bug
  BGF configure --disable-http builds a libcurl without HTTP support
  BGF CURLOPT_FILETIME had wrong type in curl.h, it expects a long argument
@@ -7541,7 +7541,7 @@ SUBTITLE(Fixed in 7.11.2 - April 26 2004)
  BGF the progress meter now displays very long times better
  BGF CURLINFO_CONTENT_LENGTH_DOWNLOAD with CURLOPT_NOBODY set TRUE now works
  BGF passwords longer than 14 letters work with NTLM
- BGF &apos;make netware&apos; in the root dir works now
+ BGF &#39;make netware&#39; in the root dir works now
  BGF builds fine on VMS again and even nicer than before
 </ul>
 
@@ -7580,14 +7580,14 @@ SUBTITLE(Fixed in 7.11.1 - March 19 2004)
  BGF --limit-rate no longer cripples the --speed-limit feature
  BGF fixed verbose output problem with ipv6-enabled re-used connections
  BGF fixed the socks5 code to check version in the socks response properly
- BGF dns cache bug - fixed the &apos;inuse&apos; counter
+ BGF dns cache bug - fixed the &#39;inuse&#39; counter
  BGF large file fix for Content-Length
  BGF better docs for the share interface
  BGF several configure fixes for mingw/msys
  BGF setting a Host: header is no longer affecting the Host: header used when
    libcurl follows a Location:
  BGF fixed numerous compiler warnings on several operating systems and compilers
- BGF PUTting from stdin couldn&apos;t disable chunked transfer-encoding
+ BGF PUTting from stdin couldn&#39;t disable chunked transfer-encoding
  BGF corrected the mingw makefiles
  BGF improved the configure libz detection
  BGF fixed EPRT/PORT use when doing FTP on ipv6-enabled AIX hosts
@@ -7617,7 +7617,7 @@ SUBTITLE(Fixed in 7.11.0 - January 22 2004)
    tool now features the --ftp-ssl option)
  CHG The Windows DLLs are built with an added "resource file"
  CHG New LIBCURL_VERSION_* defines for easier checking version number
- CHG Included Mac OS X &apos;framework&apos; makefile in the release archive
+ CHG Included Mac OS X &#39;framework&#39; makefile in the release archive
  CHG Removed the TRUE and FALSE #defines from the public curl header file
  CHG Added CURLOPT_NETRC_FILE
 </ul>
@@ -7637,7 +7637,7 @@ SUBTITLE(Fixed in 7.11.0 - January 22 2004)
  BGF configure --enable-ares now accepts a given path
  BGF -lz no longer appear twice on the link line
  BGF more descriptive error message if the FTP response reader fails
- BGF curl-config --feature now shows &apos;AsynchDNS&apos; when built with ares
+ BGF curl-config --feature now shows &#39;AsynchDNS&#39; when built with ares
  BGF VMS build up-to-date and clarified source code
  BGF resolve bug caused socks5 to fail
  BGF Content-Length: is ignored when getting chunked Transfer-Encoding
@@ -7656,7 +7656,7 @@ SUBTITLE(Fixed in 7.11.0 - January 22 2004)
  BGF The generated ca-bundle.h file is now generated in the build dir, not the
    source dir
  BGF The FTP-EPSV response parser for the 229 code was fixed
- BGF curl finds the user&apos;s home dir slightly different and hopefully better on
+ BGF curl finds the user&#39;s home dir slightly different and hopefully better on
    Windows
  BGF testcurl.sh can now be used to autotest daily tarballs
  BGF a couple of command line options now check that the underlying library
@@ -7719,12 +7719,12 @@ SUBTITLE(Fixed in 7.10.8 - November 1 2003)
  BGF asynch resolves now work on NT4 too
  BGF a DNS cache trash (possible segfault) was fixed
  BGF runtests.pl clears all proxy environment variables before the test is run
- BGF Microsoft&apos;s "Negotiate" authentication is now supported by the existing
+ BGF Microsoft&#39;s "Negotiate" authentication is now supported by the existing
    GSSNEGOTIATE option
  BGF A set zero-length proxy name confused libcurl
  BGF Digest authentication works again without OpenSSL on 64bit architectures
  BGF configure --enable-thread works now
- BGF buffer problems in the test suite&apos;s web server were fixed
+ BGF buffer problems in the test suite&#39;s web server were fixed
  BGF improved proxy password handling
  BGF LDAP is again working nicely with the current OpenLDAP
  BGF asynch name lookup for non-resolving hosts now return a proper error message
@@ -7756,7 +7756,7 @@ SUBTITLE(Fixed in 7.10.7 - August 15 2003)
  BGF cookies with no contents are sent off too now
  BGF 64bit-related bugfix for uploads
  BGF file:// URLs with drive letters now work on windows and OS/2
- BGF The output numbering (#[num]) on url globbing didn&apos;t work due to a bug
+ BGF The output numbering (#[num]) on url globbing didn&#39;t work due to a bug
    in curl_msprintf()
  BGF FTP persitent download directory re-use problem fixed
  BGF cookie parser now only requires two dots in cookie domain
@@ -7795,7 +7795,7 @@ SUBTITLE(Fixed in 7.10.6 - July 28 2003)
  BGF double slash after the host name on a FTP URL again points out the root dir
  BGF obscure and rare DNS cache problem was fixed
  BGF multiple FTP connections to the same host with different user names
-      didn&apos;t work properly
+      didn&#39;t work properly
  BGF no more CWD commands without arguments for ftp connections
  BGF curl no longer uses setvbuf() due to portability problems
  BGF VMS build fixes
@@ -7847,7 +7847,7 @@ SUBTITLE(Fixed in 7.10.5 - May 19 2003)
  BGF libcurl now returns CURLE_SSL_CACERT on CA cert problems
  BGF chunked-transfer deflate downloads work
  BGF FTP-server responses to CWD are now more liberally treated
- BGF fixed url parsing when &apos;?&apos; is used after the host name without &apos;/&apos;.
+ BGF fixed url parsing when &#39;?&#39; is used after the host name without &#39;/&#39;.
  BGF curl -I on ftp files outputs the date with correct time zone (GMT)
  BGF curl -z now works for FTP files (CURLOPT_TIMECONDITION)
  BGF the default DEBUGFUNCTION outputs incoming headers as well
@@ -7888,27 +7888,27 @@ SUBTITLE(Fixed in 7.10.4 - April 2 2003)
  BGF data transfer bug on HP-UX systems
  BGF improved random seeding for systems without a reliable random source
  BGF 64bit Sparc compiler warnings removed
- BGF a case where a connect failure didn&apos;t return an error string
+ BGF a case where a connect failure didn&#39;t return an error string
  BGF DNS cache problem in AIX 4.3 and later was fixed
  BGF a POST-then-GET problem when re-using the same handle in libcurl
  BGF extra precaution added for FTP servers returning 0 bytes to SIZE commands
  BGF looping issue in the receive function (i.e badly updated progress meter)
- BGF Fixed the &apos;Expect: 100-continue&apos; behavior
+ BGF Fixed the &#39;Expect: 100-continue&#39; behavior
  BGF CURLOPT_MAXCONNECTS segfault fixed
  BGF multi-interface connecting on Windows to non-listening ports fixed
  BGF Curl_base64_encode() now encodes zero-bytes too properly
  BGF fixed the infamous SSL error:00000000 outputs
  BGF zlib build fix in the mingw makefile
- BGF don&apos;t check for ca cert env variable if --insecure is used
+ BGF don&#39;t check for ca cert env variable if --insecure is used
  BGF always use strict cert name check unless --insecure is used
  BGF content-type extracting fixed
  BGF DEBUGFUNCTION could be called with wrong arguments in uploads
  BGF ftp downloads could wrongly return CURLE_PARTIAL_FILE in some conditions
- BGF the fopen.c example code didn&apos;t work
+ BGF the fopen.c example code didn&#39;t work
  BGF content-type extracting memory leak fixed
  BGF curl/multi.h was fixed for C++ compiles
  BGF .netrc file scanning for names+passwored fixed
- BGF curl-config --cflags works even when include dirs isn&apos;t /usr/include
+ BGF curl-config --cflags works even when include dirs isn&#39;t /usr/include
  BGF CURLINFO_PRIVATE can return NULL properly
 </ul>
 
@@ -7959,8 +7959,8 @@ SUBTITLE(Fixed in 7.10.2 - November 18 2002)
  BGF name resolving failed with glibc 2.2.93
  BGF libtool build fix for -no-undefined
  BGF the follow location code could crash occasionally
- BGF multi interface and FOLLOWLOCATION didn&apos;t work properly
- BGF curl -j (CURLOPT_COOKIESESSION) didn&apos;t work properly
+ BGF multi interface and FOLLOWLOCATION didn&#39;t work properly
+ BGF curl -j (CURLOPT_COOKIESESSION) didn&#39;t work properly
  BGF config file parser could crash on the presence of CRLF newlines
  BGF downloading HTTP without headers sometimes corrupted the data
  BGF connecting to a bad port number with the multi interface did wrong
@@ -7991,7 +7991,7 @@ SUBTITLE(Fixed in 7.10 - October 1 2002)
  CHG added curl_version_info() for various runtime version info
  CHG added curl_free() that allows freeing data libcurl malloced()
  CHG CURLOPT_ENCODING added, supports decompression of compressed downloaded data
-   This is used with &apos;curl --compressed&apos;. This feature uses the libz library,
+   This is used with &#39;curl --compressed&#39;. This feature uses the libz library,
    if present.
  CHG MIT-licensed only, no dual-stuff. That is history. Old. Gone. Forgotten.
  CHG libcurl does peer certificate verification by default. This needs to be
@@ -8016,7 +8016,7 @@ SUBTITLE(Fixed in 7.10 - October 1 2002)
  BGF --silent is more silent when doing URL globbing fetches
  BGF *multi_perform() now returns control properly when waiting for connect
  BGF curl_formadd man page was corrected
- BGF curl_escape() and curl_unescape() no longer deals with &apos;+&apos;
+ BGF curl_escape() and curl_unescape() no longer deals with &#39;+&#39;
  BGF improved performance on persistent transfers on windows
  BGF no longer closes ftp connections unncessarily often
  BGF -N works again
@@ -8024,8 +8024,8 @@ SUBTITLE(Fixed in 7.10 - October 1 2002)
  BGF the internal password prompt now uses stderr instead of stdout
  BGF minor cookie parsing bug when no space came after the header colon
  BGF better #ifdef conditions in the global curl header files
- BGF the curl tool didn&apos;t allow POST of zero contents
- BGF literal RFC2732-style IPv6 addresses didn&apos;t work
+ BGF the curl tool didn&#39;t allow POST of zero contents
+ BGF literal RFC2732-style IPv6 addresses didn&#39;t work
 </ul>
 
 <a name="7_9_8"></a>
@@ -8075,8 +8075,8 @@ SUBTITLE(Fixed in 7.9.7 - May 10 2002)
  BGF multi interface transfers work better
  BGF multiple transfers reset download counters better in between
  BGF Pruning now prevents the DNS cache from growing out of proportions
- BGF no_proxy didn&apos;t work when URL contained port numbers
- BGF --interface didn&apos;t work for IPv6 enabled libcurls
+ BGF no_proxy didn&#39;t work when URL contained port numbers
+ BGF --interface didn&#39;t work for IPv6 enabled libcurls
  BGF the TIMECOND defines are now using CURL_ prefixes
  BGF Now uses less memory for name resolves on most operating systems
  BGF pack_hostent works with 64 bit pointers
@@ -8098,10 +8098,10 @@ SUBTITLE(Fixed in 7.9.6 - April 14 2002)
 <ul class="bugfixes">
  BGF libcurl skips preceding white spaces in cookie contents
  BGF CURLINFO_CONNECT_TIME is now set even when connect fails
- BGF -x didn&apos;t use the documented default port
+ BGF -x didn&#39;t use the documented default port
  BGF RISC OS version now offers --environment
  BGF HTTP/1.0 304-replies are dealt with better
- BGF .curlrc is read from current directory if HOME isn&apos;t set
+ BGF .curlrc is read from current directory if HOME isn&#39;t set
  BGF The include file curl/curl.h compiles on pre-ISO compilers
  BGF getting http headers-only could "hang" during 1 second extra
  BGF verbose passive ftp transfers on AIX could crash
@@ -8157,7 +8157,7 @@ SUBTITLE(Fixed in 7.9.4 - March 4 2002)
  BGF Improved the gethostbyname_r configure check for HP-UX 11.00
  BGF Bugfixed the DNS cache
  BGF Bugfixed SSL download (due to the non-blocking sockets)
- BGF Only seed SSL once for a program&apos;s life time
+ BGF Only seed SSL once for a program&#39;s life time
  BGF IPv4-only Linux machines could crash on name resolves
  BGF curl_getdate() is now fully reentrant
  BGF The header length counter is now reset in each curl_easy_perform()
@@ -8172,7 +8172,7 @@ SUBTITLE(Fixed in 7.9.3 - January 23 2002)
 <ul class="changes">
  CHG introduced a DNS lookup cache
  CHG OpenSSL ENGINE support (read CHANGES for full details)
- CHG CURLFORM_CONTENTHEADER let&apos;s you add headers in form posts
+ CHG CURLFORM_CONTENTHEADER let&#39;s you add headers in form posts
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -8227,7 +8227,7 @@ SUBTITLE(Fixed in 7.9.1 - November 4 2001)
 <ul class="changes">
  CHG CURLE_GOT_NOTHING is a new possible error code
  CHG -0/--http1.0 can now be used to set HTTP 1.0 operations
- CHG &apos;curl&apos; no longer uses curl_formparse()
+ CHG &#39;curl&#39; no longer uses curl_formparse()
  CHG non-blocking connects
 </ul>
 <p> Bugfixes:
@@ -8318,8 +8318,8 @@ SUBTITLE(Fixed in 7.8.1 - August 20 2001)
 SUBTITLE(Fixed in 7.8 - June 7 2001)
 <p> Changes:
 <ul class="changes">
- CHG &apos;curl-config --vernum&apos; shows version number as a hexadecimal number
- CHG libcurl&apos;s got two new functions (for global init/cleanup)
+ CHG &#39;curl-config --vernum&#39; shows version number as a hexadecimal number
+ CHG libcurl&#39;s got two new functions (for global init/cleanup)
 </ul>
 
 <p> Bugfixes:
@@ -8329,12 +8329,12 @@ SUBTITLE(Fixed in 7.8 - June 7 2001)
  BGF netscape/mozilla cookie file parser bugfix
  BGF everything is now built with autoconf 2.50, libtool 1.4 and automake
      1.4-p1
- BGF libcurl&apos;s own version of &apos;strlcat&apos; no longer pollutes the name space
+ BGF libcurl&#39;s own version of &#39;strlcat&#39; no longer pollutes the name space
  BGF libcurl now treats an already completed resumed download as a successful
       operation, and not as an error like before
  BGF https and ftps test cases added to the test suite (depend on stunnel)
  BGF better white space awareness when parsing HTTP headers
- BGF curl -I now plays ball even if the ftp server doesn&apos;t grok SIZE
+ BGF curl -I now plays ball even if the ftp server doesn&#39;t grok SIZE
  BGF corrected resumed transfers on re-used persistent connections
  BGF FTP PORT works again when libcurl is IPv6-enabled
  BGF corrected path usage when doing multiple FTP transfers
@@ -8345,7 +8345,7 @@ SUBTITLE(Fixed in 7.8 - June 7 2001)
 SUBTITLE(Fixed in 7.7.3 - May 4 2001)
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF we&apos;ve discovered that TELNET does not work under win32
+ BGF we&#39;ve discovered that TELNET does not work under win32
  BGF HTTP Content-Length: 0 works better
  BGF HTTP 304-replies are better treated
  BGF persistent connections with mixed chunked and non-chunked transfers
@@ -8358,7 +8358,7 @@ SUBTITLE(Fixed in 7.7.3 - May 4 2001)
 SUBTITLE(Fixed in 7.7.2 - April 22 2001)
 <p> Changes:
 <ul class="changes">
- CHG &apos;curl-config&apos; was added to help applications use libcurl
+ CHG &#39;curl-config&#39; was added to help applications use libcurl
  CHG A <a href="/libcurl/tcl/">Tcl interface</a> has been written
  CHG A <a href="/libcurl/java/">Java interface</a> has been written
  CHG A <a href="/libcurl/ruby/">Ruby interface</a> was announced
@@ -8390,7 +8390,7 @@ SUBTITLE(Fixed in 7.7.1 - April 3 2001)
  BGF curl could re-use connections a little too much
  BGF different treatment of HTTP error 302
  BGF following http redirects on persistent connections could reach the maxredirs amount accidentally
- BGF curl_escape() don&apos;t re-encode already encoded letters anymore
+ BGF curl_escape() don&#39;t re-encode already encoded letters anymore
 </ul>
 
 <a name="7_7"></a>
@@ -8424,7 +8424,7 @@ SUBTITLE(Fixed in 7.6.1 - February 9 2001)
  BGF Corrected the HTTP PUT resume
  BGF Better Location: and HTTP return code (3xx) treatment
  BGF Resumed transfer status is displayed in progress meter (though simple)
- BGF HTTP download resume again complains if Range isn&apos;t supported
+ BGF HTTP download resume again complains if Range isn&#39;t supported
 </ul>
 
 <a name="7_6"></a>
@@ -8437,11 +8437,11 @@ SUBTITLE(Fixed in 7.6 - January 26 2001)
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF fixed &apos;total time&apos; counter to be more accurate
+ BGF fixed &#39;total time&#39; counter to be more accurate
  BGF possible SSL-read problem fixed (which could make curl return empty HTML)
  BGF no length restrictions on URLs anywhere in the libcurl code
  BGF supports building outside the source-tree
- BGF includes make-target for &apos;automatic&apos; RPM package creation
+ BGF includes make-target for &#39;automatic&#39; RPM package creation
  BGF added multiple URL support on the command line
  BGF krb4-ftp fixed
  BGF massive symbol renaming of libcurl internals to decrease name pollution
@@ -8510,7 +8510,7 @@ SUBTITLE(Fixed in 7.4.2 - November 15 2000)
 <ul class="changes">
  CHG an initial attempt to make a test suite is included
  CHG binary/custom package information is added
- CHG possibility to verify the peer&apos;s certificate for HTTPS connections (libcurl)
+ CHG possibility to verify the peer&#39;s certificate for HTTPS connections (libcurl)
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -8521,7 +8521,7 @@ SUBTITLE(Fixed in 7.4.2 - November 15 2000)
  BGF ftp --head now sets type first, as some servers report different sizes for different types
  BGF ftp upload resume could hang if the whole file was already uploaded
  BGF another cookie parser fix
- BGF added possibility to replace the internal &apos;enter password&apos; function (libcurl)
+ BGF added possibility to replace the internal &#39;enter password&#39; function (libcurl)
  BGF encoded username/password in URL is now supported
  BGF username in http-URL bugfix
  BGF fixed the timers when location: headers were followed
@@ -8614,7 +8614,7 @@ SUBTITLE(Fixed in 7.1 - August 7 2000)
 <p> Changes:
 <ul class="changes">
  CHG CURLOPT_PROXYPORT added to curl_easy_setopt() in the lib
- CHG Now features an &apos;auto referer&apos; so that curl can set the "correct" referer
+ CHG Now features an &#39;auto referer&#39; so that curl can set the "correct" referer
      when following location:
  CHG removed CURLOPT_PROGRESSMODE from the lib
  CHG libcurl offers a progress meter callback
@@ -8623,9 +8623,9 @@ SUBTITLE(Fixed in 7.1 - August 7 2000)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF builds libcurl as a shared library with libtool
- BGF JavaWebServer&apos;s incorrect Content-Range headers are supported
+ BGF JavaWebServer&#39;s incorrect Content-Range headers are supported
  BGF localtime_r() is now used if available instead of localtime()
- BGF &apos;make install&apos; installs the include files properly
+ BGF &#39;make install&#39; installs the include files properly
  BGF Replacing an internal HTTP header with one that has no content removes the header
  BGF user+password is now restricted and sent only to the first host when
   Location: is followed to another host
@@ -8655,7 +8655,7 @@ SUBTITLE(Fixed in 7.1 - August 7 2000)
  BGF <b>Major</b> re-organisation of all library internals to allow for a new
      library interface.
  BGF A buffer overflow (with URLs larger than 4096 characters) was fixed
- BGF The FTP sessions are slightly modified and now they&apos;re using CWD to
+ BGF The FTP sessions are slightly modified and now they&#39;re using CWD to
      change to the directory where the operation is requested.
  BGF FTP URLs are now treated more like the RFC specifies (minor change)
  BGF now sends user agent string when talking ftp through a http proxy
@@ -8664,8 +8664,8 @@ SUBTITLE(Fixed in 7.1 - August 7 2000)
  BGF improved win32 headers for VC++ compiling
  BGF minor fix when using libcurl in a multi-threaded program
  BGF the OS/2 port was slightly adjusted
- BGF location following through a http proxy on a specified non-default port didn&apos;t work
- BGF location following to an absolute URL on a different port didn&apos;t work
+ BGF location following through a http proxy on a specified non-default port didn&#39;t work
+ BGF location following to an absolute URL on a different port didn&#39;t work
 </ul>
 
 <a name="6_5_2"></a>
@@ -8680,7 +8680,7 @@ SUBTITLE(Fixed in 6.5.1 - March 20 2000)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF curl_unescape() buffer overrun removed
- BGF -w &apos;http_code&apos; works!
+ BGF -w &#39;http_code&#39; works!
  BGF OS/2 port
  BGF adjusted to compile smoothly with MS VC++
  BGF -D/--dump-header now only writes the file when needed, and not before
@@ -8703,13 +8703,13 @@ SUBTITLE(Fixed in 6.5 - March 13 2000)
  BGF new progress meter to better show both upload and download
  BGF MacOS X port
  BGF upload and download now performs simultaneously in case of need. This will make posting of big forms that are "echoed back" to finally work.
- BGF the cookie parser shouldn&apos;t crash on empty cookie names, nor should it send empty cookies to the server anymore.
+ BGF the cookie parser shouldn&#39;t crash on empty cookie names, nor should it send empty cookies to the server anymore.
  BGF -b now supports both @[filename] and @- for stdin
  BGF unlimited line lengths in the config file
  BGF Compiles on sunos4 again
  BGF Corrected the removed possibility to chose the progress bar
  BGF Made the max display width with progress bar 79 when the COLUMNS variable
-      isn&apos;t set.
+      isn&#39;t set.
 </ul>
 
 <a name="6_4"></a>
@@ -8724,7 +8724,7 @@ SUBTITLE(Fixed in 6.4 - January 17 2000)
  BGF Getting files with URL syntax codes (%-stuff) from a ftp server was not dealt with nicely
  BGF -b corrupted the cookie header lines when they were read off a server
  BGF Cleaned up the interface between the lib and the curl tool.
- BGF Made the -X&apos;s long option change name to --request and now you can specify full request command for ftp listings (like "LIST -l").
+ BGF Made the -X&#39;s long option change name to --request and now you can specify full request command for ftp listings (like "LIST -l").
  BGF Improved the --stderr workings for win32.
  BGF BeOS port by Lars J. Aas!
 </ul>
@@ -8749,11 +8749,11 @@ SUBTITLE(Fixed in 6.3 - November 10 1999)
    in a netscape cookie file. This is useful when you want your script to
    better inherit the properties of your previous browser session.
  CHG -H/--header now is capable of replacing internal headers. If you add
-   a header that would&apos;ve been used internally, the added will be used instead.
+   a header that would&#39;ve been used internally, the added will be used instead.
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF -z (date-dependent HTTP fetches) now works better since we&apos;re doing a
+ BGF -z (date-dependent HTTP fetches) now works better since we&#39;re doing a
    date comparison in the client as well.
  BGF Corrected several mistakes in the man page.
  BGF -I now works for ftp-files too. It merely shows the file size now.
@@ -8772,7 +8772,7 @@ SUBTITLE(Fixed in 6.2 - October 21 1999)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF another bug in loction: following with proxies when the protocol part
-  isn&apos;t specified was fixed
+  isn&#39;t specified was fixed
  BGF fixed the lib Makefile to not include getpass twice when linking
  BGF removed core-dump due to bad free after download was complete in src/main.c
  BGF removed double text output when ftp-downloading
@@ -8784,7 +8784,7 @@ SUBTITLE(Fixed in 6.2 - October 21 1999)
 SUBTITLE(Fixed in 6.1 - October 17 1999)
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF zlib proved not to be as easy to add as I had anticipated. I&apos;ll keep
+ BGF zlib proved not to be as easy to add as I had anticipated. I&#39;ll keep
       it on hold for now.
  BGF moved the libcurl include files into a subdir named curl
  BGF #include zlib.h fixes
@@ -8826,8 +8826,8 @@ SUBTITLE(Fixed in 5.11 - August 25 1999)
  BGF Fixed a bug in the header-line realloc() system in download.c.
  BGF I added lib/file.[ch] to offer a first, simple, file:// support.
  BGF Made the release archives get a Makefile in the root dir
- BGF Another Location: bug. Curl didn&apos;t do proper relative locations if the
-   original URL had cgi-parameters that contained a slash. Nusu&apos;s page
+ BGF Another Location: bug. Curl didn&#39;t do proper relative locations if the
+   original URL had cgi-parameters that contained a slash. Nusu&#39;s page
    again.
  BGF Corrected the NO_PROXY usage. It is a list of substrings that if one of
    them matches the tail of the host name it should connect to, curl should
@@ -8836,7 +8836,7 @@ SUBTITLE(Fixed in 5.11 - August 25 1999)
    page.
  BGF Made cookies work a lot better. Setting the same cookie name several times
    used to add more cookies instead of replacing the former one which it
-   should&apos;ve.
+   should&#39;ve.
  BGF Brought new .spec files as well as a patch for configure.in that lets the
    configure script find the openssl files better, even when the include
    files are in /usr/include/openssl
@@ -8851,7 +8851,7 @@ SUBTITLE(Fixed in 5.10 - August 13 1999)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF SSL_CTX_set_default_passwd_cb() has been modified in the 0.9.4 version of
-   OpenSSL. Now why couldn&apos;t they simply add a *new* function instead of
+   OpenSSL. Now why couldn&#39;t they simply add a *new* function instead of
    modifying the parameters of an already existing function?
  BGF Made curl output the SSL version number get displayed properly with 0.9.4.
  BGF Added MingW32 (GCC-2.95) support under Win32. The INSTALL file was also
@@ -8876,13 +8876,13 @@ SUBTITLE(Fixed in 5.10 - August 13 1999)
    support.
  BGF David Sanderson reported that FORCE_ALLOCA_H or HAVE_ALLOCA_H must be
    defined for getdate.c to compile properly on HP-UX 11.0.
- BGF I finally got to understand Marcus Klein&apos;s ftp download resume problem,
+ BGF I finally got to understand Marcus Klein&#39;s ftp download resume problem,
    which turns out to be due to different outputs from different ftp
    servers.
  BGF Added text about file transfer resuming to README.curl.
  BGF It breaks with segfault when 1) curl is using .netrc to obtain
-   username/password (option &apos;-n&apos;), and 2) is auto-matically redirected to
-   another location (option &apos;-L&apos;).
+   username/password (option &#39;-n&#39;), and 2) is auto-matically redirected to
+   another location (option &#39;-L&#39;).
 </ul>
 
 <a name="5_9_1"></a>
@@ -8891,7 +8891,7 @@ SUBTITLE(Fixed in 5.9.1 - July 30 1999)
 <ul class="bugfixes">
  BGF Memory leak in the formdata functions. I added a FormFree() function that
    is now used and supposed to correct this flaw.
- BGF &apos;curl -L https://www.cwa.com.au/&apos; core dumps.  I managed to cure this by
+ BGF &#39;curl -L https://www.cwa.com.au/&#39; core dumps.  I managed to cure this by
    correcting the cleanup procedure.
  BGF Now supports longer URLs when following Location:
  BGF Fixed a problem in the upload/POST department: It turned out that http.c
@@ -8904,7 +8904,7 @@ SUBTITLE(Fixed in 5.9.1 - July 30 1999)
    follow location header outputs it will never show any html on location:
    pages. I have now made it look for >=400 codes if CONF_FOLLOWLOCATION is
    set.
- BGF &apos;struct slist&apos; is now renamed to &apos;struct curl_slist&apos;
+ BGF &#39;struct slist&#39; is now renamed to &#39;struct curl_slist&#39;
  BGF The latest OpenSSL package now have moved the standard include path. It is
    now in /usr/local/ssl/include/openssl and I have now modified the
    --enable-ssl option for the configure script to use that as the primary
@@ -8916,7 +8916,7 @@ SUBTITLE(Fixed in 5.9.1 - July 30 1999)
  BGF Rearranged. README is new, the old one is now README.curl and I added a
    README.libcurl
  BGF I also updated the INSTALL text.
- BGF curl didn&apos;t properly deal with form posting where the variable shouldn&apos;t
+ BGF curl didn&#39;t properly deal with form posting where the variable shouldn&#39;t
    have any content, as in curl -F "form=" www.site.com. It was now fixed.
 </ul>
 
@@ -8932,15 +8932,15 @@ SUBTITLE(Fixed in 5.9 - May 22 1999)
  BGF Problems with -L under FreeBSD 3.0. I made the allocation of the new url
    string a bit faster and different
  BGF Made the cookie parser deal with CRLF newlines too.
- BGF Download() didn&apos;t properly deal with failing return codes from the
+ BGF Download() didn&#39;t properly deal with failing return codes from the
    sread() function
- BGF --dump-header didn&apos;t work anymore!
+ BGF --dump-header didn&#39;t work anymore!
  BGF I moved the code concerning HTTP, DICT and TELNET it their own source
    files
  BGF Made it compile on cygwin too.
  BGF Made curl compile smoothly on MSVC++ 6 again!
  BGF Changed the #ifdef HAVE_STRFTIME placement for the -z code so that it will
-   be easier to discover systems that don&apos;t have that function and thus can&apos;t
+   be easier to discover systems that don&#39;t have that function and thus can&#39;t
    use -z successfully. Made the strftime() get used if WIN32 is defined too.
 </ul>
 
@@ -8948,7 +8948,7 @@ SUBTITLE(Fixed in 5.9 - May 22 1999)
 SUBTITLE(Fixed in 5.8 - May 5 1999)
 <p> Changes:
 <ul class="changes">
- CHG curl can now send "If-Modified-Since" headers. Try -z <expression> where
+ CHG curl can now send "If-Modified-Since" headers. Try -z &lt;expression&gt; where
    expression is a full GNU date expression or a file name to get the date
    from!
 </ul>
@@ -8956,11 +8956,11 @@ SUBTITLE(Fixed in 5.8 - May 5 1999)
 <ul class="bugfixes">
  BGF mkhelp.pl has been doing badly lately. I corrected a case problem in
    the regexes.
- BGF I&apos;ve now remade the -o option to not touch the file unless it needs to.
+ BGF I&#39;ve now remade the -o option to not touch the file unless it needs to.
  BGF Corrected a bug in the SSLv2/v3 selection.
- BGF Problem with the src/Makefile for FreeBSD. The RM variable isn&apos;t set and
+ BGF Problem with the src/Makefile for FreeBSD. The RM variable isn&#39;t set and
    causes the make to fail.
- BGF The curl version number was not set properly. Hasn&apos;t been since 5.6. This
+ BGF The curl version number was not set properly. Hasn&#39;t been since 5.6. This
    was due to a bug in my maketgz script!
  BGF Found a bug in cookies.c that made it crash at times.
 </ul>
@@ -8974,14 +8974,14 @@ SUBTITLE(Fixed in 5.7.1 - April 23 1999)
    INSTALL file.
  BGF New mailing list address. Info updated on the web page as well as in the
    README file
- BGF hostip.c didn&apos;t compile properly on SunOS 5.5.1. It needs an #include <sys/types.h>
+ BGF hostip.c didn&#39;t compile properly on SunOS 5.5.1. It needs an #include &lt;sys/types.h&gt;
 </ul>
 
 <a name="5_7"></a>
 SUBTITLE(Fixed in 5.7 - April 20 1999)
 <ul class="changes">
- CHG I&apos;ve separated the version number of libcurl and curl now.
- CHG Removed the &apos;enable-no-pass&apos; from configure, I doubt anyone wanted
+ CHG I&#39;ve separated the version number of libcurl and curl now.
+ CHG Removed the &#39;enable-no-pass&#39; from configure, I doubt anyone wanted
    that.
  CHG -D or --dump-header is now storing HTTP headers separately in the specified
    file.
@@ -8992,20 +8992,20 @@ SUBTITLE(Fixed in 5.7 - April 20 1999)
    simply enlarged every time it turns out to be too small!
  BGF Added the FAQ file to the archive. Still a bit smallish, but it is a
    start.
- BGF Made -D accept &apos;-&apos; instead of filename to write to stdout.
- BGF Changed two #ifdef WIN32 to better #ifdef <errorcode> when connect()ing
+ BGF Made -D accept &#39;-&#39; instead of filename to write to stdout.
+ BGF Changed two #ifdef WIN32 to better #ifdef &lt;errorcode&gt; when connect()ing
    in url.c and ftp.c. Makes cygwin32 deal with them better too.
  BGF The old -3/--crlf option is now ONLY --crlf!
- BGF I changed the "SSL fix" to a more lame one, but that doesn&apos;t remove as
-   much functionality. Now I&apos;ve enabled the lib to select what SSL version it
+ BGF I changed the "SSL fix" to a more lame one, but that doesn&#39;t remove as
+   much functionality. Now I&#39;ve enabled the lib to select what SSL version it
    should try first.
  BGF Corrected the math for the "Curr.Speed" progress meter.
- BGF Made &apos;-K -&apos; read a config file from stdin.
- BGF I found out we didn&apos;t close the file properly before so I added it!
- BGF FTP download resume didn&apos;t work at all!
+ BGF Made &#39;-K -&#39; read a config file from stdin.
+ BGF I found out we didn&#39;t close the file properly before so I added it!
+ BGF FTP download resume didn&#39;t work at all!
  BGF Corrected the version string part generated for the SSL version.
  BGF I found a way to make some other SSL page work with openssl 0.9.1+ that
-   previously didn&apos;t (ssleay 0.8.0 works with it though!).
+   previously didn&#39;t (ssleay 0.8.0 works with it though!).
  BGF Finally have curl more cookie "aware".
  BGF Added a paragraph in the TODO file about the SSL problems recently
    reported.
@@ -9047,8 +9047,8 @@ SUBTITLE(Fixed in 5.5 - January 15 1999)
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF Added Bjorn&apos;s small text to the README about the DICT protocol.
- BGF The win32-version: "Doesn&apos;t use ALL_PROXY environment variable". Turned out
+ BGF Added Bjorn&#39;s small text to the README about the DICT protocol.
+ BGF The win32-version: "Doesn&#39;t use ALL_PROXY environment variable". Turned out
    to be because of the static- buffer nature of the win32 environment
    variable calls!
  BGF Corrected the progress meter for files larger than 20MB.
@@ -9064,7 +9064,7 @@ SUBTITLE(Fixed in 5.4 - January 7 1999)
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF curl -s didn&apos;t always supress the progress reporting. It was the form post
+ BGF curl -s didn&#39;t always supress the progress reporting. It was the form post
    that autoamtically always switched it on again.
  BGF Corrected a width bug in the mprintf() function.
  BGF curl accepted very limited URL sizes. It should now accept path parts that are
@@ -9106,10 +9106,10 @@ SUBTITLE(Fixed in 5.2 - December 14 1998)
 <ul class="bugfixes">
  BGF Rewrote the mkhelp script and now, the mkhelp.pl script generates the
    hugehelp.c file from the README *and* the man page file curl.1.
- BGF gcc2.8.1 with the -Wall flag complaints a lot on subscript has type `char&apos;
-   if I don&apos;t explicitly typecast the argument to isdigit() or isspace() to
+ BGF gcc2.8.1 with the -Wall flag complaints a lot on subscript has type `char&#39;
+   if I don&#39;t explicitly typecast the argument to isdigit() or isspace() to
    int.
- BGF Added checks for &apos;long double&apos; and &apos;long long&apos; in the configure script.
+ BGF Added checks for &#39;long double&#39; and &#39;long long&#39; in the configure script.
 </ul>
 
 <a name="5_0"></a>
@@ -9118,7 +9118,7 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
 <ul class="changes">
  CHG Introducing the new -F flag for HTTP POST. It supports multipart/form-data
    which means it is gonna be possible to upload files etc through HTTP POST.
- CHG Added a &apos;configure&apos; script
+ CHG Added a &#39;configure&#39; script
  CHG Use -H/--header for custom HTTP-headers. Lets you pass on your own
    specified headers to the remote server.
  CHG Use -B/--ftp-ascii to force ftp to use ASCII mode when transfering files.
@@ -9132,7 +9132,7 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
    another product, you need to recompile with the new headers.
  BGF Win32 compiled with a silly error. Corrected now.
  BGF Yet another problem in multiline FTP responses.
- BGF Improved the &apos;maketgz&apos; to create a temporary directory tree which it makes
+ BGF Improved the &#39;maketgz&#39; to create a temporary directory tree which it makes
    an archive from instead of the previous renaming of the current one.
  BGF Mailing list opened (see README).
  BGF Made -v more verbose on the PASV section of ftp transfers. Now it tells
@@ -9152,17 +9152,17 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
  BGF Moved the former -h to -M and made -h show the short help text instead. I
    had to enable a forced help text option. Now an even shorter help text will
    be presented when an unknown option and similar, is used.
- BGF stdcheaders.h didn&apos;t work with IRIX 6.4 native cc compiler. I hope my
-   changes don&apos;t make other versions go nuts instead.
+ BGF stdcheaders.h didn&#39;t work with IRIX 6.4 native cc compiler. I hope my
+   changes don&#39;t make other versions go nuts instead.
  BGF Added a check in the configure script to check for the silly AIX
    warnings about my #define strcasecmp() stuff. I do that define to prevent
    me and other contributors to accidentaly use that function name instead
    of strequal()...
- BGF I bugfixed Angus&apos;s getpass.c very little.
- BGF Fixed the verbose flag names to getopt-style, i.e &apos;curl --loc&apos; will be
+ BGF I bugfixed Angus&#39;s getpass.c very little.
+ BGF Fixed the verbose flag names to getopt-style, i.e &#39;curl --loc&#39; will be
    sufficient instead of --location as "loc" is a unique prefix.
  BGF Another getopt-adjust; curl now accepts flags after the URL on the command
-   line. &apos;curl www.foo.com -O&apos; is perfectly valid.
+   line. &#39;curl www.foo.com -O&#39; is perfectly valid.
  BGF Corrected the .curlrc parser so that strtok() is no longer used and I
    believe it works better. Even URLs can be specified in it now.
  BGF Replaced getpass.c with a newly written one, not under GPL license
@@ -9172,13 +9172,13 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
    I build a release archive!
  BGF Remade the parameter parser to be more getopt compliant. Curl now supports "merged"
    flags as in "curl -lsv ftp.site.com"
- BGF I&apos;ve changed the headers in all files that are subject to the MozPL
+ BGF I&#39;ve changed the headers in all files that are subject to the MozPL
    license, as they are supposed to look like when conforming.
  BGF Made the configure script make the config.h. The former config.h is now
    setup.h.
  BGF The RESOURCES and TODO files have been added to the archive.
  BGF Fixed getpass.c and various configure stuff
- BGF Corrected the &apos;getlinks.pl&apos; script
+ BGF Corrected the &#39;getlinks.pl&#39; script
  BGF SSLeay versions prior to 0.8 will *not* work with curl!
  BGF Fixed a bug that occurred since curl did not properly use CRLF when issuing ftp
    commands.
@@ -9188,7 +9188,7 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
  BGF You can now disable a proxy by using -x "". Useful if the .curlrc file
    specifies a proxy and you wanna fetch something without going through
    that.
- BGF I&apos;m thinking of dropping the -p support. Its really not useful since ports
+ BGF I&#39;m thinking of dropping the -p support. Its really not useful since ports
    could (and should?) be specified as :<port> appended on the host name
    instead, both in URLs and to proxy host names.
  BGF curl -L bugs under Windows NT (test with URL http://come.to/scsde).
@@ -9201,14 +9201,14 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
  BGF Building curl with SSL under FreeBSD should work better and automatically now.
  BGF Cleaned up in the port number mess in the source. No longer stores and uses
    proxy port number separate from normal port number.
- BGF The 5beta (and 4.10) under win32 failed if the HOME variable wasn&apos;t set.
+ BGF The 5beta (and 4.10) under win32 failed if the HOME variable wasn&#39;t set.
  BGF When using a proxy, curl now guesses and uses the protocol part in cases
    like: "curl -x proxy:80 www.site.com". Proxies normally go nuts unless
    http:// is prepended to the host name, so if curl is used like this, it
    guesses protocol and appends the protocol string before passing it to the
    proxy. It already did this when used without proxy.
  BGF Better port usage with SSL through proxy now. If you specified a different
-   https-port when accessing through a proxy, it didn&apos;t use that number
+   https-port when accessing through a proxy, it didn&#39;t use that number
    correctly. I also rewrote the code that parses the stuff read from the
    proxy when you wanna connect through it with SSL.
  BGF Work-around one of the compiler warnings on IRIX native cc compiles.
@@ -9254,8 +9254,8 @@ SUBTITLE(Fixed in 4.8.4 - September 20 1998)
    version number.
  BGF As Teemu Yli-Elsila pointed out,
    the win32 version of 4.8 (and probably all other versions for win32)
-   didn&apos;t work with binary files since I&apos;m too used to the UNIX style
-   fopen() where binary and text don&apos;t differ...
+   didn&#39;t work with binary files since I&#39;m too used to the UNIX style
+   fopen() where binary and text don&#39;t differ...
  BGF Ralph Beckmann brought me some changes that lets
    curl compile error and warning free with -Wall -pedantic with
    g++. I also took the opportunity to clean off some unused variables
@@ -9271,7 +9271,7 @@ SUBTITLE(Fixed in 4.8.3 - September 7 1998)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF I was too quick to release 4.8.2 with too little testing. One of the
-   changes is now reverted slightly to the 4.8.1 way since 4.8.2 couldn&apos;t
+   changes is now reverted slightly to the 4.8.1 way since 4.8.2 couldn&#39;t
    upload files. I still think both problems corrected in 4.8.2 remain
    corrected.
 </ul>
@@ -9281,7 +9281,7 @@ SUBTITLE(Fixed in 4.8.2 - August 14 1998)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF Bernhard Iselborn reported two FTP protocol
-   errors curl did. They&apos;re now corrected. Both appeared when getting files
+   errors curl did. They&#39;re now corrected. Both appeared when getting files
    from a MS FTP server! :-)
 </ul>
 
@@ -9290,7 +9290,7 @@ SUBTITLE(Fixed in 4.8.1 - August 7 1998)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF Added a last update of the progress meter when the transfer is done. The
-   final output on the screen didn&apos;t have to be the final size transfered
+   final output on the screen didn&#39;t have to be the final size transfered
    which made it sometimes look odd.
  BGF Thanks to David Long I got rid of a silly
    bug that happened if a HTTP-page had nothing but header. Appearantly
@@ -9310,7 +9310,7 @@ SUBTITLE(Fixed in 4.8 - July 30  1998)
 SUBTITLE(Fixed in 4.7 - July 20 1998)
 <p> Changes:
 <ul class="changes">
- CHG Wrote a perl script &apos;recursiveftpget.pl&apos;
+ CHG Wrote a perl script &#39;recursiveftpget.pl&#39;
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -9333,9 +9333,9 @@ SUBTITLE(Fixed in 4.6 - July 3 1998)
    verbose flag set. Gary W. Swearingen found it.
  BGF Now using alarm() to enable second-precision timeout even on the name
    resolving/connecting phase. The timeout is although reset after that first
-   sequence. (This should be corrected.) Gary W. Swearingen <swear@aa.net>
+   sequence. (This should be corrected.) Gary W. Swearingen &lt;swear@aa.net&gt;
    reported.
- BGF Now spells "Unknown" properly, as in "Unknown option &apos;z&apos;"... :-)
+ BGF Now spells "Unknown" properly, as in "Unknown option &#39;z&#39;"... :-)
  BGF Added bug report email address in the README.
  BGF Added a "current speed" field to the progress meter. It shows the average
    speed the last 5 seconds. The other speed field shows the average speed of
@@ -9369,7 +9369,7 @@ SUBTITLE(Fixed in 4.5 - May 30 1998)
 SUBTITLE(Fixed in 4.4 - May 13 1998)
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF -x can now also specify proxyport when used as in &apos;proxyhost:proxyport&apos;
+ BGF -x can now also specify proxyport when used as in &#39;proxyhost:proxyport&#39;
  BGF SSL fixes
 </ul>
 
@@ -9378,7 +9378,7 @@ SUBTITLE(Fixed in 4.3 - April 30 1998)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF Adjusted to compile under win32 (VisualC++ 5). The -P switch does not
-   support network interface names in win32. I couldn&apos;t figure out how!
+   support network interface names in win32. I couldn&#39;t figure out how!
 </ul>
 
 <a name="4_2"></a>
@@ -9394,7 +9394,7 @@ SUBTITLE(Fixed in 4.2 - April 15 1998)
  BGF Made -P a lot better to use other IP addresses
  BGF The Makefile is now ready to compile for solaris, sunos4 and linux right
    out of the box
- BGF Better generated version string seen with &apos;curl -V&apos;
+ BGF Better generated version string seen with &#39;curl -V&#39;
 </ul>
 
 <a name="4_1"></a>


### PR DESCRIPTION
Since `&apos;` (&apos;) is only defined for XML and not HTML4, use `&#39;` (&#39;) instead. Also make sure to use `&lt; &gt;` for < > as well as set an ALT attribute on the video image.