### PR TITLE
htaccess: don't redirect curl.local

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -156,6 +156,7 @@ ExpiresByType application/x-pem-file "access plus 12 hours"
 RewriteEngine On
 
 RewriteCond expr "! %{HTTP_HOST} -strmatch 'curl.se'"
+RewriteCond expr "! %{HTTP_HOST} -strmatch 'curl.local'"
 RewriteRule (.*) https://curl.se%{REQUEST_URI} [R=301,L]
 
 </IfModule>


### PR DESCRIPTION
As we have a wide redirect on the origin server, this change makes
"curl.local" *not* redirect for a specific purpose: this allows us to
run a local copy of the site using this name with Apache, without having
it redirect over to curl.se all the time!

I'm curious to hear if this impacts @vszakats, @danielgustafsson or @dfandrich. I figure we could possibly even document this way of running a local version of the site for working on fixes.