### PR TITLE
vuln2json.pl: adapted to the schema more

### DIFF
--- a/docs/vuln2json.pl
+++ b/docs/vuln2json.pl
@@ -139,12 +139,17 @@ for(@vuln) {
     my $v = inclusive($first, $last, "        ");
     push @single,
         "{\n".
-        "  \"id\": \"$cve\",\n".
+        "  \"id\": \"CURL-$cve\",\n".
+        "  \"aliases\": [\n".
+        "    \"$cve\"\n".
+        "  ],\n".
         "  \"summary\": \"$name\",\n".
-        "  \"URL\": \"https://curl.se/docs/$cve.html\",\n".
         "  \"modified\": \"${modified}Z\",\n".
-        "  \"CWE\": \"$cwe\",\n".
-        "  \"published\": \"$announce\",\n".
+        "  \"database_specific\": {\n".
+        "    \"URL\": \"https://curl.se/docs/$cve.html\",\n".
+        "    \"CWE\": \"$cwe\"\n".
+        "  },\n".
+        "  \"published\": \"${announce}T08:00:00Z\",\n".
         "  \"affected\": [\n".
         "    {\n".
         "      \"package\": {\n".
@@ -156,7 +161,7 @@ for(@vuln) {
         "           \"type\": \"SEMVER\",\n".
         "           \"events\": [\n".
         "             {\"introduced\": \"$first\"},\n".
-        "             {\"last\": \"$last\"},\n".
+        "             {\"last_affected\": \"$last\"},\n".
         "             {\"fixed\": \"$fixed\"}\n".
         "           ]\n".
         "        }\n".


### PR DESCRIPTION
- Provide a bogus (curl) Id and make the CVE an alias
- Add a (made up) time to the published string to make it correct syntax
- Provide URL and CWE in a "database_specific" object
- Rename 'last' to 'last_affected' within the affected ranges

Reported-by: Oliver Chang

Ref: #240

## Example

The first JSON object now looks like this:
~~~json
{
  "id": "CURL-CVE-2023-27538",
  "aliases": [
    "CVE-2023-27538"
  ],
  "summary": "SSH connection too eager reuse still",
  "modified": "2023-05-02T13:52:45+02:00Z",
  "database_specific": {
    "URL": "https://curl.se/docs/CVE-2023-27538.html",
    "CWE": "CWE-305: Authentication Bypass by Primary Weakness"
  },
  "published": "2023-03-20T08:00:00Z",
  "affected": [
    {
      "package": {
        "name": "curl",
        "purl": "pkg:generic/curl"
      },
      "ranges": [
        {
           "type": "SEMVER",
           "events": [
             {"introduced": "7.16.1"},
             {"last_affected": "7.88.1"},
             {"fixed": "8.0.0"}
           ]
        }
      ],
      "versions": [
        "7.88.1", "7.88.0", "7.87.0", "7.86.0", "7.85.0", "7.84.0", "7.83.1", 
        "7.83.0", "7.82.0", "7.81.0", "7.80.0", "7.79.1", "7.79.0", "7.78.0", 
        "7.77.0", "7.76.1", "7.76.0", "7.75.0", "7.74.0", "7.73.0", "7.72.0", 
        "7.71.1", "7.71.0", "7.70.0", "7.69.1", "7.69.0", "7.68.0", "7.67.0", 
        "7.66.0", "7.65.3", "7.65.2", "7.65.1", "7.65.0", "7.64.1", "7.64.0", 
        "7.63.0", "7.62.0", "7.61.1", "7.61.0", "7.60.0", "7.59.0", "7.58.0", 
        "7.57.0", "7.56.1", "7.56.0", "7.55.1", "7.55.0", "7.54.1", "7.54.0", 
        "7.53.1", "7.53.0", "7.52.1", "7.52.0", "7.51.0", "7.50.3", "7.50.2", 
        "7.50.1", "7.50.0", "7.49.1", "7.49.0", "7.48.0", "7.47.1", "7.47.0", 
        "7.46.0", "7.45.0", "7.44.0", "7.43.0", "7.42.1", "7.42.0", "7.41.0", 
        "7.40.0", "7.39.0", "7.38.0", "7.37.1", "7.37.0", "7.36.0", "7.35.0", 
        "7.34.0", "7.33.0", "7.32.0", "7.31.0", "7.30.0", "7.29.0", "7.28.1", 
        "7.28.0", "7.27.0", "7.26.0", "7.25.0", "7.24.0", "7.23.1", "7.23.0", 
        "7.22.0", "7.21.7", "7.21.6", "7.21.5", "7.21.4", "7.21.3", "7.21.2", 
        "7.21.1", "7.21.0", "7.20.1", "7.20.0", "7.19.7", "7.19.6", "7.19.5", 
        "7.19.4", "7.19.3", "7.19.2", "7.19.1", "7.19.0", "7.18.2", "7.18.1", 
        "7.18.0", "7.17.1", "7.17.0", "7.16.4", "7.16.3", "7.16.2", "7.16.1"
      ]
    }
  ],
  "severity": [
    {
      "type": "basic",
      "score": "Low"
    },
    {
      "type": "CVSS_V3",
      "score": "1.0"
    }
  ],
  "credits": [
    {
      "name": "Harry Sintonen",
      "type": "FINDER"
    },
    {
      "name": "Daniel Stenberg",
      "type": "REMEDIATION_DEVELOPER"
    }
  ],
  "details": "libcurl would reuse a previously created connection even when an SSH related\noption had been changed that should have prohibited reuse.\n\nlibcurl keeps previously used connections in a connection pool for subsequent\ntransfers to reuse if one of them matches the setup. However, two SSH settings\nwere left out from the configuration match checks, making them match too\neasily."
}