### PR TITLE
windows: try fixing zip sizes intermittently appearing as zero

### DIFF
--- a/windows/mkfiles.pl
+++ b/windows/mkfiles.pl
@@ -95,7 +95,7 @@ my $dl = latest();
 my @files = getdl($dl);
 for(@files) {
     my $file = $_;
-    if($file =~ /^curl-([0-9.]*(|_[0-9]*))-(\S+)-(\S+)\.(zip)/) {
+    if($file =~ /^curl-([0-9.]*(|_[0-9]*))-(\S+)-(\S+)\.(zip)$/) {
         my ($version, $arch, $env, $ext)=($1, $3, $4, $5);
         $exts{$version}.="$ext,";
         $archs{$version.$ext}.="$arch,";


### PR DESCRIPTION
Starting with 7.73.0_3, curl-for-win started adding a GPG signature for each .zip and .tar.gz files with a .asc suffix, so let's make sure that these are not caught by the regexp.

Ref: https://github.com/curl/curl-for-win/issues/15
