### PR TITLE
fix docker pull pull/download invoke

### DIFF
--- a/_download.html
+++ b/_download.html
@@ -74,7 +74,7 @@ SUBTITLE(Official curl docker images)
     The official curl docker images are available at:
     <ul>
         <li><a href="https://quay.io/repository/curl/curl?tab=info">Quay.io</a>: > podman run quay.io/curl/curl:latest</li>
-        <li><a href="https://hub.docker.com/r/curlimages/curl">Docker hub</a>: > podman run curl/curl:latest</li>
+        <li><a href="https://hub.docker.com/r/curlimages/curl">Docker hub</a>: > podman run curlimages/curl:latest</li>
     </ul>
 
     #include "_footer.html"


### PR DESCRIPTION
I had made previous branch assuming we would get curl/curl on docker ... now not going to pursue that anymore so switching invoke to pull from docker to reflect that