### PR TITLE
css: remove border from h2

### DIFF
--- a/curl.css
+++ b/curl.css
@@ -51,10 +51,6 @@ h1 {
     margin-top: 1em;
 }
 
-h2 {
-    border-bottom: solid 1px black;
-}
-
 .subtitle {
   font-weight: bold;
 }


### PR DESCRIPTION
An attempt to make pages less busy, and in particular the generated man pages, this change removes the "border" from the h2 tag. The border was just the lower line of the box.

I also want to change the case of the titles in the generated man page outputs, but that requires modifying roffit and needs a separate change.

Here's a visual display of what I have in mind.

Here's the look of the man page before this change (version A)
![version-a](https://user-images.githubusercontent.com/177011/136031390-b504d73b-7aa9-49ee-a8d7-03d6aa840088.png)

Here's the look after this change (only) (version C)
![version-c](https://user-images.githubusercontent.com/177011/136031387-4b8f95f0-d96b-4906-ada0-a561bd85e509.png)

Here's the look after this change **and** a modified roffit to change the title cases (version B)
![version-b](https://user-images.githubusercontent.com/177011/136031394-638a7c06-11db-4504-8dbf-3d236490f3e9.png)
