### PR TITLE
windows: add support for ARM64 builds

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -42,24 +42,24 @@ TITLE(curl DEP_CURL for Windows)
  <b>Changes</b>: <a href="/changes.html#DEPU_CURL">DEP_CURL changelog</a>
 
 <p class="windl">
-  <a href="CURL_WIN64_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download x64 curl" width="90" height="90" style="float:left;"></a>
+  <a href="CURL_WIN64_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download 64-bit curl" width="90" height="90" style="float:left;"></a>
 
-<a href="CURL_WIN64_ZIP" class="windl">curl for x64</a> <br>
+<a href="CURL_WIN64_ZIP" class="windl">curl for 64-bit</a> <br>
 Size: CURL_WIN64_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN64
 
 #ifdef CURL_WIN64A_ZIP
 <p class="windl">
-  <a href="CURL_WIN64A_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download arm64 curl" width="90" height="90" style="float:left;"></a>
+  <a href="CURL_WIN64A_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download 64-bit (ARM) curl" width="90" height="90" style="float:left;"></a>
 
-<a href="CURL_WIN64A_ZIP" class="windl">curl for arm64</a> <br>
+<a href="CURL_WIN64A_ZIP" class="windl">curl for 64-bit (ARM)</a> <br>
 Size: CURL_WIN64A_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN64A
 #endif
 
 <p class="windl">
- <a href="CURL_WIN32_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download x86 curl" width="90" height="90" style="float:left;"></a>
- <a href="CURL_WIN32_ZIP" class="windl">curl for x86</a> <br>
+ <a href="CURL_WIN32_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download 32-bit curl" width="90" height="90" style="float:left;"></a>
+ <a href="CURL_WIN32_ZIP" class="windl">curl for 32-bit</a> <br>
 Size: CURL_WIN32_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN32
 

--- a/windows/_index.html
+++ b/windows/_index.html
@@ -42,15 +42,24 @@ TITLE(curl DEP_CURL for Windows)
  <b>Changes</b>: <a href="/changes.html#DEPU_CURL">DEP_CURL changelog</a>
 
 <p class="windl">
-  <a href="CURL_WIN64_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download 64-bit curl" width="90" height="90" style="float:left;"></a>
+  <a href="CURL_WIN64_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download x64 curl" width="90" height="90" style="float:left;"></a>
 
-<a href="CURL_WIN64_ZIP" class="windl">curl for 64 bit</a> <br>
+<a href="CURL_WIN64_ZIP" class="windl">curl for x64</a> <br>
 Size: CURL_WIN64_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN64
 
+#ifdef CURL_WIN64A_ZIP
 <p class="windl">
- <a href="CURL_WIN32_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download 32-bit curl" width="90" height="90" style="float:left;"></a>
- <a href="CURL_WIN32_ZIP" class="windl">curl for 32 bit</a> <br>
+  <a href="CURL_WIN64A_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download arm64 curl" width="90" height="90" style="float:left;"></a>
+
+<a href="CURL_WIN64A_ZIP" class="windl">curl for arm64</a> <br>
+Size: CURL_WIN64A_ZIP_SIZE<br>
+sha256: SHA256_CURL_WIN64A
+#endif
+
+<p class="windl">
+ <a href="CURL_WIN32_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download x86 curl" width="90" height="90" style="float:left;"></a>
+ <a href="CURL_WIN32_ZIP" class="windl">curl for x86</a> <br>
 Size: CURL_WIN32_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN32
 
@@ -59,6 +68,7 @@ SUBTITLE(Fixed URLs)
   These links automatically always provide the latest curl package:
 <p>
 <a href="curl-win64-latest.zip">curl-win64-latest.zip</a><br>
+<a href="curl-win64a-latest.zip">curl-win64a-latest.zip</a><br>
 <a href="curl-win32-latest.zip">curl-win32-latest.zip</a><br>
 
 SUBTITLE(Specifications)

--- a/windows/unpack.pl
+++ b/windows/unpack.pl
@@ -40,8 +40,10 @@ if($n = $sul[0]) {
             system "(mkdir -p $extract-$stamp && cd $extract-$stamp && unzip -oq $f)";
             system "echo $stamp > $latest";
             # update symlinks for "the latest"
+            system "ln -sf dl-$stamp/curl-$stamp-win64a-mingw.zip curl-win64a-latest.zip";
             system "ln -sf dl-$stamp/curl-$stamp-win64-mingw.zip curl-win64-latest.zip";
             system "ln -sf dl-$stamp/curl-$stamp-win32-mingw.zip curl-win32-latest.zip";
+            system "ln -sf dl-$stamp/curl-$stamp-win64a-mingw.tar.xz curl-win64a-latest.tar.xz";
             system "ln -sf dl-$stamp/curl-$stamp-win64-mingw.tar.xz curl-win64-latest.tar.xz";
             system "ln -sf dl-$stamp/curl-$stamp-win32-mingw.tar.xz curl-win32-latest.tar.xz";
         }


### PR DESCRIPTION
Ref: https://github.com/curl/curl-for-win/commit/0528a0cffcb1c4180304abfcf35994181997dce5

I changed '64 bit' to 'x64' and '32 bit' to 'x86' on the page to use
Windows-terminology an to differenciate from the new arm build.

win64/win32/win64a in the filenames remain a little bit ambiguous so
it's an option to rename them, though it will break existing URLs:
  `-win64` → `-win-x64`
  `-win32` → `-win-x86`
  `-win64a` → `-win-a64` or `-win-arm64`