### PR TITLE
Fix cacert-${d}.pem.sha256 files to actually refer to the correct file

### DIFF
--- a/ca/update.sh
+++ b/ca/update.sh
@@ -15,3 +15,10 @@ if test $? -gt "0"; then
   perl ./listpem.pl > pemlist.gen
   make
 fi
+
+# rebuild hashes if they refer to the wrong filename
+for f in cacert-*.pem; do
+  if grep -q 'cacert.pem$' "${f}.sha256" ; then
+      sed -i.bak "s/cacert.pem/${f}/" "${f}.sha256"
+  fi
+done

--- a/ca/update.sh
+++ b/ca/update.sh
@@ -7,9 +7,9 @@ sha256sum -c cacert.pem.sha256
 if test $? -gt "0"; then
   # PEM was updated, save this by date
   d="$(date +%Y-%m-%d)"
-  cp cacert.pem "cacert-${d}.pem"
   sha256sum cacert.pem > cacert.pem.sha256
-  cp cacert.pem.sha256 "cacert-${d}.pem.sha256"
+  cp cacert.pem "cacert-${d}.pem"
+  sed "s/cacert.pem/cacert-${d}.pem/" < cacert.pem.sha256 > "cacert-${d}.pem.sha256"
   gzip -c cacert.pem > cacert.pem.gz
   xz -c cacert.pem > cacert.pem.xz
   perl ./listpem.pl > pemlist.gen


### PR DESCRIPTION
I put a retroactive fix snippet to a separate commit. I don't have the necessary files locally, so not actually tested...