### PR TITLE
fix link to libcurl tutorial in dropdown menus

### DIFF
--- a/libcurl/_menu.html
+++ b/libcurl/_menu.html
@@ -27,7 +27,7 @@ VLINK("/libcurl/", libcurl, Front page of the libcurl section)
     <a href="https://curl.se/libcurl/relatedlibs.html">Related libs</a>
     <a href="https://curl.se/libcurl/using/">Using libcurl</a>
     <a href="https://curl.se/libcurl/security.html">Security</a>
-    <a href="https://curl.se/libcurl/c/tutorial.html">Tutorial</a>
+    <a href="https://curl.se/libcurl/c/libcurl-tutorial.html">Tutorial</a>
     <a href="https://curl.se/libcurl/theysay.html">Testimonials</a>
   </div>
 </div>

--- a/libcurl/c/_menu.html
+++ b/libcurl/c/_menu.html
@@ -25,7 +25,7 @@ VLINK("https://curl.se/libcurl/c/libcurl.html", API Overview, Overview)
     <a href="https://curl.se/libcurl/c/libcurl-share.html">Share interface</a>
     <a href="https://curl.se/libcurl/c/libcurl-url.html">URL parsing interface</a>
     <a href="https://curl.se/libcurl/c/symbols-in-versions.html">Symbols</a>
-    <a href="https://curl.se/libcurl/c/tutorial.html">Tutorial</a>
+    <a href="https://curl.se/libcurl/c/libcurl-tutorial.html">Tutorial</a>
   </div>
 </div>
 <div class="dropdown">


### PR DESCRIPTION
This will hopefully fix _Docs&rarr;Tutorial_ link on [curl / libcurl overview](https://curl.se/libcurl/) and [curl / libcurl / API](https://curl.se/libcurl/c/) pages.