### PR TITLE
docs/listvulns: redo the severity symbols without unicode

### DIFF
--- a/docs/listvulns.pl
+++ b/docs/listvulns.pl
@@ -39,17 +39,17 @@ sub sev2color {
     }
     elsif($sev =~ /^Low/i) {
         $col = "green";
-        $sym = "&#9409;";
+        $sym = "L";
     }
     elsif($sev =~ /^Medium/i) {
         $col = "orange";
-        $sym = "&#9410;";
+        $sym = "M";
     }
     else {
         $col = "red";
-        $sym = "&#9405;";
+        $sym = "H";
     }
-    return "<div style=\"color:$col;\">$sym</div>";
+    return "<div style=\"color: white; border-radius: 8px; background: $col; text-align: center;\">$sym</div>";
 }
 
 my $num = $#vuln + 1;
@@ -64,11 +64,16 @@ for(@vuln) {
     my $sev = cve2severity($cve);
     my $col;
     $c = sev2color($sev);
+    my $sevcol="<td></td>";
+    if($sev) {
+        $sevcol = "<td title=\"Severity $sev\">$c</td>";
+    }
+        
     
     print <<VUL
 <tr>
 <td>$num</td>
-<td title="$sev">$c</td>
+$sevcol
 <td><a href="$id">$cve: $desc</a></td>
 <td>$year-$mon-$day</td>
 <td><a href="vuln-$start.html">$start</a></td>


### PR DESCRIPTION
To work better with more fonts and browsers

Follow-up to 38bc35b1c7cc562fdb30a7d2e52

New look:
![Screenshot 2023-06-01 at 17-56-22 curl - Security](https://github.com/curl/curl-www/assets/177011/86db77ec-299b-4dca-a84f-f2469be13af1)
