### PR TITLE
metalink: remove mentions of metalink

### DIFF
--- a/curl.css
+++ b/curl.css
@@ -210,11 +210,6 @@ tr.odd {
   background-color: #e0e0e0;
 }
 
-/* used for Metalink download links */
-span.metalink {
-  font-weight: bold;
-}
-
 /* a non-selected item in the main menu */
 .menuitem {
   text-decoration: none;

--- a/dev/summarize.pl
+++ b/dev/summarize.pl
@@ -48,8 +48,6 @@ my $filterform = '
 <option value="^........-">Kerberos disabled</option>
 <option value="^..Y">Memory tracking</option>
 <option value="^..-">Memory tracking disabled</option>
-<option value="^..............E">Metalink</option>
-<option value="^..............-">Metalink disabled</option>
 <option value="^..........M">NTLM</option>
 <option value="^..........-">NTLM disabled</option>
 <option value="^...............1">PSL</option>
@@ -442,13 +440,12 @@ sub endofsingle {
     my $showntlm = $ntlmenabled ? "M" : "-";
     my $showsspi = $sspi ? "P" : "-";
     my $showssh = $libssh2 ? "2" : "-";
-    my $showmetalink = $libmetalink ? "E" : "-";
     my $showpsl = $libpsl ? "1" : "-";
     my $showidn = $libidn ? "I" : ($winidn ? "W" : "-");
     my $showhttp2 = $http2 ? "F" : "-";
     my $showunixsockets = $unixsocketsenabled ? "U" : "-";
 
-    my $o = "$showipv6$showdebug$showtrackmem$showvalgrind$showssl$showres$showzlib$showgssapi$showkrb5$showspnego$showntlm$showidn$showsspi$showssh$showmetalink$showpsl$showhttp2$showunixsockets";
+    my $o = "$showipv6$showdebug$showtrackmem$showvalgrind$showssl$showres$showzlib$showgssapi$showkrb5$showspnego$showntlm$showidn$showsspi$showssh$showpsl$showhttp2$showunixsockets";
 
     if(!$desc) {
         $desc = $os;
@@ -501,7 +498,6 @@ sub singlefile {
 
     $openssl=$gnutls=$nss=$mbedtls=$polarssl=$schannel=$darwinssl=$wolfssl=$boringssl=$libressl=$mesalink=0;
 
-    $libmetalink=0;
     $libpsl=0;
     $libssh2=0;
     $ssl=0;
@@ -739,10 +735,6 @@ sub singlefile {
                     $libz = 1;
                 }
 
-                if($feat =~ /Metalink/i) {
-                    $libmetalink = 1;
-                }
-
                 if($feat =~ /PSL/i) {
                     $libpsl = 1;
                 }
@@ -804,9 +796,6 @@ sub singlefile {
             }
             elsif($line =~ /^\#define USE_LIBSSH2 1/) {
                 $libssh2 = 1;
-            }
-            elsif($line =~ /^\#define USE_METALINK 1/) {
-                $libmetalink = 1;
             }
             elsif($line =~ /^\#define USE_LIBPSL 1/) {
                 $libpsl = 1;
@@ -876,10 +865,6 @@ sub singlefile {
 
                 if($feat =~ /libz/i) {
                     $libz = 1;
-                }
-
-                if($feat =~ /Metalink/i) {
-                    $libmetalink = 1;
                 }
 
                 if($feat =~ /PSL/i) {

--- a/docs/_comparison-table.html
+++ b/docs/_comparison-table.html
@@ -117,7 +117,7 @@ TITLE(Compare curl with other download tools)
   FEAT( IMAP )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( IPv6 )                   YES__ YES__ YES__ YES__ YES__ YES__ YES_P YES__ YES__ ENDLINE
   FEAT( LDAP )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
-  FEAT( Metalink )               YES__ YES__ YES__ no___ no___ no___ YES__ no___ no___ ENDLINE
+  FEAT( Metalink )               no___ YES__ YES__ no___ no___ no___ YES__ no___ no___ ENDLINE
   FEAT( MQTT )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( Multilingual Messages )  no___ YES__ YES__ YES__ no___ YES__ YES__ no___ no___ ENDLINE
   FEAT( Multiple URLs )          YES__ YES__ YES__ YES__ YES__ no___ YES__ no___ no___ ENDLINE

--- a/docs/_libs.html
+++ b/docs/_libs.html
@@ -150,15 +150,6 @@ href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS">NSS</a> </t
 </td>
 </tr>
 
-<tr class="odd">
-<td>
-  <a href="https://launchpad.net/libmetalink">libmetalink</a>
-</td>
-<td>
-  For Metalink support.
-</td>
-</tr>
-
 </table>
 
 #include "_footer.html"


### PR DESCRIPTION
When curl 7.78.0 ships without metalink support, it's time to clean
out any references to curl supporting metalink. This will scrub the
autobuild feature identifier even for older builds which did enable
metalink, but it seems a pretty low price to pay for simplifying.