### PR TITLE
CVE: remove "There is no known exploit at the time of this writing"

### DIFF
--- a/docs/CVE-2005-3185.md
+++ b/docs/CVE-2005-3185.md
@@ -18,8 +18,6 @@ and either:
      HTTP 30x response code) and the new URL contains a URL with a user name
      and domain name that together are longer than 192 bytes
 
-There is no known exploit at the time of this writing.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CAN-2005-3185 to this issue.
 

--- a/docs/CVE-2005-4077.md
+++ b/docs/CVE-2005-4077.md
@@ -29,8 +29,6 @@ lots of programs may still pass in user-provided URLs to libcurl without doing
 much syntax checking of their own, allowing a user to exploit this
 vulnerability.
 
-There is no known exploit at the time of this writing.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2005-4077 to this issue.
 

--- a/docs/CVE-2006-1061.md
+++ b/docs/CVE-2006-1061.md
@@ -18,8 +18,6 @@ The affected flaw can be triggered by a redirect, if curl/libcurl is told to
 follow redirects and an HTTP server points the client to a tftp URL with the
 characteristics described above.
 
-There is no known exploit at the time of this writing.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2006-1061 to this issue.
 

--- a/docs/CVE-2007-3564.md
+++ b/docs/CVE-2007-3564.md
@@ -14,8 +14,6 @@ servers to present certificates to libcurl that won't be rejected properly.
 Notably, the cacert and common name checks are still in place which reduces
 the risk for random servers to take advantage of this flaw.
 
-There is no known exploit at the time of this writing.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2007-3564 to this issue.
 

--- a/docs/CVE-2009-0037.md
+++ b/docs/CVE-2009-0037.md
@@ -31,8 +31,6 @@ running libcurl.  This is most common for FTP servers, but can occur with
 any protocol supported by libcurl.  Files on remote SSH servers are also
 accessible when the user has an unencrypted SSH key.
 
-There is no known exploit at the time of this writing.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2009-0037 to this issue.
 

--- a/docs/CVE-2010-0734.md
+++ b/docs/CVE-2010-0734.md
@@ -24,9 +24,9 @@ This error is only present in zlib-enabled builds of libcurl and only if
 automatic decompression has been explicitly enabled by the application - it
 is disabled by default.
 
-There is no known exploit for this problem and we have not found any libcurl
-client software that is vulnerable to this flaw - but we acknowledge that
-there may still be vulnerable software in existence.
+We have not found any libcurl client software that is vulnerable to this
+flaw - but we acknowledge that there may still be vulnerable software in
+existence.
 
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2010-0734 to this issue.

--- a/docs/CVE-2010-3842.md
+++ b/docs/CVE-2010-3842.md
@@ -27,8 +27,6 @@ Symbian.
 This error is only present in the curl command line tool, it is NOT a
 problem of the library libcurl.
 
-There is no known exploit for this problem.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2010-3842 to this issue.
 

--- a/docs/CVE-2011-2192.md
+++ b/docs/CVE-2011-2192.md
@@ -17,8 +17,6 @@ The GSS/Negotiate feature is only used by libcurl for HTTP authentication if
 told to, and only if libcurl was built with a library that provides the
 GSSAPI. Many builds of libcurl don't have GSS enabled.
 
-There is no known exploit for this problem.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2011-2192 to this issue.
 

--- a/docs/CVE-2011-3389.md
+++ b/docs/CVE-2011-3389.md
@@ -22,8 +22,6 @@ VULNERABILITY
   While SSL_OP_ALL is documented to enable "rather harmless" work-arounds, it
   does in this case effectively enable this security vulnerability again.
 
-  There is no known exploit for this problem.
-
   CWE-924: Improper Enforcement of Message Integrity During Transmission in a
   Communication Channel
 

--- a/docs/CVE-2012-0036.md
+++ b/docs/CVE-2012-0036.md
@@ -35,8 +35,6 @@ IMAP, POP3 and SMTP.
 Both curl the command line tool and applications using the libcurl library
 are vulnerable.
 
-There is no known exploit for this problem.
-
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2012-0036 to this issue.
 

--- a/docs/CVE-2013-0249.md
+++ b/docs/CVE-2013-0249.md
@@ -27,8 +27,6 @@ VULNERABILITY
   Both curl the command line tool and applications using the libcurl library
   are vulnerable.
 
-  There is no known exploit for this problem.
-
   The Common Vulnerabilities and Exposures (CVE) project has assigned the name
   CVE-2013-0249 to this issue.
 

--- a/docs/CVE-2013-1944.md
+++ b/docs/CVE-2013-1944.md
@@ -22,8 +22,6 @@ VULNERABILITY
   Both curl the command line tool and applications using the libcurl library
   are vulnerable.
 
-  There are no known exploits available at this time.
-
   The Common Vulnerabilities and Exposures (CVE) project has assigned the name
   CVE-2013-1944 to this issue.
 

--- a/docs/CVE-2013-2174.md
+++ b/docs/CVE-2013-2174.md
@@ -37,8 +37,6 @@ VULNERABILITY
   The curl command line tool is not affected by this problem as it doesn't use
   this function.
 
-  There are no known exploits available at this time.
-
   The Common Vulnerabilities and Exposures (CVE) project has assigned the name
   CVE-2013-2174 to this issue.
 

--- a/docs/CVE-2013-4545.md
+++ b/docs/CVE-2013-4545.md
@@ -25,8 +25,6 @@ Project curl Security Advisory, November 15th 2013
   The curl command line tool is not affected by this problem as it either
   enables both options or disables both at the same time.
 
-  There are no known exploits available at this time.
-
   The Common Vulnerabilities and Exposures (CVE) project has assigned the name
   CVE-2013-4545 to this issue.
 

--- a/docs/CVE-2013-6422.md
+++ b/docs/CVE-2013-6422.md
@@ -30,8 +30,6 @@ VULNERABILITY
   The curl command line tool is not affected by this problem as it either
   enables both options or disables both at the same time.
 
-  There are no known exploits available at this time.
-
   The Common Vulnerabilities and Exposures (CVE) project has assigned the name
   CVE-2013-6422 to this issue.
 

--- a/docs/CVE-2014-8150.md
+++ b/docs/CVE-2014-8150.md
@@ -20,8 +20,6 @@ user is not stripped good enough this flaw allows malicious users to do
 additional requests in a way that was not intended, or just to insert request
 headers into the request that the program didn't intend.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2014-8151.md
+++ b/docs/CVE-2014-8151.md
@@ -29,8 +29,6 @@ ceritificate check status into account.
 This problem is specific to libcurl built to use the DarwinSSL back-end for
 TLS, so it can only affect Mac and iPhone based applications.
 
-We are not aware of any exploit of this flaw.
-
 DarwinSSL is also known as SecureTransport.
 
 INFO

--- a/docs/CVE-2015-3143.md
+++ b/docs/CVE-2015-3143.md
@@ -33,8 +33,6 @@ This problem is very similar to the previous problem known as
 difference this time is that the subsequent request that wrongly re-use a
 connection doesn't ask for NTLM authentication.
 
-We are not aware of any exploits of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2015-3144.md
+++ b/docs/CVE-2015-3144.md
@@ -19,8 +19,6 @@ At best, this gets unnoticed but can also lead to a crash or worse. We have
 not researched further what kind of malicious actions that potentially this
 could be used for.
 
-We are not aware of any exploits of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2015-3145.md
+++ b/docs/CVE-2015-3145.md
@@ -26,8 +26,6 @@ could be used for.
 Applications have to explicitly enable cookie parsing in libcurl for this
 problem to trigger, and if not enabled libcurl will not hit this problem.
 
-We are not aware of any exploits of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2015-3148.md
+++ b/docs/CVE-2015-3148.md
@@ -22,8 +22,6 @@ connection and sending subsequent requests on it using new credentials, while
 the connection remains authenticated with a previous initial credentials
 setup.
 
-We are not aware of any exploits of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2015-3236.md
+++ b/docs/CVE-2015-3236.md
@@ -33,8 +33,6 @@ one section of a web site, and then do a second request of a public resource
 from a completely different part of the site without authentication. This flaw
 would then inadvertently leak the credentials in the second request.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2015-3237.md
+++ b/docs/CVE-2015-3237.md
@@ -20,8 +20,6 @@ to be valid. This allows carefully handicrafted packages to trick libcurl into
 responding and sending off data that was not intended. Or just crash if the
 values cause libcurl to access invalid memory.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-0754.md
+++ b/docs/CVE-2016-0754.md
@@ -34,9 +34,9 @@ incorrectly write foo to the working directory for drive F even if drive F
 isn't the current drive. For a more detailed explanation see the 'MORE
 BACKGROUND AND EXAMPLE' section towards the end of this advisory.
 
-Though no known exploit is available for this issue, writing one would be
-undemanding and could be serious depending on the name of the file and where
-it ends up being written.
+Though no known exploit is available for this issue at the time of the
+publication, writing one would be undemanding and could be serious depending
+on the name of the file and where it ends up being written.
 
 INFO
 ----

--- a/docs/CVE-2016-0755.md
+++ b/docs/CVE-2016-0755.md
@@ -34,8 +34,6 @@ This problem is very similar to
 [CVE-2014-0015](https://curl.se/docs/CVE-2014-0015.html), which was for
 direct server connections while this is for proxy connections.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-3739.md
+++ b/docs/CVE-2016-3739.md
@@ -33,8 +33,6 @@ Man In The Middle host without noticing.
 Note: PolarSSL is the old name and releases of the library that nowadays is
 known and released under the name mbedTLS.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-4802.md
+++ b/docs/CVE-2016-4802.md
@@ -54,8 +54,6 @@ path. There is nothing we can do to fix this, it is endemic in the design of
 Windows. We advise you to guard write permissions on your application
 directory.**
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-5419.md
+++ b/docs/CVE-2016-5419.md
@@ -18,8 +18,6 @@ previous TLS sessions to speed up subsequent TLS handshakes. They are used
 when for any reason an existing TLS connection couldn't be kept alive to make
 the next handshake faster.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-5420.md
+++ b/docs/CVE-2016-5420.md
@@ -24,8 +24,6 @@ This mistakenly using the wrong connection could of course lead to
 applications sending requests to the wrong realms of the server using
 authentication that it wasn't supposed to have for those operations.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-5421.md
+++ b/docs/CVE-2016-5421.md
@@ -62,8 +62,6 @@ Pseudo code for a bad application
 
 This flaw can also be exploited using libcurl bindings in other languages.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-7141.md
+++ b/docs/CVE-2016-7141.md
@@ -15,8 +15,6 @@ While the symptoms are similar to CVE-2016-5420 (Re-using connection with wrong
 client cert), this vulnerability was caused by an implementation detail of the
 NSS backend in libcurl, which is orthogonal to the cause of CVE-2016-5420.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-7167.md
+++ b/docs/CVE-2016-7167.md
@@ -21,8 +21,6 @@ of heap memory that curl would attempt to write gigabytes of data into.
 The use of 'int' for this input type in the API is of course unwise but has
 remained so in order to maintain the API over the years.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8615.md
+++ b/docs/CVE-2016-8615.md
@@ -20,8 +20,6 @@ would be stored in the file and subsequently that cookie could be read
 partially and crafted correctly, it could be treated as a different cookie for
 another server.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8616.md
+++ b/docs/CVE-2016-8616.md
@@ -15,8 +15,6 @@ protocol that has connection-scoped credentials, an attacker can cause that
 connection to be reused if s/he knows the case-insensitive version of the
 correct password.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8617.md
+++ b/docs/CVE-2016-8617.md
@@ -25,8 +25,6 @@ option), this vulnerability can be triggered. The name has to be at least
 Systems with 64 bit versions of the `size_t` type are not affected by this
 issue.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8618.md
+++ b/docs/CVE-2016-8618.md
@@ -22,8 +22,6 @@ issue.
 
 This behavior is triggable using the publicly exposed function.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8619.md
+++ b/docs/CVE-2016-8619.md
@@ -20,8 +20,6 @@ memory *again* in the error path.
 This flaw could be triggered by a malicious or just otherwise ill-behaving
 server.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8620.md
+++ b/docs/CVE-2016-8620.md
@@ -25,8 +25,6 @@ string was just 4 bytes and end up reading outside the given buffer.
 
 This flaw exists only in the curl tool, not in the libcurl library.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8621.md
+++ b/docs/CVE-2016-8621.md
@@ -21,8 +21,6 @@ of time that was sent in had the final digit cut off, thus ending with a
 single-digit, the date parser code would advance its read pointer one byte too
 much and end up reading out of bounds.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8622.md
+++ b/docs/CVE-2016-8622.md
@@ -17,8 +17,6 @@ lead to libcurl writing outside of its heap based buffer.
 This can be triggered by a user on a 64bit system if the user can send in a
 custom (very large) URL to a libcurl using program.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8623.md
+++ b/docs/CVE-2016-8623.md
@@ -19,8 +19,6 @@ together with its strings, a use-after-free can occur and lead to information
 disclosure. Another thread can also replace the contents of the cookies from
 separate HTTP responses or API calls.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8624.md
+++ b/docs/CVE-2016-8624.md
@@ -19,8 +19,6 @@ same URL.
 
 The problem exists for most protocol schemes.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-8625.md
+++ b/docs/CVE-2016-8625.md
@@ -28,8 +28,6 @@ world of network user-agents about which IDNA version to support and use.
 This name problem exists for DNS-using protocols in curl, but only when built
 to use libidn.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-9586.md
+++ b/docs/CVE-2016-9586.md
@@ -25,8 +25,6 @@ without necessary input filtering, it could allow remote attacks.
 
 This flaw does not exist in the command line tool.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-9594.md
+++ b/docs/CVE-2016-9594.md
@@ -21,8 +21,6 @@ sure libcurl uses strong random as much as possible - provided by the backend
 TLS crypto libraries when present. The faulty function was introduced in [this
 commit](https://github.com/curl/curl/commit/f682156a4fc6c43fb).
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-9952.md
+++ b/docs/CVE-2016-9952.md
@@ -21,8 +21,6 @@ ends with the modified cert name. This means a hostname of example.com would
 match a DNS SAN of *.com, among other variations. This approach violates
 recommendations in RFC 6125 and could lead to MITM attacks.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2016-9953.md
+++ b/docs/CVE-2016-9953.md
@@ -20,8 +20,6 @@ based buffer. This issue could technically leak the contents of memory
 immediately preceding the connection hostname buffer, just a crash or at worst
 happen to match against another piece of data.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-1000099.md
+++ b/docs/CVE-2017-1000099.md
@@ -18,8 +18,6 @@ The wrong buffer was an uninitialized memory area allocated on the heap and if
 it turned out to not contain any zero byte, it would continue and display the
 data following that buffer in memory.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-1000100.md
+++ b/docs/CVE-2017-1000100.md
@@ -21,8 +21,6 @@ redirects to) and trick it to send private memory contents to a remote server
 over UDP. Limit curl's redirect protocols with `--proto-redir` and libcurl's
 with `CURLOPT_REDIR_PROTOCOLS`.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-1000101.md
+++ b/docs/CVE-2017-1000101.md
@@ -19,8 +19,6 @@ of crashing.
 An example of a URL that triggers the flaw would be
 `http://ur%20[0-60000000000000000000`.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-1000254.md
+++ b/docs/CVE-2017-1000254.md
@@ -28,8 +28,6 @@ connections and the mistake has a high chance of causing a segfault.
 The simple fact that this issue has remained undiscovered for this long could
 suggest that malformed PWD responses are rare in benign servers.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-1000257.md
+++ b/docs/CVE-2017-1000257.md
@@ -20,8 +20,6 @@ heap based buffer that might not be zero terminated so libcurl might read
 beyond the end of it into whatever memory lies after (or just crash) and then
 deliver that to the application as if it was actually downloaded.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-2629.md
+++ b/docs/CVE-2017-2629.md
@@ -26,8 +26,6 @@ is in reality.
 This flaw also exists in the command line tool
 ([--cert-status](https://curl.se/docs/manpage.html#--cert-status)).
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-7407.md
+++ b/docs/CVE-2017-7407.md
@@ -26,8 +26,6 @@ issue is specifically only about the `%` part of this flaw.
 
 This flaw only exists in the command line tool.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-7468.md
+++ b/docs/CVE-2017-7468.md
@@ -22,8 +22,6 @@ This flaw is a regression and identical to
 [CVE-2016-5419](https://curl.se/docs/CVE-2016-5419.html) reported on
 August 3rd 2016, but affecting a different version range.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-8816.md
+++ b/docs/CVE-2017-8816.md
@@ -21,8 +21,6 @@ usually causes a very small buffer to actually get allocated instead of the
 intended very huge one, making the use of that buffer end up in a buffer
 overrun.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-8817.md
+++ b/docs/CVE-2017-8817.md
@@ -20,8 +20,6 @@ For applications that use HTTP(S) URLs, allow libcurl to handle redirects and
 have FTP wildcards enabled, this flaw can be triggered by malicious servers
 that can redirect clients to a URL using such a wildcard pattern.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-8818.md
+++ b/docs/CVE-2017-8818.md
@@ -28,8 +28,6 @@ Specifically the vulnerability is present if libcurl was built so that
 `sizeof(long long *) < sizeof(long long)` which as far as we are aware only
 happens in 32-bit builds.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2017-9502.md
+++ b/docs/CVE-2017-9502.md
@@ -17,8 +17,6 @@ Windows or DOS, then libcurl would copy the path with a wrong offset, so that
 the end of the given path would write beyond the malloc buffer. Up to seven
 bytes too much.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-0500.md
+++ b/docs/CVE-2018-0500.md
@@ -27,8 +27,6 @@ the scratch buffer when sending contents of sufficient size and contents.
 The curl command line tool lowers the buffer size when `--limit-rate` is set
 to a value smaller than 16KB.
 
-We are not aware of any exploit of this flaw.
-
 TEST CASES
 ----------
 Here's a shell script

--- a/docs/CVE-2018-1000005.md
+++ b/docs/CVE-2018-1000005.md
@@ -23,8 +23,6 @@ that the (too large) data gets passed to the libcurl callback. This might lead
 to a denial-of-service situation or an information disclosure if someone has a
 service that echoes back or uses the trailers for something.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-1000007.md
+++ b/docs/CVE-2018-1000007.md
@@ -19,8 +19,6 @@ for applications that pass on custom `Authorization:` headers, as this header
 often contains privacy sensitive information or data that could allow others
 to impersonate the curl-using client's request.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-1000120.md
+++ b/docs/CVE-2018-1000120.md
@@ -29,8 +29,6 @@ By using different file part lengths and putting %00 in different places in
 the URL, an attacker that can control what paths a curl-using application uses
 can write that zero byte on different indexes.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-1000121.md
+++ b/docs/CVE-2018-1000121.md
@@ -17,8 +17,6 @@ surprise to us and to the code.
 libcurl-using applications that allow LDAP URLs, or that allow redirects to
 LDAP URLs could be made to crash by a malicious server.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-1000122.md
+++ b/docs/CVE-2018-1000122.md
@@ -18,8 +18,6 @@ several hundreds bytes out of range.
 This could lead to information leakage or a denial of service for the
 application if the server offering the RTSP data can trigger this.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-1000300.md
+++ b/docs/CVE-2018-1000300.md
@@ -23,8 +23,6 @@ This situation was detected by an assert() in the code, but that was of course
 only preventing bad stuff in debug builds. This bug is very unlikely to
 trigger with non-malicious servers.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-1000301.md
+++ b/docs/CVE-2018-1000301.md
@@ -25,8 +25,6 @@ size worth of memory to use.
 This could potentially lead to information leakage but most likely a
 crash/denial of service for applications if a server triggers this flaw.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-14618.md
+++ b/docs/CVE-2018-14618.md
@@ -23,8 +23,6 @@ huge one, making the use of that buffer end up in a heap buffer overflow.
 (This bug is almost identical to
 [CVE-2017-8816](https://curl.se/docs/CVE-2017-8816.html).)
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-16839.md
+++ b/docs/CVE-2018-16839.md
@@ -22,8 +22,6 @@ very huge one, making the use of that buffer end up in a heap buffer overflow.
 (This bug is very similar to
 [CVE-2018-14618](https://curl.se/docs/CVE-2018-14618.html).)
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-16840.md
+++ b/docs/CVE-2018-16840.md
@@ -15,8 +15,6 @@ the library code first frees a struct (without nulling the pointer) and might
 then subsequently erroneously write to a struct field within that already
 freed struct.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-16842.md
+++ b/docs/CVE-2018-16842.md
@@ -29,8 +29,6 @@ situations:
  5. the stderr output may now contain user memory contents that wasn't meant
     to be available
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2018-16890.md
+++ b/docs/CVE-2018-16890.md
@@ -17,8 +17,6 @@ Using that overflow, a malicious or broken NTLM server could trick libcurl to
 accept a bad length + offset combination that would lead to a buffer read
 out-of-bounds.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2019-15601.md
+++ b/docs/CVE-2019-15601.md
@@ -34,8 +34,6 @@ vulnerable to this flaw. Both the curl tool and library.
 
 Example URL exploiting this: `file://localhost//hostname/home/secret.txt`.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2019-3822.md
+++ b/docs/CVE-2019-3822.md
@@ -23,8 +23,6 @@ malicious or broken HTTP server.
 Such a "large value" needs to be around 1000 bytes or more. The actual payload
 data copied to the target buffer comes from the NTLMv2 type-2 response header.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2019-3823.md
+++ b/docs/CVE-2019-3823.md
@@ -15,8 +15,6 @@ no character ending the parsed number, and `len` is set to 5, then the
 `strtol()` call reads beyond the allocated buffer. The read contents will not
 be returned to the caller.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2019-5435.md
+++ b/docs/CVE-2019-5435.md
@@ -14,8 +14,6 @@ buffer overflow.
 The flaws only exist on 32 bit architectures and require excessive string
 input lengths.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2019-5436.md
+++ b/docs/CVE-2019-5436.md
@@ -23,8 +23,6 @@ case for changing the size is to make it larger.
 It is rare for users to use TFTP across the Internet. It is most commonly used
 within local networks.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2019-5481.md
+++ b/docs/CVE-2019-5481.md
@@ -25,8 +25,6 @@ Kerberos FTP is a rarely used protocol with curl. Also, Kerberos
 authentication is usually only attempted and used with servers that the client
 has a previous association with.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2019-5482.md
+++ b/docs/CVE-2019-5482.md
@@ -27,8 +27,6 @@ This issue was introduced by the add of the TFTP BLKSIZE option handling. It
 was previously incompletely fixed by an almost identical issue called
 CVE-2019-5436.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2020-8169.md
+++ b/docs/CVE-2020-8169.md
@@ -67,8 +67,6 @@ that is actually prepended to the host name (ie an observer won't know how
 much data there was on the left side of the `@`), but it can of course be a
 significant enough clue for an attacker to figure out the rest.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2020-8177.md
+++ b/docs/CVE-2020-8177.md
@@ -33,8 +33,6 @@ them like this, until the first CRLF-CRLF sequence appears.
 (Also note that `-J` needs to be used in combination with `-O` to have any
 effect.)
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2020-8231.md
+++ b/docs/CVE-2020-8231.md
@@ -34,8 +34,6 @@ though this is now a new and different connection.
 The application could then accidentally send data over that connection which
 wasn't at all intended for that recipient, entirely unknowingly.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2020-8284.md
+++ b/docs/CVE-2020-8284.md
@@ -26,8 +26,6 @@ If curl operates on a URL provided by a user (which by all means is an unwise
 setup), a user can exploit that and pass in a URL to a malicious FTP server
 instance without needing any server breach to perform the attack.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2020-8285.md
+++ b/docs/CVE-2020-8285.md
@@ -30,8 +30,6 @@ trigger a crash.
 (There is also a few other ways the function can be made to call itself and
 trigger this problem.)
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2020-8286.md
+++ b/docs/CVE-2020-8286.md
@@ -21,8 +21,6 @@ This flaw would allow an attacker, who perhaps could have breached a TLS
 server, to provide a fraudulent OCSP response that would appear fine, instead
 of the real one. Like if the original certificate actually has been revoked.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22876.md
+++ b/docs/CVE-2021-22876.md
@@ -16,8 +16,6 @@ libcurl automatically sets the `Referer:` HTTP request header field in
 outgoing HTTP requests if the `CURLOPT_AUTOREFERER` option is set. With the
 curl tool, it is enabled with `--referer ";auto"`.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22890.md
+++ b/docs/CVE-2021-22890.md
@@ -27,8 +27,6 @@ malicious HTTPS proxy needs to provide a certificate that curl will accept for
 the MITMed server for an attack to work - unless curl has been told to ignore
 the server certificate check.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22897.md
+++ b/docs/CVE-2021-22897.md
@@ -19,8 +19,6 @@ an application sets up multiple concurrent transfers, the last one that sets
 the ciphers will accidentally control the set used by all transfers. In a
 worst-case scenario, this weakens transport security significantly.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22898.md
+++ b/docs/CVE-2021-22898.md
@@ -35,8 +35,6 @@ An easy proof of concept command line looks like this:
 
     curl telnet://example.com -tNEW_ENV=a,bbbbbb (256 'b's)
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22901.md
+++ b/docs/CVE-2021-22901.md
@@ -29,8 +29,6 @@ using that memory, libcurl might even call a function pointer in the object,
 making it possible for a remote code execution if the server could somehow
 manage to get crafted memory content into the correct place in memory.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22922.md
+++ b/docs/CVE-2021-22922.md
@@ -26,8 +26,6 @@ disk.
 There's a risk the user doesn't notice the message and instead assumes the
 file is fine.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22923.md
+++ b/docs/CVE-2021-22923.md
@@ -13,8 +13,6 @@ credentials are then subsequently passed on to each of the servers from which
 curl will download or try to download the contents from. Often contrary to the
 user's expectations and intentions and without telling the user it happened.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22924.md
+++ b/docs/CVE-2021-22924.md
@@ -20,11 +20,8 @@ even vary depending on used file systems.
 The comparison also didn't include the 'issuer cert' which a transfer can set
 to qualify how to verify the server certificate.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
-
 This flaw has existed in curl since commit
 [89721ff04af70f](https://github.com/curl/curl/commit/89721ff04af70f) in
 libcurl 7.10.4, released on April 2, 2003.

--- a/docs/CVE-2021-22925.md
+++ b/docs/CVE-2021-22925.md
@@ -24,8 +24,6 @@ The previous curl security vulnerability
 to this one but the fix was insufficient so this security vulnerability
 remained.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22926.md
+++ b/docs/CVE-2021-22926.md
@@ -22,8 +22,6 @@ same name as the app wants to use by name, and thereby trick the application
 to use the file based cert instead of the one referred to by name making
 libcurl send the wrong client certificate in the TLS connection handshake.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22945.md
+++ b/docs/CVE-2021-22945.md
@@ -11,8 +11,6 @@ When sending data to an MQTT server, libcurl could in some circumstances
 erroneously keep a pointer to an already freed memory area and both use that
 again in a subsequent call to send data and also free it *again*.
 
-We are not aware of any case of this flaw having been exploited in the wild.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22946.md
+++ b/docs/CVE-2021-22946.md
@@ -17,8 +17,6 @@ This flaw would then make curl silently continue its operations **without
 TLS** contrary to the instructions and expectations, exposing possibly
 sensitive data in clear text over the network.
 
-We are not aware of any case of this flaw having been exploited in the wild.
-
 INFO
 ----
 

--- a/docs/CVE-2021-22947.md
+++ b/docs/CVE-2021-22947.md
@@ -21,8 +21,6 @@ injected data comes from the TLS-protected server.
 
 Over POP3 and IMAP an attacker can inject fake response data.
 
-We are not aware of any case of this flaw having been exploited in the wild.
-
 INFO
 ----
 

--- a/docs/CVE-2022-22576.md
+++ b/docs/CVE-2022-22576.md
@@ -23,8 +23,6 @@ erroneously reused even for user + [other OAUTH2 bearer], even though that
 might not even be a valid bearer. This could lead to an authentication bypass,
 either by mistake or by a malicious actor.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27774.md
+++ b/docs/CVE-2022-27774.md
@@ -22,8 +22,6 @@ way.
 By default, curl only allows redirects to HTTP(S) and FTP(S), but can be asked
 to allow redirects to all protocols curl supports.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27775.md
+++ b/docs/CVE-2022-27775.md
@@ -15,8 +15,6 @@ address zone id into account which could lead to libcurl reusing the wrong
 connection when one transfer uses a zone id and a subsequent transfer uses
 another (or no) zone id.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27776.md
+++ b/docs/CVE-2022-27776.md
@@ -24,8 +24,6 @@ headers, as those headers often contain privacy sensitive information or data.
 curl and libcurl have options that allow users to opt out from this check, but
 that is not set by default.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27778.md
+++ b/docs/CVE-2022-27778.md
@@ -19,8 +19,6 @@ If curl adds a number to not "clobber" the output and an error occurs during
 transfer, the remove on error logic would remove the *original* file name
 without the added number.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27779.md
+++ b/docs/CVE-2022-27779.md
@@ -19,8 +19,6 @@ TLDs. This check was broken if the host name in the URL uses a trailing dot.
 This can allow arbitrary sites to set cookies that then would get sent to a
 different and unrelated site or domain.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27780.md
+++ b/docs/CVE-2022-27780.md
@@ -15,8 +15,6 @@ For example, a URL like `http://example.com%2F10.0.0.1/`, would be allowed by
 the parser and get transposed into `http://example.com/10.0.0.1/`. This flaw
 can be used to circumvent filters, checks and more.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27781.md
+++ b/docs/CVE-2022-27781.md
@@ -14,8 +14,6 @@ Due to an erroneous function, a malicious server could make libcurl built with
 NSS get stuck in a never-ending busy-loop when trying to retrieve that
 information.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-27782.md
+++ b/docs/CVE-2022-27782.md
@@ -15,8 +15,6 @@ transfers to reuse if one of them matches the setup. However, several TLS and
 SSH settings were left out from the configuration match checks, making them
 match too easily.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-30115.md
+++ b/docs/CVE-2022-30115.md
@@ -19,8 +19,6 @@ trailing dot in the URL.
 Since trailing dots in host names are somewhat special, many sites work
 equally fine with or without a trailing dot present.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-32205.md
+++ b/docs/CVE-2022-32205.md
@@ -20,8 +20,6 @@ and haven't expired. Due to cookie matching rules, a server on
 making it it possible for a "sister server" to effectively cause a denial of
 service for a sibling site on the same second level domain using this method.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-32206.md
+++ b/docs/CVE-2022-32206.md
@@ -17,8 +17,6 @@ The use of such a decompression chain could result in a "malloc bomb", making
 curl end up spending enormous amounts of allocated heap memory, or trying to
 and returning out of memory errors.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-32207.md
+++ b/docs/CVE-2022-32207.md
@@ -15,8 +15,6 @@ In that rename operation, it might accidentally *widen* the permissions for
 the target file, leaving the updated file accessible to more users than
 intended.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-32208.md
+++ b/docs/CVE-2022-32208.md
@@ -11,8 +11,6 @@ When curl does FTP transfers secured by krb5, it handles message verification
 failures wrongly. This flaw makes it possible for a Man-In-The-Middle attack
 to go unnoticed and even allows it to inject data to the client.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-32221.md
+++ b/docs/CVE-2022-32221.md
@@ -19,8 +19,6 @@ send off the wrong data or use memory after free or similar in the subsequent
 The problem exists in the logic for a reused handle when it is changed from a
 PUT to a POST.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-35252.md
+++ b/docs/CVE-2022-35252.md
@@ -13,8 +13,6 @@ such control codes are later sent back to an HTTP(S) server, it might make the
 server return a 400 response. Effectively allowing a "sister site" to deny
 service to siblings.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-35260.md
+++ b/docs/CVE-2022-35260.md
@@ -18,8 +18,6 @@ also cause different outcomes.
 If a malicious user can provide a custom netrc file to an application or
 otherwise affect its contents, this flaw could be used as denial-of-service.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-42915.md
+++ b/docs/CVE-2022-42915.md
@@ -19,8 +19,6 @@ Due to flaws in the error/cleanup handling, this could trigger a double-free
 in curl if one of the following schemes were used in the URL for the transfer:
 `dict`, `gopher`, `gophers`, `ldap`, `ldaps`, `rtmp`, `rtmps`, `telnet`
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-42916.md
+++ b/docs/CVE-2022-42916.md
@@ -18,8 +18,6 @@ instead of the common ASCII full stop (U+002E) `.`.
 
 Like this: `http://curl。se。`
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-43551.md
+++ b/docs/CVE-2022-43551.md
@@ -24,8 +24,6 @@ Reproducible like this:
     curl --hsts hsts.txt https://curl%E3%80%82se
     curl --hsts hsts.txt http://curl%E3%80%82se
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2022-43552.md
+++ b/docs/CVE-2022-43552.md
@@ -15,8 +15,6 @@ When getting denied to tunnel the specific protocols SMB or TELNET, curl would
 use a heap-allocated struct after it had been freed, in its transfer shutdown
 code path.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-23914.md
+++ b/docs/CVE-2023-23914.md
@@ -22,8 +22,6 @@ Reproducible like this:
 The first URL returns HSTS information that the second URL fails to take
 advantage of.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-23915.md
+++ b/docs/CVE-2023-23915.md
@@ -24,8 +24,6 @@ Reproducible like this:
 1. `curl --hsts hsts.txt --parallel https://curl.se https://example.com`
 2. `curl --hsts hsts.txt http://curl.se`
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-23916.md
+++ b/docs/CVE-2023-23916.md
@@ -18,8 +18,6 @@ The use of such a decompression chain could result in a "malloc bomb", making
 curl end up spending enormous amounts of allocated heap memory, or trying to
 and returning out of memory errors.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-27533.md
+++ b/docs/CVE-2023-27533.md
@@ -18,8 +18,6 @@ pass on content or do option negotiation without the application intending to
 do so. In particular if an application for example allows users to provide the
 data or parts of the data.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-27534.md
+++ b/docs/CVE-2023-27534.md
@@ -25,8 +25,6 @@ home directory `/home/dan`) would then quite surprisingly access the file
 
 This can be taken advantage of to circumvent filtering or worse.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-27535.md
+++ b/docs/CVE-2023-27535.md
@@ -19,8 +19,6 @@ too easily. The settings in questions are `CURLOPT_FTP_ACCOUNT`,
 `CURLOPT_FTP_ALTERNATIVE_TO_USER`, `CURLOPT_FTP_SSL_CCC` and `CURLOPT_USE_SSL`
 level.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-27536.md
+++ b/docs/CVE-2023-27536.md
@@ -16,8 +16,6 @@ transfers to reuse if one of them matches the setup. However, this GSS
 delegation setting was left out from the configuration match checks, making
 them match too easily, affecting krb5/kerberos/negotiate/GSSAPI transfers.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-27537.md
+++ b/docs/CVE-2023-27537.md
@@ -14,8 +14,6 @@ but there was no indication of this fact in the documentation.
 Due to missing mutexes or thread locks, two threads sharing the same HSTS data
 could end up doing a double-free or use-after-free.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 

--- a/docs/CVE-2023-27538.md
+++ b/docs/CVE-2023-27538.md
@@ -15,8 +15,6 @@ transfers to reuse if one of them matches the setup. However, two SSH settings
 were left out from the configuration match checks, making them match too
 easily.
 
-We are not aware of any exploit of this flaw.
-
 INFO
 ----
 


### PR DESCRIPTION
... and variations from all security advisories.

- it was used as a blanket statement and in some cases wrongly from the get go

- it is a statement about the state at the time of the publish but since it lingers around on the site the statement risk turning incorrect in many cases

- it was not very clear exactly what this meant