### PR TITLE
ca: generate missing .sha256 files retroactively

### DIFF
--- a/ca/update.sh
+++ b/ca/update.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# generate missing .sha256 files retroactively
+for f in cacert-*.pem; do
+  if [ ! -s "${f}.sha256" ]; then
+    sha256sum "${f}" > "${f}.sha256"
+  fi
+done
+
 # get the cert and create ca-bundle.crt
 perl ../cvssource/scripts/mk-ca-bundle.pl
 


### PR DESCRIPTION
This logic can/should be deleted after letting it run once.
