### PR TITLE
docs: remove numerical score form past advisories

### DIFF
--- a/docs/CVE-2018-16839.md
+++ b/docs/CVE-2018-16839.md
@@ -39,7 +39,7 @@ CVE-2018-16839 to this issue.
 
 CWE-131: Incorrect Calculation of Buffer Size
 
-Severity: 3.2 (Low)
+Severity: Low
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2018-16840.md
+++ b/docs/CVE-2018-16840.md
@@ -28,7 +28,7 @@ CVE-2018-16840 to this issue.
 
 CWE-416: Use After Free
 
-Severity: 2.3 (Low)
+Severity: Low
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2018-16842.md
+++ b/docs/CVE-2018-16842.md
@@ -44,7 +44,7 @@ CVE-2018-16842 to this issue.
 
 CWE-125: Out-of-bounds Read
 
-Severity: 3.3 (Low)
+Severity: Low
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2018-16890.md
+++ b/docs/CVE-2018-16890.md
@@ -30,7 +30,7 @@ CVE-2018-16890 to this issue.
 
 CWE-125: Out-of-bounds Read
 
-Severity: 5.3 (Medium)
+Severity: Medium
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2019-15601.md
+++ b/docs/CVE-2019-15601.md
@@ -49,7 +49,7 @@ CVE-2019-15601 to this issue.
 
 CWE-20: Improper Input Validation
 
-Severity: 3.0 (Low)
+Severity: Low
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2019-3822.md
+++ b/docs/CVE-2019-3822.md
@@ -36,7 +36,7 @@ CVE-2019-3822 to this issue.
 
 CWE-121: Stack-based Buffer Overflow
 
-Severity: 7.3 (High)
+Severity: High
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2019-3823.md
+++ b/docs/CVE-2019-3823.md
@@ -28,7 +28,7 @@ CVE-2019-3823 to this issue.
 
 CWE-125: Out-of-bounds Read
 
-Severity: 3.7 (Low)
+Severity: Low
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2019-5435.md
+++ b/docs/CVE-2019-5435.md
@@ -36,7 +36,7 @@ CVE-2019-5435 to this issue.
 
 CWE-131: Incorrect Calculation of Buffer Size
 
-Severity: 3.7 (Low)
+Severity: Low
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2019-5436.md
+++ b/docs/CVE-2019-5436.md
@@ -36,7 +36,7 @@ CVE-2019-5436 to this issue.
 
 CWE-122: Heap-based Buffer Overflow
 
-Severity: 1.8 (Low)
+Severity: Low
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2019-5481.md
+++ b/docs/CVE-2019-5481.md
@@ -38,7 +38,7 @@ CVE-2019-5481 to this issue.
 
 CWE-415: Double Free
 
-Severity: 6.3 (Medium)
+Severity: Medium
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2019-5482.md
+++ b/docs/CVE-2019-5482.md
@@ -40,7 +40,7 @@ CVE-2019-5482 to this issue.
 
 CWE-122: Heap-based Buffer Overflow
 
-Severity: 5.2 (Medium)
+Severity: Medium
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2020-8169.md
+++ b/docs/CVE-2020-8169.md
@@ -97,7 +97,7 @@ CVE-2020-8169 to this issue.
 
 CWE-200: Exposure of Sensitive Information to an Unauthorized Actor
 
-Severity: 5.5 (Medium)
+Severity: Medium
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2020-8177.md
+++ b/docs/CVE-2020-8177.md
@@ -57,7 +57,7 @@ CVE-2020-8177 to this issue.
 
 CWE-641: Improper Restriction of Names for Files and Other Resources
 
-Severity: 4.7 (Medium)
+Severity: Medium
 
 AFFECTED VERSIONS
 -----------------


### PR DESCRIPTION
... and standardize on Low, Medium, High, Critical for easier parsing.