### PR TITLE
libcurl/c/index: link to libcurl.html (aka libcurl.3)

### DIFF
--- a/libcurl/c/_index.html
+++ b/libcurl/c/_index.html
@@ -15,8 +15,10 @@ WHERE2(libcurl, "/libcurl/", API)
 
 TITLE(The libcurl API)
 <p>
- Read <a href="libcurl-tutorial.html">the libcurl tutorial</a> to get a
- general in-depth grip of what libcurl programming is all about.
+ Read <a href="libcurl.html">the libcurl API overview</a> and
+ <a href="libcurl-tutorial.html">the libcurl tutorial</a> to get a general
+ in-depth grip of what libcurl programming is all about.
+
 <p>
  There are some <a href="example.html">example C source codes</a> you can
  check out.

--- a/libcurl/c/_libcurl.html
+++ b/libcurl/c/_libcurl.html
@@ -1,6 +1,6 @@
 #include "_doctype.html"
 <HTML>
-<HEAD> <TITLE>libcurl - overview</TITLE>
+<HEAD> <TITLE>libcurl - API overview</TITLE>
 #include "css.t"
 #include "manpage.t"
 </HEAD>
@@ -11,9 +11,9 @@
 #include "_menu.html"
 #include "setup.t"
 
-WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", libcurl overview)
+WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", libcurl API overview)
 
-TITLE(libcurl overview)
+TITLE(libcurl API overview)
 #include "libcurl.gen"
 #include "_footer.html"
 


### PR DESCRIPTION
- Add a link to libcurl.html in the page content.

- Change the name of the libcurl.html page title from "libcurl overview"
  to "libcurl API overview" since the former is already used by the
  overview at libcurl/index.html.

Prior to this change libcurl.html was only linked at the top of the page
as a menu link "API Overview", and not in the content.

Closes #xxxx