### PR TITLE
ca: create .sha256 checksum file for versioned downloads

### DIFF
--- a/ca/listpem.pl
+++ b/ca/listpem.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 opendir(my $dh, ".") || die "can't opendir: $!";
-my @pems = grep { /^cacert-.*pem/ } readdir($dh);
+my @pems = grep { /^cacert-.*pem$/ } readdir($dh);
 closedir $dh;
 
 sub countcerts {
@@ -19,12 +19,14 @@ sub countcerts {
 print "<table><tr><th>Date</th><th>Certificates</th><tr>\n";
 my $l = 0;
 foreach my $p (reverse sort @pems) {
-    if($p =~ /cacert-(.*).pem/) {
+    if($p =~ /cacert-(.*).pem$/) {
         my $n = countcerts($p);
         my $date = $1;
-        printf "<tr %s><td><a href=\"/ca/$p\">%s</a></td> <td align=center>%d</td></tr>\n",
+        printf "<tr %s><td><a href=\"/ca/$p\">%s</a>%s</td> <td align=center>%d</td></tr>\n",
             $l&1?"class=\"odd\"":"",
-            $date, $n;
+            $date,
+            (-e "$p.sha256" ? " (<a href=\"/ca/$p.sha256\">sha256</a>)" : ""),
+            $n;
         if(++$l >= 10) {
             # only show 10
             last;

--- a/ca/update.sh
+++ b/ca/update.sh
@@ -6,8 +6,10 @@ perl ../cvssource/scripts/mk-ca-bundle.pl
 sha256sum -c cacert.pem.sha256
 if test $? -gt "0"; then
   # PEM was updated, save this by date
-  cp cacert.pem cacert-`date +%Y-%m-%d`.pem
+  d="$(date +%Y-%m-%d)"
+  cp cacert.pem "cacert-${d}.pem"
   sha256sum cacert.pem > cacert.pem.sha256
+  cp cacert.pem.sha256 "cacert-${d}.pem.sha256"
   gzip -c cacert.pem > cacert.pem.gz
   xz -c cacert.pem > cacert.pem.xz
   perl ./listpem.pl > pemlist.gen


### PR DESCRIPTION
The unversioned https://curl.se/ca/cacert.pem has a checksum file at https://curl.se/ca/cacert.pem.sha256.

This patch adds a checksum file for the versioned counterparts: https://curl.se/ca/cacert-2022-12-31.pem.sha256 for https://curl.se/ca/cacert-2022-12-31.pem

This allows to verify the expected checksum for versioned cacerts.

Caveat: This patch doesn't add the checksum files retroactively, the current latest release included. Only the next release will have an .sha256 file.