### PR TITLE
windows: add the "auto-links" to the latest zip files

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -41,7 +41,6 @@ TITLE(curl DEP_CURL for Windows)
  <b>Date</b>: CURL_WIN64_ZIP_DATE <br>
  <b>Changes</b>: <a href="/changes.html#DEPU_CURL">DEP_CURL changelog</a>
 
-SUBTITLE(Packages)
 <p class="windl">
   <a href="CURL_WIN64_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download 64-bit curl" width="90" height="90" style="float:left;"></a>
 
@@ -54,6 +53,13 @@ sha256: SHA256_CURL_WIN64
  <a href="CURL_WIN32_ZIP" class="windl">curl for 32 bit</a> <br>
 Size: CURL_WIN32_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN32
+
+SUBTITLE(Fixed URLs)
+<p>
+  These links automatically always provide the latest curl package:
+<p>
+<a href="curl-win64-latest.zip">curl-win64-latest.zip</a><br>
+<a href="curl-win32-latest.zip">curl-win32-latest.zip</a><br>
 
 SUBTITLE(Specifications)
 <p>


### PR DESCRIPTION
Ref: https://github.com/curl/curl-for-win/issues/27