### PR TITLE
add "edit on GitHub" link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dl/data
 dl/pbase_error.log
 recentmail.t
 cvssource
+*.href.inc

--- a/setup.mk
+++ b/setup.mk
@@ -1,4 +1,5 @@
-ACTION=fcpp $(FCPP_OPTS) -I$(ROOT) -WWW -Uunix -P -H -C -V -LL $< $@
+ACTION=fcpp $(FCPP_OPTS) -I$(ROOT) -WWW -Uunix -P -H -C -V -LL $< $@ \
+ && sed -i 's/\.\.\/cvssource\///g' $@
 TXT2PLAIN=$(ROOT)/docs/txt2plain.pl
-MARKDOWN=pandoc -f gfm
+MARKDOWN=echo "<p><a href=\"https://github.com/curl/curl/edit/master/"$<"\">Edit this page on GitHub</a></p>" > $@.href.inc && pandoc -B $@.href.inc -f gfm
 GITHUB=pandoc -f gfm


### PR DESCRIPTION
A lot of sites on GitHub have a link/button similar to this. I thought it might make it a *little* easier for someone to edit a page more easily if they spot an error.

Do you want me continue with this?

![image](https://user-images.githubusercontent.com/16764864/223633018-1190e21b-cc6f-4d96-a372-152278f2fe38.png)
