### PR TITLE
add Tests Overview page (from tests/README.md)

### DIFF
--- a/_menu.html
+++ b/_menu.html
@@ -102,6 +102,7 @@
     <a href="/dev/secprocess.html">Security Process</a>
     <a href="/rfc/">Specifications</a>
     <a href="/dev/testcurl.html">Test curl</a>
+    <a href="/dev/tests-overview.html">Tests Overview</a>
   </div>
 </div>
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -37,7 +37,8 @@ PAGES = \
  code-review.html \
  feature-window.html \
  new-protocol.html \
- test-fileformat.html
+ test-fileformat.html \
+ tests-overview.html
 
 all: $(PAGES)
 
@@ -55,6 +56,11 @@ new-protocol.gen: $(SRCROOT)/docs/NEW-PROTOCOL.md
 test-fileformat.html: _test-fileformat.html $(MAINPARTS) fileformat.gen
 	$(ACTION)
 fileformat.gen: $(SRCROOT)/tests/FILEFORMAT.md
+	$(MARKDOWN) < $< > $@
+
+tests-overview.html: _tests-overview.html $(MAINPARTS) testsoverview.gen
+	$(ACTION)
+testsoverview.gen: $(TESTROOT)/README.md
 	$(MARKDOWN) < $< > $@
 
 source.html: _source.html $(MAINPARTS)

--- a/dev/_menu.html
+++ b/dev/_menu.html
@@ -33,6 +33,7 @@
     <a href="/rfc/">Specifications</a>
     <a href="/dev/testcurl.html">Test curl</a>
     <a href="/dev/test-fileformat.html">Test case file format</a>
+    <a href="/dev/tests-overview.html">Tests Overview</a>
   </div>
 </div>
 <div class="dropdown">

--- a/dev/_runtests.html
+++ b/dev/_runtests.html
@@ -16,6 +16,7 @@ WHERE2(Development, "/dev/", runtests.pl)
 TITLE(runtests.1 the man page)
 <div class="relatedbox">
 <b>Related:</b>
+<br><a href="tests-overview.html">Tests Overview</a>
 <br><a href="/docs/manpage.html">man page</a>
 <br><a href="testcurl.html">testcurl.1</a>
 </div>

--- a/dev/_tests-overview.html
+++ b/dev/_tests-overview.html
@@ -1,27 +1,25 @@
 #include "_doctype.html"
 <html>
-<head> <title>curl - Automatic Test</title>
+<head> <title>curl - Tests Overview</title>
 #include "css.t"
-#include "manpage.t"
 </head>
 
-#define DEVEL_TESTCURL
-#define CURL_URL dev/testcurl.html
+#define DEVEL_TESTS_OVERVIEW
+#define CURL_URL dev/tests-overview.html
 
 #include "_menu.html"
 #include "setup.t"
 
-WHERE2(Development, "/dev/", testcurl.pl)
+WHERE2(Development, "/dev/", Tests Overview)
 
-TITLE(testcurl.1 the man page)
 <div class="relatedbox">
 <b>Related:</b>
-<br><a href="tests-overview.html">Tests Overview</a>
+<br><a href="testcurl.html">Test curl</a>
 <br><a href="runtests.html">runtests.1</a>
 <br><a href="/docs/manual.html">Manual</a>
 </div>
 
-#include "testcurl.gen"
+#include "testsoverview.gen"
 
 #include "_footer.html"
 


### PR DESCRIPTION
Related discussion https://github.com/curl/curl/discussions/10577

I'd say that "testcurl.html" and "runtests.html" don't need to appear in the "dev related docs" dropdown, but could be linked to prominently near the top of this new "Tests Overview" page. (more prominently than how they appear now, under the "related" section on the right).

![image](https://user-images.githubusercontent.com/16764864/223112248-7acd402f-a217-4b51-be87-49aee70c11f5.png)
