### PR TITLE
mod_entry: revert parts of b52b15c931

### DIFF
--- a/dl/mod_entry.cgi
+++ b/dl/mod_entry.cgi
@@ -207,6 +207,9 @@ sub my_show_form()
     alternative("Packager Email/URL", "email",
                 "name\@somewhere.com or URL");
 
+    alternative("Regex-name", "re",
+                "name of the package regex (NOT USED ANYMORE)");
+
     alternative("Uploader", "resp",
                 "username of the person responsible for this package");
 


### PR DESCRIPTION
Brings back "Regex-name" but also restores functionality

@dfandrich this seems to repair the saving of entries in the database, although I haven't actually figured out why!