### PR TITLE
docs: add Severity to sec advisories missing them

### DIFF
--- a/docs/CVE-2000-0973.md
+++ b/docs/CVE-2000-0973.md
@@ -19,6 +19,8 @@ CVE-2000-0973 to this issue.
 
 CWE-121: Stack-based Buffer Overflow
 
+Severity: Critical
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2003-1605.md
+++ b/docs/CVE-2003-1605.md
@@ -22,6 +22,8 @@ CVE-2003-1605 to this issue.
 
 CWE-201: Information Exposure Through Sent Data
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2005-0490.md
+++ b/docs/CVE-2005-0490.md
@@ -22,6 +22,8 @@ CVE-2005-0490 to this issue.
 
 CWE-121: Stack-based Buffer Overflow
 
+Severity: High
+
 (This flaw was originally treated as two separate ones by the curl project,
 but due to it using a single CVE number we've reconsidered.)
 

--- a/docs/CVE-2005-3185.md
+++ b/docs/CVE-2005-3185.md
@@ -26,6 +26,8 @@ CAN-2005-3185 to this issue.
 
 CWE-121: Stack-based Buffer Overflow
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2005-4077.md
+++ b/docs/CVE-2005-4077.md
@@ -37,6 +37,8 @@ CVE-2005-4077 to this issue.
 
 CWE-122: Heap-based Buffer Overflow
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2006-1061.md
+++ b/docs/CVE-2006-1061.md
@@ -26,6 +26,8 @@ CVE-2006-1061 to this issue.
 
 CWE-122: Heap-based Buffer Overflow
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2007-3564.md
+++ b/docs/CVE-2007-3564.md
@@ -22,6 +22,8 @@ CVE-2007-3564 to this issue.
 
 CWE-298: Improper Validation of Certificate Expiration
 
+Severity: Low
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2009-0037.md
+++ b/docs/CVE-2009-0037.md
@@ -39,6 +39,8 @@ CVE-2009-0037 to this issue.
 
 CWE-142: Improper Neutralization of Value Delimiters
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2009-2417.md
+++ b/docs/CVE-2009-2417.md
@@ -33,6 +33,8 @@ CVE-2009-2417 to this issue.
 
 CWE-170: Improper Null Termination
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2010-0734.md
+++ b/docs/CVE-2010-0734.md
@@ -36,6 +36,8 @@ CVE-2010-0734 to this issue.
 
 CWE-628: Function Call with Incorrectly Specified Arguments
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2010-3842.md
+++ b/docs/CVE-2010-3842.md
@@ -35,6 +35,8 @@ CVE-2010-3842 to this issue.
 
 CWE-30: Path Traversal
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2011-2192.md
+++ b/docs/CVE-2011-2192.md
@@ -25,6 +25,8 @@ CVE-2011-2192 to this issue.
 
 CWE-281: Improper Preservation of Permissions
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2011-3389.md
+++ b/docs/CVE-2011-3389.md
@@ -30,6 +30,8 @@ CVE-2011-3389 to this issue.
 
 CWE-924: Improper Enforcement of Message Integrity During Transmission in a Communication Channel
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2012-0036.md
+++ b/docs/CVE-2012-0036.md
@@ -43,6 +43,8 @@ CVE-2012-0036 to this issue.
 
 CWE-93: Improper Neutralization of CRLF Sequences ('CRLF Injection')
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2013-0249.md
+++ b/docs/CVE-2013-0249.md
@@ -30,10 +30,12 @@ VULNERABILITY
 INFO
 ----
 
-  The Common Vulnerabilities and Exposures (CVE) project has assigned the name
-  CVE-2013-0249 to this issue.
+The Common Vulnerabilities and Exposures (CVE) project has assigned the name
+CVE-2013-0249 to this issue.
 
-  CWE-121: Stack-based Buffer Overflow
+CWE-121: Stack-based Buffer Overflow
+
+Severity: Critical
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2013-1944.md
+++ b/docs/CVE-2013-1944.md
@@ -25,10 +25,12 @@ VULNERABILITY
 INFO
 ----
 
-  The Common Vulnerabilities and Exposures (CVE) project has assigned the name
-  CVE-2013-1944 to this issue.
+The Common Vulnerabilities and Exposures (CVE) project has assigned the name
+CVE-2013-1944 to this issue.
 
-  CWE-201: Information Exposure Through Sent Data
+CWE-201: Information Exposure Through Sent Data
+
+Severity: High
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2013-2174.md
+++ b/docs/CVE-2013-2174.md
@@ -40,10 +40,12 @@ VULNERABILITY
 INFO
 ----
 
-  The Common Vulnerabilities and Exposures (CVE) project has assigned the name
-  CVE-2013-2174 to this issue.
+The Common Vulnerabilities and Exposures (CVE) project has assigned the name
+CVE-2013-2174 to this issue.
 
-  CWE-126: Buffer Over-read
+CWE-126: Buffer Over-read
+
+Severity: High
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2013-4545.md
+++ b/docs/CVE-2013-4545.md
@@ -29,10 +29,12 @@ VULNERABILITY
 INFO
 ----
 
-  The Common Vulnerabilities and Exposures (CVE) project has assigned the name
-  CVE-2013-4545 to this issue.
+The Common Vulnerabilities and Exposures (CVE) project has assigned the name
+CVE-2013-4545 to this issue.
 
-  CWE-297: Improper Validation of Certificate with Host Mismatch
+CWE-297: Improper Validation of Certificate with Host Mismatch
+
+Severity: Medium
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2013-6422.md
+++ b/docs/CVE-2013-6422.md
@@ -33,10 +33,12 @@ VULNERABILITY
 INFO
 ----
 
-  The Common Vulnerabilities and Exposures (CVE) project has assigned the name
-  CVE-2013-6422 to this issue.
+The Common Vulnerabilities and Exposures (CVE) project has assigned the name
+CVE-2013-6422 to this issue.
 
-  CWE-297: Improper Validation of Certificate with Host Mismatch
+CWE-297: Improper Validation of Certificate with Host Mismatch
+
+Severity: Medium
 
 AFFECTED VERSIONS
 -----------------

--- a/docs/CVE-2014-0015.md
+++ b/docs/CVE-2014-0015.md
@@ -49,6 +49,8 @@ CVE-2014-0015 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-0138.md
+++ b/docs/CVE-2014-0138.md
@@ -42,6 +42,8 @@ CVE-2014-0138 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-0139.md
+++ b/docs/CVE-2014-0139.md
@@ -47,6 +47,8 @@ CVE-2014-0139 to this issue.
 
 CWE-297: Improper Validation of Certificate with Host Mismatch
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-1263.md
+++ b/docs/CVE-2014-1263.md
@@ -32,6 +32,8 @@ CVE-2014-1263 to this issue.
 
 CWE-297: Improper Validation of Certificate with Host Mismatch
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-2522.md
+++ b/docs/CVE-2014-2522.md
@@ -27,6 +27,8 @@ CVE-2014-2522 to this issue.
 
 CWE-297: Improper Validation of Certificate with Host Mismatch
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-3613.md
+++ b/docs/CVE-2014-3613.md
@@ -40,6 +40,8 @@ CVE-2014-3613 to this issue.
 
 CWE-201: Information Exposure Through Sent Data
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-3620.md
+++ b/docs/CVE-2014-3620.md
@@ -28,6 +28,8 @@ CVE-2014-3620 to this issue.
 
 CWE-201: Information Exposure Through Sent Data
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-3707.md
+++ b/docs/CVE-2014-3707.md
@@ -67,6 +67,8 @@ CVE-2014-3707 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-8150.md
+++ b/docs/CVE-2014-8150.md
@@ -31,6 +31,8 @@ CVE-2014-8150 to this issue.
 
 CWE-444: Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2014-8151.md
+++ b/docs/CVE-2014-8151.md
@@ -40,6 +40,8 @@ CVE-2014-8151 to this issue.
 
 CWE-297: Improper Validation of Certificate with Host Mismatch
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2015-3143.md
+++ b/docs/CVE-2015-3143.md
@@ -44,6 +44,8 @@ CVE-2015-3143 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2015-3144.md
+++ b/docs/CVE-2015-3144.md
@@ -29,6 +29,8 @@ CVE-2015-3144 to this issue.
 
 CWE-124: Buffer Underwrite ('Buffer Underflow')
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2015-3145.md
+++ b/docs/CVE-2015-3145.md
@@ -37,6 +37,8 @@ CVE-2015-3145 to this issue.
 
 CWE-124: Buffer Underwrite ('Buffer Underflow')
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2015-3148.md
+++ b/docs/CVE-2015-3148.md
@@ -33,6 +33,8 @@ CVE-2015-3148 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2015-3153.md
+++ b/docs/CVE-2015-3153.md
@@ -45,6 +45,8 @@ CVE-2015-3153 to this issue.
 
 CWE-201: Information Exposure Through Sent Data
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2015-3236.md
+++ b/docs/CVE-2015-3236.md
@@ -44,6 +44,8 @@ CVE-2015-3236 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2015-3237.md
+++ b/docs/CVE-2015-3237.md
@@ -31,6 +31,8 @@ CVE-2015-3237 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-0754.md
+++ b/docs/CVE-2016-0754.md
@@ -49,6 +49,8 @@ CVE-2016-0754 to this issue.
 
 CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-0755.md
+++ b/docs/CVE-2016-0755.md
@@ -45,6 +45,8 @@ CVE-2016-0755 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-3739.md
+++ b/docs/CVE-2016-3739.md
@@ -43,6 +43,8 @@ CVE-2016-3739 to this issue.
 
 CWE-297: Improper Validation of Certificate with Host Mismatch
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-4802.md
+++ b/docs/CVE-2016-4802.md
@@ -64,6 +64,8 @@ CVE-2016-4802 to this issue.
 
 CWE-94: Improper Control of Generation of Code ('Code Injection')
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-5419.md
+++ b/docs/CVE-2016-5419.md
@@ -28,6 +28,8 @@ CVE-2016-5419 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-5420.md
+++ b/docs/CVE-2016-5420.md
@@ -34,6 +34,8 @@ CVE-2016-5420 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-5421.md
+++ b/docs/CVE-2016-5421.md
@@ -72,6 +72,8 @@ CVE-2016-5421 to this issue.
 
 CWE-416: Use After Free
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-7141.md
+++ b/docs/CVE-2016-7141.md
@@ -25,6 +25,8 @@ CVE-2016-7141 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-7167.md
+++ b/docs/CVE-2016-7167.md
@@ -31,6 +31,8 @@ CVE-2016-7167 to this issue.
 
 CWE-131: Incorrect Calculation of Buffer Size
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8615.md
+++ b/docs/CVE-2016-8615.md
@@ -28,6 +28,8 @@ CVE-2016-8615 to this issue.
 
 CWE-187: Partial Comparison
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8616.md
+++ b/docs/CVE-2016-8616.md
@@ -23,6 +23,8 @@ CVE-2016-8616 to this issue.
 
 CWE-178: Improper Handling of Case Sensitivity
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8617.md
+++ b/docs/CVE-2016-8617.md
@@ -33,6 +33,8 @@ CVE-2016-8617 to this issue.
 
 CWE-131: Incorrect Calculation of Buffer Size
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8618.md
+++ b/docs/CVE-2016-8618.md
@@ -30,6 +30,8 @@ CVE-2016-8618 to this issue.
 
 CWE-415: Double Free
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8619.md
+++ b/docs/CVE-2016-8619.md
@@ -28,6 +28,8 @@ CVE-2016-8619 to this issue.
 
 CWE-415: Double Free
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8620.md
+++ b/docs/CVE-2016-8620.md
@@ -33,6 +33,8 @@ CVE-2016-8620 to this issue.
 
 CWE-122: Heap-based Buffer Overflow
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 
@@ -40,8 +42,6 @@ This flaw exists in the following curl versions.
 
 - Affected versions: curl 7.34.0 to and including 7.50.3
 - Not affected versions: curl < 7.34.0 and curl >= 7.51.0
-
-libcurl is used by many applications, but not always advertised as such!
 
 SOLUTION
 ------------

--- a/docs/CVE-2016-8621.md
+++ b/docs/CVE-2016-8621.md
@@ -29,6 +29,8 @@ CVE-2016-8621 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8622.md
+++ b/docs/CVE-2016-8622.md
@@ -25,6 +25,8 @@ CVE-2016-8622 to this issue.
 
 CWE-122: Heap-based Buffer Overflow
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8623.md
+++ b/docs/CVE-2016-8623.md
@@ -27,6 +27,8 @@ CVE-2016-8623 to this issue.
 
 CWE-416: Use After Free
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8624.md
+++ b/docs/CVE-2016-8624.md
@@ -27,6 +27,8 @@ CVE-2016-8624 to this issue.
 
 CWE-172: Encoding Error
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-8625.md
+++ b/docs/CVE-2016-8625.md
@@ -36,6 +36,8 @@ CVE-2016-8625 to this issue.
 
 CWE-838: Inappropriate Encoding for Output Context
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-9586.md
+++ b/docs/CVE-2016-9586.md
@@ -33,6 +33,8 @@ CVE-2016-9586 to this issue.
 
 CWE-121: Stack-based Buffer Overflow
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-9594.md
+++ b/docs/CVE-2016-9594.md
@@ -39,6 +39,8 @@ CVE-2016-9594 to this issue.
 
 CWE-330: Use of Insufficiently Random Values
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-9952.md
+++ b/docs/CVE-2016-9952.md
@@ -33,6 +33,8 @@ CVE-2016-9952 to this issue.
 
 CWE-295: Improper Certificate Validation
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2016-9953.md
+++ b/docs/CVE-2016-9953.md
@@ -32,6 +32,8 @@ CVE-2016-9953 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-1000099.md
+++ b/docs/CVE-2017-1000099.md
@@ -28,6 +28,8 @@ CVE-2017-1000099 to this issue.
 
 CWE-170: Improper Null Termination
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-1000100.md
+++ b/docs/CVE-2017-1000100.md
@@ -31,6 +31,8 @@ CVE-2017-1000100 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-1000101.md
+++ b/docs/CVE-2017-1000101.md
@@ -33,6 +33,8 @@ CVE-2017-1000101 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-1000254.md
+++ b/docs/CVE-2017-1000254.md
@@ -39,6 +39,8 @@ CVE-2017-1000254 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-1000257.md
+++ b/docs/CVE-2017-1000257.md
@@ -30,6 +30,8 @@ CVE-2017-1000257 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-2629.md
+++ b/docs/CVE-2017-2629.md
@@ -37,6 +37,8 @@ CVE-2017-2629 to this issue.
 
 CWE-304: Missing Critical Step in Authentication
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-7407.md
+++ b/docs/CVE-2017-7407.md
@@ -33,6 +33,8 @@ CVE-2017-7407 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-7468.md
+++ b/docs/CVE-2017-7468.md
@@ -35,6 +35,8 @@ CVE-2017-7468 to this issue.
 
 CWE-305: Authentication Bypass by Primary Weakness
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-8816.md
+++ b/docs/CVE-2017-8816.md
@@ -29,6 +29,8 @@ CVE-2017-8816 to this issue.
 
 CWE-131: Incorrect Calculation of Buffer Size
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-8817.md
+++ b/docs/CVE-2017-8817.md
@@ -28,6 +28,8 @@ CVE-2017-8817 to this issue.
 
 CWE-126: Buffer Over-read
 
+Severity: Medium
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-8818.md
+++ b/docs/CVE-2017-8818.md
@@ -36,6 +36,8 @@ CVE-2017-8818 to this issue.
 
 CWE-125: Out-of-bounds Read
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/CVE-2017-9502.md
+++ b/docs/CVE-2017-9502.md
@@ -30,6 +30,8 @@ CVE-2017-9502 to this issue.
 
 CWE-122: Heap-based Buffer Overflow
 
+Severity: High
+
 AFFECTED VERSIONS
 -----------------
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -408,7 +408,7 @@ caextract.html: _caextract.html $(MAINPARTS) ../ca/pemlist.gen
 
 security.html: _security.html seclist.gen $(MAINPARTS) $(ADVBOX)
 	$(ACTION)
-seclist.gen: vuln.pm listvulns.pl
+seclist.gen: vuln.pm listvulns.pl $(CVELIST)
 	./listvulns.pl > seclist.gen
 
 CVE-%.html: CVE-%.md $(MAINPARTS) advisory.t $(ADVBOX) curlver-to-vulnlink.pl mk-adv-template.pl cve-checker.pl

--- a/docs/listvulns.pl
+++ b/docs/listvulns.pl
@@ -46,9 +46,13 @@ sub sev2color {
         $col = "orange";
         $sym = "M";
     }
-    else {
+    elsif($sev =~ /^High/i) {
         $col = "red";
         $sym = "H";
+    }
+    elsif($sev =~ /^Critical/i) {
+        $col = "black";
+        $sym = "C";
     }
     return "<div style=\"color: $col; border-radius: 8px; border: 2px $col solid; text-align: center;\">$sym</div>";
 }


### PR DESCRIPTION
This is a manual work and I am using my own "best effort" by manually reading the descriptions, checking the conditions for them to trigger and comparing with how other projects grade similar problems.