### PR TITLE
CVE-2022-32206/CVE-2023-23916: corrections

### DIFF
--- a/docs/CVE-2022-32206.md
+++ b/docs/CVE-2022-32206.md
@@ -26,8 +26,9 @@ CVE-2022-32206 was introduced in [commit
 dbcced8e32b50c06](https://github.com/curl/curl/commit/dbcced8e32b50c06),
 shipped in curl 7.57.0.
 
-Automatic decompression of content needs to be enabled per transfer. It is
-disabled by default and then nothing bad happens.
+Automatic content decompression of content needs to be enabled per transfer
+but the way Transfer-Encoding works in curl this code path and problem can be
+reached with default options.
 
 This flaw exists with just one of the compression algorithms built-in (gzip,
 brotli or zstd), but the individual algorithms have different "exploding"
@@ -62,8 +63,6 @@ RECOMMENDATIONS
  A - Upgrade curl to version 7.84.0
 
  B - Apply the patch to your local version
- 
- C - Do not enable automatic decompression
  
 TIMELINE
 --------

--- a/docs/CVE-2023-23916.md
+++ b/docs/CVE-2023-23916.md
@@ -27,8 +27,9 @@ CVE-2023-23916 was introduced in [commit
 dbcced8e32b50c06](https://github.com/curl/curl/commit/dbcced8e32b50c06),
 shipped in curl 7.57.0.
 
-Automatic decompression of content needs to be enabled per transfer. It is
-disabled by default and then nothing bad happens.
+Automatic content decompression of content needs to be enabled per transfer
+but the way Transfer-Encoding works in curl this code path and problem can be
+reached with default options.
 
 This flaw exists with one or more of the compression algorithms built-in
 (gzip, brotli or zstd), but the individual algorithms have different
@@ -67,8 +68,6 @@ RECOMMENDATIONS
  A - Upgrade curl to version 7.88.0
 
  B - Apply the patch to your local version
- 
- C - Do not enable automatic decompression
  
 TIMELINE
 --------


### PR DESCRIPTION
These problems can also be triggered with transfer-encoding which can be activated in curl without any option being set.

Reported-by: Ben Fritz @ColBFritz
