### PR TITLE
Update licenses for OpenSSL and NSS in comparison table

### DIFF
--- a/docs/_ssl-compared.html
+++ b/docs/_ssl-compared.html
@@ -298,9 +298,9 @@ to use.
 
  NEWLINE
   FEAT License ENDFEAT
-  FEAT 4-clause BSD ENDFEAT
+  FEAT Apache-2.0 (since OpenSSL 3.0) ENDFEAT
   FEAT LGPL ENDFEAT
-  FEAT MPL/LGPL/GPL ENDFEAT
+  FEAT MPL-2.0 (since NSS 3.14) ENDFEAT
   FEAT GPLv2 / prop ENDFEAT
   FEAT Apache 2.0 license / GPLv2 ENDFEAT
   FEAT Proprietary ENDFEAT


### PR DESCRIPTION
Since OpenSSL 3.0, OpenSSL uses the Apache-2.0 license. NSS is licensed under the MPL-2.0 license since version 3.14.