### PR TITLE
windows: update dl page for curl-uni, the new unified packages

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -65,13 +65,7 @@ SUBTITLE(Specifications)
 <p>
   curl CURL_WINDOWS_VERSION was built and statically linked with
   <ul>
-    <li> OpenSSL DEP_OPENSSL [<a href=DL_OPENSSL_WIN64>64bit</a>/<a href=DL_OPENSSL_WIN32>32bit</a>]
-    <li> brotli DEP_BROTLI [<a href=DL_BROTLI_WIN64>64bit</a>/<a href=DL_BROTLI_WIN32>32bit</a>]
-    <li> libgsasl DEP_LIBGSASL [<a href=DL_LIBGSASL_WIN64>64bit</a>/<a href=DL_LIBGSASL_WIN32>32bit</a>]
-    <li> libidn2 DEP_LIBIDN2 [<a href=DL_LIBIDN2_WIN64>64bit</a>/<a href=DL_LIBIDN2_WIN32>32bit</a>]
-    <li> libssh2 DEP_LIBSSH2 [<a href=DL_LIBSSH2_WIN64>64bit</a>/<a href=DL_LIBSSH2_WIN32>32bit</a>]
-    <li> nghttp2 DEP_NGHTTP2 [<a href=DL_NGHTTP2_WIN64>64bit</a>/<a href=DL_NGHTTP2_WIN32>32bit</a>]
-    <li> zlib DEP_ZLIB [<a href=DL_ZLIB_WIN64>64bit</a>/<a href=DL_ZLIB_WIN32>32bit</a>]
+DEP_PKGS
   </ul>
 
 <p>

--- a/windows/mkfiles.pl
+++ b/windows/mkfiles.pl
@@ -38,23 +38,29 @@ sub depversions {
     my ($dl) = @_;
     open(D, "<$dl/build.txt");
     my $tools;
+    my $pkgs;
     while(<D>) {
         if($_ =~ /^\.(.*)/) {
             # tools
             $tools .= "<li>$1";
         }
-        elsif($_ =~ /^([^.]\S+) (\S+)/) {
+        elsif($_ =~ /^([^.]\S+ \S+)/) {
             my ($dep, $ver) = ($1, $2);
-            my $u = $ver;
-            $u =~ s/\./_/g;
-            printf("#define DEP_%s %s\n", uc($dep), $ver);
-            printf("#define DEPU_%s %s\n", uc($dep), $u);
-            $depver{$dep}=$ver;
-            push @alldeps, $dep;
+            if($_ =~ /^curl /) {
+                my $u = $ver;
+                $u =~ s/\./_/g;
+                printf("#define DEP_%s %s\n", uc($dep), $ver);
+                printf("#define DEPU_%s %s\n", uc($dep), $u);
+            }
+            else {
+                $pkgs .= "<li>$1";
+                chomp $pkgs;
+            }
         }
     }
     close(D);
     printf "#define DEP_TOOLS %s\n", $tools;
+    printf "#define DEP_PKGS %s\n", $pkgs;
 }
 
 sub latest {
@@ -136,14 +142,6 @@ depversions($dl);
 my $gensuff="";
 if($gen) {
     $gensuff = sprintf "_%d", $gen;
-}
-
-# generate download links for deps
-for(@alldeps) {
-    for my $arch ('win32', 'win64') {
-        printf "#define DL_%s_%s %s/%s-%s%s-%s-mingw.zip\n",
-        uc($_), uc($arch), $dl, $_, $depver{$_}, $gensuff, $arch;
-    }
 }
 
 gethashes($dl);


### PR DESCRIPTION
The new packages contain all, previously separately packaged files in two, per-target (win64 & win32), files. So, replace the hardcoded list of dependencies along with their download URLs, with a dynamically generated list with names and version numbers only, similar to the tool dependency section was already. This will also adapt to any configuration changes done in curl-for-win builds, e.g. it will show openssl-quic and list nghttp3 + ngtcp2 if/when those builds are made default.