### PR TITLE
Mailing list url typos

### DIFF
--- a/_menu.html
+++ b/_menu.html
@@ -63,7 +63,7 @@
     <a href="/libcurl/competitors.html">Competitors</a>
     <a href="/libcurl/c/example.html">Examples</a>
     <a href="/libcurl/features.html">Features</a>
-    <a href="//mail/list.cgi?list=curl-library">Mailing list</a>
+    <a href="/mail/list.cgi?list=curl-library">Mailing list</a>
     <a href="/libcurl/relatedlibs.html">Related libs</a>
     <a href="/libcurl/using/">Using libcurl</a>
     <a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a>

--- a/libcurl/_menu.html
+++ b/libcurl/_menu.html
@@ -23,7 +23,7 @@ VLINK("/libcurl/", libcurl, Front page of the libcurl section)
     <a href="/libcurl/competitors.html">Competitors</a>
     <a href="/libcurl/c/example.html">Examples</a>
     <a href="/libcurl/features.html">Features</a>
-    <a href="/libcurl//mail/list.cgi?list=curl-library.html">Mailist list</a>
+    <a href="/mail/list.cgi?list=curl-library">Mailing list</a>
     <a href="/libcurl/relatedlibs.html">Related libs</a>
     <a href="/libcurl/using/">Using libcurl</a>
     <a href="/libcurl/security.html">Security</a>


### PR DESCRIPTION
The `_menu.html` mailing list link turns into `https://mail/list.cgi?list=curl-library`
and the `libcurl/_menu.html` mailing list link is a 404.
This is an fix for those.