### PR TITLE
CI: install CGI.pm for the make workflow

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: install prereqs
-      run: sudo apt-get install pandoc
+      run: sudo apt-get install pandoc libcgi-pm-perl
 
     - name: clone the source repo
       run: git clone --depth=1 https://github.com/curl/curl.git cvssource


### PR DESCRIPTION
This allows us to build the site without having that module present.