### PR TITLE
Fix docs menu links for subdirectories

### DIFF
--- a/docs/_menu.html
+++ b/docs/_menu.html
@@ -19,68 +19,68 @@ VLINK(/docs/, Docs Overview, Documentation Overview)
 #endif
 
 <div class="dropdown">
-  <a class="dropbtn" href="projdocs.html">Project</a>
+  <a class="dropbtn" href="/docs/projdocs.html">Project</a>
   <div class="dropdown-content">
-    <a href="bugbounty.html">Bug Bounty</a>
-    <a href="bugs.html">Bug Report</a>
-    <a href="code-of-conduct.html">Code of conduct</a>
-    <a href="libs.html">Dependencies</a>
-    <a href="https://curl.se/donation.html">Donate</a>
-    <a href="faq.html">FAQ</a>
-    <a href="features.html">Features</a>
-    <a href="governance.html">Governance</a>
-    <a href="history.html">History</a>
-    <a href="install.html">Install</a>
-    <a href="knownbugs.html">Known Bugs</a>
-    <a href="todo.html">TODO</a>
-    <a href="https://curl.se/about.html">Web Site Info</a>
+    <a href="/docs/bugbounty.html">Bug Bounty</a>
+    <a href="/docs/bugs.html">Bug Report</a>
+    <a href="/docs/code-of-conduct.html">Code of conduct</a>
+    <a href="/docs/libs.html">Dependencies</a>
+    <a href="/donation.html">Donate</a>
+    <a href="/docs/faq.html">FAQ</a>
+    <a href="/docs/features.html">Features</a>
+    <a href="/docs/governance.html">Governance</a>
+    <a href="/docs/history.html">History</a>
+    <a href="/docs/install.html">Install</a>
+    <a href="/docs/knownbugs.html">Known Bugs</a>
+    <a href="/docs/todo.html">TODO</a>
+    <a href="/about.html">Web Site Info</a>
   </div>
 </div>
 
 <div class="dropdown">
-  <a class="dropbtn" href="protdocs.html">Protocols</a>
+  <a class="dropbtn" href="/docs/protdocs.html">Protocols</a>
   <div class="dropdown-content">
-    <a href="http-cookies.html">HTTP cookies</a>
-    <a href="http2.html">HTTP/2</a>
-    <a href="http3.html">HTTP/3</a>
-    <a href="mqtt.html">MQTT</a>
-    <a href="sslcerts.html">SSL certs</a>
-    <a href="caextract.html">CA Extract</a>
-    <a href="ssl-compared.html">SSL libs compared</a>
-    <a href="url-syntax.html">URL syntax</a>
+    <a href="/docs/http-cookies.html">HTTP cookies</a>
+    <a href="/docs/http2.html">HTTP/2</a>
+    <a href="/docs/http3.html">HTTP/3</a>
+    <a href="/docs/mqtt.html">MQTT</a>
+    <a href="/docs/sslcerts.html">SSL certs</a>
+    <a href="/docs/caextract.html">CA Extract</a>
+    <a href="/docs/ssl-compared.html">SSL libs compared</a>
+    <a href="/docs/url-syntax.html">URL syntax</a>
   </div>
 </div>
 
 <div class="dropdown">
-  <a class="dropbtn" href="reldocs.html">Releases</a>
+  <a class="dropbtn" href="/docs/reldocs.html">Releases</a>
   <div class="dropdown-content">
-    <a href="https://curl.se/changes.html">Changelog</a>
-    <a href="releases.html">Release Table</a>
-    <a href="security.html">Security Problems</a>
-    <a href="versions.html">Version Nums</a>
-    <a href="vulnerabilities.html">Vulnerabilities</a>
+    <a href="/changes.html">Changelog</a>
+    <a href="/docs/releases.html">Release Table</a>
+    <a href="/docs/security.html">Security Problems</a>
+    <a href="/docs/versions.html">Version Nums</a>
+    <a href="/docs/vulnerabilities.html">Vulnerabilities</a>
   </div>
 </div>
 
 <div class="dropdown">
-  <a class="dropbtn" href="tooldocs.html">Tool</a>
+  <a class="dropbtn" href="/docs/tooldocs.html">Tool</a>
   <div class="dropdown-content">
-    <a href="comparison-table.html">Comparison Table</a>
-    <a href="manpage.html">curl man page</a>
-    <a href="httpscripting.html">HTTP Scripting</a>
-    <a href="mk-ca-bundle.html">mk-ca-bundle</a>
-    <a href="manual.html">Tutorial</a>
+    <a href="/docs/comparison-table.html">Comparison Table</a>
+    <a href="/docs/manpage.html">curl man page</a>
+    <a href="/docs/httpscripting.html">HTTP Scripting</a>
+    <a href="/docs/mk-ca-bundle.html">mk-ca-bundle</a>
+    <a href="/docs/manual.html">Tutorial</a>
   </div>
 </div>
 
 <div class="dropdown">
-  <a class="dropbtn" href="whodocs.html">Who and Why</a>
+  <a class="dropbtn" href="/docs/whodocs.html">Who and Why</a>
   <div class="dropdown-content">
-    <a href="companies.html">Companies</a>
-    <a href="copyright.html">Copyright</a>
-    <a href="https://curl.se/sponsors.html">Sponsors</a>
-    <a href="thanks.html">Thanks</a>
-    <a href="thename.html">The name</a>
+    <a href="/docs/companies.html">Companies</a>
+    <a href="/docs/copyright.html">Copyright</a>
+    <a href="/sponsors.html">Sponsors</a>
+    <a href="/docs/thanks.html">Thanks</a>
+    <a href="/docs/thename.html">The name</a>
   </div>
 </div>
 


### PR DESCRIPTION
- Change the relative docs links to prefix /docs/

Prior to this change the relative doc menu links did not work for
subdirectories. For example docs subdirectory survey/

https://curl.se/docs/survey/survey2014.html

.. would have a Bug Bounty relative menu link to bugbounty.html:

Before: https://curl.se/docs/survey/bugbounty.html (Incorrect)
After: https://curl.se/docs/bugbounty.html (Correct)

Reported-by: Emil Engler

Fixes https://github.com/curl/curl-www/issues/88
Closes #xxxx
