### PR TITLE
vuln2json: add the 'versions' array

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -426,7 +426,7 @@ allvulns.gen: $(ROOT)/_changes.html ./vulntable.pl vuln.pm _singlevuln.templ
 vuln.csv: vuln.pm
 	./vuln2csv.pl > $@
 
-vuln.json: vuln.pm vuln2json.pl $(CVELIST)
+vuln.json: vuln.pm vuln2json.pl $(CVELIST) releases.csv
 	./vuln2json.pl > $@
 
 http2.gen: $(SRCROOT)/docs/HTTP2.md


### PR DESCRIPTION
This is an array listing all curl versions that are affected by the particular vulnerability.

Example object:
~~~json
{
  "id": "CVE-2022-32207",
  "summary": "Unpreserved file permissions",
  "URL": "https://curl.se/docs/CVE-2022-32207.html",
  "modified": "2023-05-02T13:52:45+02:00Z",
  "CWE": "CWE-281: Improper Preservation of Permissions",
  "published": "2022-06-27",
  "affected": [
    {
      "package": {
        "name": "curl",
        "purl": "pkg:generic/curl"
      },
      "ranges": [
        {
           "type": "SEMVER",
           "events": [
             {"introduced": "7.69.0"},
             {"last": "7.83.1"},
             {"fixed": "7.84.0"}
           ]
        }
      ],
      "versions": [
        "7.83.1", "7.83.0", "7.82.0", "7.81.0", "7.80.0", "7.79.1", "7.79.0", 
        "7.78.0", "7.77.0", "7.76.1", "7.76.0", "7.75.0", "7.74.0", "7.73.0", 
        "7.72.0", "7.71.1", "7.71.0", "7.70.0", "7.69.1", "7.69.0"
      ]
    }
  ],
  "severity": [
    {
      "type": "basic",
      "score": "Medium"
    },
    {
      "type": "CVSS_V3",
      "score": "4.0"
    }
  ],
  "credits": [
    {
      "name": "Harry Sintonen",
      "type": "FINDER"
    },
    {
      "name": "Daniel Stenberg",
      "type": "REMEDIATION_DEVELOPER"
    }
  ],
  "details": "When curl saves cookies, alt-svc and hsts data to local files, it makes the\noperation atomic by finalizing the operation with a rename from a temporary\nname to the final target file name.\n\nIn that rename operation, it might accidentally *widen* the permissions for\nthe target file, leaving the updated file accessible to more users than\nintended."
}