### PR TITLE
docs/listvulns: show the severity in the issue list

### DIFF
--- a/docs/listvulns.pl
+++ b/docs/listvulns.pl
@@ -21,7 +21,9 @@ sub cve2severity {
     open(C, "$cve.md");
     while(<C>) {
         if(/^Severity: (.*)/) {
-            return $1;
+            my $sev = $1;
+            $sev =~ s/[\r\n]+//g;
+            return ucfirst($sev);
         }
     }
     close(C);
@@ -48,9 +50,12 @@ for(@vuln) {
     }
 
     my $sev = cve2severity($cve);
-    my $col= sev2color($sev);
-
-    my $c="<div style=\"color:$col;\">&#9679;</div>";
+    my $col;
+    my $c = "&nbsp;";
+    if($sev) {
+        $col = sev2color($sev);
+        $c="<div style=\"color:$col;\">&#9679;</div>";
+    }
     
     print <<VUL
 <tr>

--- a/docs/listvulns.pl
+++ b/docs/listvulns.pl
@@ -7,6 +7,7 @@ print "<table>\n";
 print <<HEAD
 <tr class=\"tabletop\">
 <th>#</th>
+<th>S</th>
 <th>Vulnerability</th>
 <th>Date</th>
 <th>First</th>
@@ -14,6 +15,28 @@ print <<HEAD
 </tr>
 HEAD
     ;
+
+sub cve2severity {
+    my ($cve) = @_;
+    open(C, "$cve.md");
+    while(<C>) {
+        if(/^Severity: (.*)/) {
+            return $1;
+        }
+    }
+    close(C);
+    return "";
+}
+
+sub sev2color {
+    my ($sev) = @_;
+    if(!$sev) {
+        return "white";
+    }
+    return "green" if($sev =~ /^Low/i);
+    return "orange" if($sev =~ /^Medium/i);
+    return "red";
+}
 
 my $num = $#vuln + 1;
 for(@vuln) {
@@ -24,9 +47,15 @@ for(@vuln) {
         ($year, $mon, $day)=($1, $2, $3);
     }
 
+    my $sev = cve2severity($cve);
+    my $col= sev2color($sev);
+
+    my $c="<div style=\"color:$col;\">&#9679;</div>";
+    
     print <<VUL
 <tr>
 <td>$num</td>
+<td title="$sev">$c</td>
 <td><a href="$id">$cve: $desc</a></td>
 <td>$year-$mon-$day</td>
 <td><a href="vuln-$start.html">$start</a></td>


### PR DESCRIPTION
It uses a color-coded little circle, green, orange or red.

Example screenshot:

![Screenshot 2022-12-21 at 09-24-08 curl - Security Problems](https://user-images.githubusercontent.com/177011/208855973-6cd72de3-c4b5-47cd-a4b5-8d460f1b5292.png)
