### PR TITLE
libcurl/c: Generate and link to URL parsing page libcurl-url.html

### DIFF
--- a/libcurl/_features.html
+++ b/libcurl/_features.html
@@ -129,8 +129,9 @@ SUBTITLE(Thoroughly Documented!)
 <p> All interfaces have overview-style man pages describing the concepts that
  glue all the functions together: <a
  href="/libcurl/c/libcurl-easy.html">easy</a>, <a
- href="/libcurl/c/libcurl-multi.html">multi</a> and <a
- href="/libcurl/c/libcurl-share.html">share</a>.
+ href="/libcurl/c/libcurl-multi.html">multi</a>, <a
+ href="/libcurl/c/libcurl-share.html">share</a> and <a
+ href="/libcurl/c/libcurl-url.html">URL parsing</a>.
 
 <p> There is a <a href="/libcurl/c/libcurl-tutorial.html">libcurl tutorial</a>.
 

--- a/libcurl/c/Makefile
+++ b/libcurl/c/Makefile
@@ -37,7 +37,7 @@ MIME = curl_mime_init.html curl_mime_free.html curl_mime_addpart.html	\
  curl_mime_encoder.html
 
 URLAPI = curl_url.html curl_url_cleanup.html curl_url_dup.html	\
- curl_url_get.html curl_url_set.html
+ curl_url_get.html curl_url_set.html libcurl-url.html
 
 EASY_OPTION = curl_easy_option_by_id.html \
  curl_easy_option_by_name.html \
@@ -288,6 +288,11 @@ libcurl-errors.gen: $(MANROOT)/libcurl-errors.3
 libcurl-tutorial.html: _libcurl-tutorial.html $(MAINPARTS) libcurl-tutorial.gen
 	$(ACTION)
 libcurl-tutorial.gen: $(MANROOT)/libcurl-tutorial.3
+	$(MAN2HTML) < $< >$@
+
+libcurl-url.html: _libcurl-url.html $(MAINPARTS) libcurl-url.gen
+	$(ACTION)
+libcurl-url.gen: $(MANROOT)/libcurl-url.3
 	$(MAN2HTML) < $< >$@
 
 curl_multi_add_handle.html: _curl_multi_add_handle.html $(MAINPARTS_CAPI) curl_multi_add_handle.gen

--- a/libcurl/c/_libcurl-url.html
+++ b/libcurl/c/_libcurl-url.html
@@ -1,0 +1,24 @@
+#include "_doctype.html"
+<HTML>
+<HEAD> <TITLE>libcurl - URL parsing interface overview</TITLE>
+#include "css.t"
+#include "manpage.t"
+</HEAD>
+
+#define MENU_URL
+#define LIBCURL_DOCS
+#define DOCS_OVERVIEW_URL
+#define CURL_URL libcurl/c/libcurl-url.html
+
+#include "_menu.html"
+#include "setup.t"
+
+WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", URL parsing interface)
+TITLE(URL parsing interface overview)
+#include "libcurl-url.gen"
+#include "_footer.html"
+
+</BODY>
+</HTML>
+
+

--- a/libcurl/c/_menu.html
+++ b/libcurl/c/_menu.html
@@ -23,6 +23,7 @@ VLINK("https://curl.se/libcurl/c/libcurl.html", API Overview, Overview)
     <a href="https://curl.se/libcurl/c/example.html">Examples</a>
     <a href="https://curl.se/libcurl/c/libcurl-multi.html">Multi interface</a>
     <a href="https://curl.se/libcurl/c/libcurl-share.html">Share interface</a>
+    <a href="https://curl.se/libcurl/c/libcurl-url.html">URL parsing interface</a>
     <a href="https://curl.se/libcurl/c/symbols-in-versions.html">Symbols</a>
     <a href="https://curl.se/libcurl/c/tutorial.html">Tutorial</a>
   </div>


### PR DESCRIPTION
- Generate missing libcurl-url.html (aka libcurl-url.3).

- Link to it in the menu and the content in the features page.

- Refer to the URL interface in the title as "URL parsing interface"
  so (I hope) it is easier to understand that it's not needed for
  transfers.

Prior to this change the main URL interface page was not generated,
and the URLAPI functions (curl_url*) were generated and linked to
only on the all-functions page.

Closes #xxxx

---

untested