### PR TITLE
vulntable.pl: remove CVE and CWE from table

### DIFF
--- a/docs/_singlevuln.templ
+++ b/docs/_singlevuln.templ
@@ -2,11 +2,6 @@
 <html>
 <head> <title>Vulnerabilities in curl %version</title>
 #include "css.t"
-<style type="text/css">
-.contents {
-  max-width: 95%;
-}
-</style>
 </head>
 
 #define CURL_DOCS

--- a/docs/vulntable.pl
+++ b/docs/vulntable.pl
@@ -62,31 +62,14 @@ sub single {
     my $vulnplural;
 
     if($vulnnum) {
-        $vulnhtml = "<table><tr class=\"tabletop\"><th>Flaw</th><th>From version</th><th>To and including</th><th>CVE</th><th>CWE</th></tr>";
+        $vulnhtml = "<table><tr class=\"tabletop\"><th>Flaw</th><th>From version</th><th>To and including</th></tr>";
 
         for my $i (@v) {
-            my $c = $cve[$i];
-            if($c ne "-") {
-                $c = "<a href=\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=$c\">$c</a>";
-            }
-            else {
-                $c = "";
-            }
-            my $cstr="";
-            if($cwe[$i]) {
-                my $n = $cwe[$i];
-                if($n =~ /^CWE-(\d+)/) {
-                    $n = $1;
-                }
-                $cstr = "<a href=\"https://cwe.mitre.org/data/definitions/$n.html\">$cwe[$i]</a>";
-            }
-
-            $vulnhtml .= sprintf("<tr class=\"%s\"><td><a href=\"%s\">%s</a></td><td><a href=\"vuln-%s.html\">%s</a></td><td><a href=\"vuln-%s.html\">%s</a></td><td>$c</td><td>%s</td></tr>\n",
+            $vulnhtml .= sprintf("<tr class=\"%s\"><td><a href=\"%s\">%s</a></td><td><a href=\"vuln-%s.html\">%s</a></td><td><a href=\"vuln-%s.html\">%s</a></td></tr>\n",
                                  $odd&1?"even":"odd",
                                  $vurl[$i], $vulndesc[$i],
                                  $vstart[$i], $vstart[$i],
-                                 $vstop[$i], $vstop[$i],
-                                 $cstr);
+                                 $vstop[$i], $vstop[$i]);
             $odd++;
         }
         $vulnhtml .= "</table>";


### PR DESCRIPTION
This simplifies the table by removing two columns that aren't usually that interested when you look at this overview. The info is still provided in every individual page.

This makes the table much easier on the eye.