### PR TITLE
windows: add links to dependencies

### DIFF
--- a/windows/mkfiles.pl
+++ b/windows/mkfiles.pl
@@ -36,25 +36,34 @@ sub filesize {
 my @alldeps;
 sub depversions {
     my ($dl) = @_;
-    open(D, "<$dl/build.txt");
+    open(D, "<$dl/urls.txt");
     my $tools;
     my $pkgs;
     while(<D>) {
-        if($_ =~ /^\.(.*)/) {
-            # tools
-            $tools .= "<li>$1";
-        }
-        elsif($_ =~ /^([^.]\S+) (\S+)/) {
-            my ($dep, $ver) = ($1, $2);
+        if($_ =~ /^(\S+) (\S+)( https:\/\/\S+)?( .+)?/) {
+            my ($dep, $ver, $url, $suff) = ($1, $2, $3, $4);
             if($dep eq 'curl') {
                 my $u = $ver;
                 $u =~ s/\./_/g;
                 printf("#define DEP_%s %s\n", uc($dep), $ver);
                 printf("#define DEPU_%s %s\n", uc($dep), $u);
             }
+            my $tool = 0;
+            if($dep =~ /^\.(.*)/) {
+                $dep =~ s/^\.//;
+                $tool = 1;
+            }
+            $ver = "$dep $ver";
+            chomp $ver;
+            if($url ne '') {
+                $url =~ s/^ //;
+                $ver = "<a href='$url'>$ver</a>"
+            }
+            if($tool == 1) {
+                $tools .= "<li>$ver$suff";
+            }
             else {
-                $pkgs .= "<li>$dep $ver";
-                chomp $pkgs;
+                $pkgs .= "<li>$ver$suff";
             }
         }
     }


### PR DESCRIPTION
Change each dependency + version line into a link to the original source (or package) that we used for the build.

Also include curl sources in the list. This isn't stricly necessary, but otherwise curl would be the only component without a direct link to its source code.

Caveat: Needs an `fcpp` update bumping up `NBUFF` and `NWORK` to make it process the longer `DEP_TOOLS` (356 bytes) and `DEP_PKGS` (1013 bytes) macros.

https://github.com/bagder/fcpp:
```diff
diff --git a/cppdef.h b/cppdef.h
index c188a22..c5b44b5 100644
--- a/cppdef.h
+++ b/cppdef.h
@@ -299,11 +299,11 @@
 #endif

 #ifndef NBUFF
-#define NBUFF			512
+#define NBUFF			2048
 #endif

 #ifndef NWORK
-#define NWORK			512
+#define NWORK			2048
 #endif

 #ifndef NEXP
```
Or, build it with `CPPFLAGS='-DNBUFF=2048 -DNWORK=2048'` for curl-www purposes.

Live sample `urls.txt` from the curl-for-win package:
```
.clang 15.0.6
.clang 16.0.0 (ARM64)
.curl-for-win 29b99783 https://github.com/curl/curl-for-win/archive/29b997832d92414a960e51fbd5a4e78e39b38c1b.tar.gz
.llvm-mingw 20230320 https://github.com/mstorsjo/llvm-mingw/releases/download/20230320/llvm-mingw-20230320-ucrt-ubuntu-18.04-x86_64.tar.xz (ARM64)
.mingw-w64 10.0.0-3
brotli 1.0.9 https://github.com/google/brotli/archive/v1.0.9.tar.gz
cacert 2023-01-10 https://curl.se/ca/cacert-2023-01-10.pem
curl 8.0.1 https://curl.se/download/curl-8.0.1.tar.xz
gsasl 2.2.0 https://ftp.gnu.org/gnu/gsasl/gsasl-2.2.0.tar.gz
libssh2 1.10.0 https://www.libssh2.org/download/libssh2-1.10.0.tar.gz
nghttp2 1.52.0 https://github.com/nghttp2/nghttp2/releases/download/v1.52.0/nghttp2-1.52.0.tar.xz
nghttp3 0.9.0 https://github.com/ngtcp2/nghttp3/releases/download/v0.9.0/nghttp3-0.9.0.tar.xz
ngtcp2 0.13.1 https://github.com/ngtcp2/ngtcp2/releases/download/v0.13.1/ngtcp2-0.13.1.tar.xz
quictls 3.0.8 https://github.com/quictls/openssl/archive/refs/heads/openssl-3.0.8+quic.tar.gz
zlib 1.2.13 https://zlib.net/zlib-1.2.13.tar.xz
zstd 1.5.4 https://github.com/facebook/zstd/releases/download/v1.5.4/zstd-1.5.4.tar.gz
```

Webpage:
<img width="653" alt="Screen Shot" src="https://user-images.githubusercontent.com/1446897/227420650-961ed5b5-995c-4643-a78a-9f28dd601bc5.png">
