### PR TITLE
Add enscript and zip to prereqs and clarify bootstrap cvssource msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ Markdown is converted to HTML with `pandoc`.
 Make sure the following tools are in your $PATH.
 
  - curl
+ - GNU date
+ - GNU enscript
  - [fcpp](https://daniel.haxx.se/projects/fcpp/)
  - GNU make
  - pandoc
  - perl (with CPAN packages: CGI, HTML::Entities)
  - roffit
- - GNU date
+ - zip
 
 ## Build
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ mkdir -p download/archeology
 touch dl/data/databas.db
 
 if test ! -d cvssource; then
-  echo "specify full path to source code root dir"
+  echo "specify full path to curl source code root dir"
   read -r code
   ln -sf "${code}" cvssource
 fi


### PR DESCRIPTION
While working on #265 I had some minor issues getting this project to build. This PR adds **enscript** (used by `mkexam.pl`) and **zip** (used for `allexamples.zip`) as prerequisites. It also adds a clarification to the `bootstrap.sh` script that the source code it needs is the [curl](https://github.com/curl/curl) repository (not the curl-www repository itself).