### PR TITLE
dark mode: sidebar-box and downloads border tweaks

### DIFF
--- a/_index.html
+++ b/_index.html
@@ -22,7 +22,7 @@
 }
 @media (prefers-color-scheme: dark) {
     .sidebar-box {
-        border-color: white;
+        border-color: #999;
     }
 }
 </style>

--- a/curl.css
+++ b/curl.css
@@ -523,24 +523,14 @@ a.sitesearch:hover {
     td.ostitle, .older2 {
         color: white;
         background-color: #212121;
-        border-color: white;
     }
 
     .download2, div.quote {
         background-color: #2c2c2c;
-        border-color: white;
     }
 
     td.oslogo {
         background-color: white;
-    }
-
-    .col1 {
-        border-color: white;
-    }
-
-    .osend {
-        border-color: white;
     }
 
     tr.odd {

--- a/curl.css
+++ b/curl.css
@@ -523,7 +523,7 @@ a.sitesearch:hover {
     td.ostitle, .older2 {
         color: white;
         background-color: #212121;
-        border-bottom: 1px #ccc solid;
+        border-bottom: 1px #999 solid;
     }
 
     .download2, div.quote {

--- a/curl.css
+++ b/curl.css
@@ -523,6 +523,7 @@ a.sitesearch:hover {
     td.ostitle, .older2 {
         color: white;
         background-color: #212121;
+        border-bottom: 1px #ccc solid;
     }
 
     .download2, div.quote {


### PR DESCRIPTION
Tweak ee10e76946fcfe55cabbe4f0b4b6858be7f0537f to reduce border contrast in sponsor boxes and restore the non-contrasty borders on the download page, while adding a separator line to make the OS headers stand out:

---

Before:
![Screen Shot 2023-06-24 at 14 35 50](https://github.com/curl/curl-www/assets/1446897/d4d18130-e92c-4702-8500-4f55bfb855d8)

After:
![Screen Shot 2023-06-24 at 14 35 36](https://github.com/curl/curl-www/assets/1446897/0389ee35-d52f-43c9-ac9f-83962b51918c)

---

Before:
![Screen Shot 2023-06-24 at 14 05 00](https://github.com/curl/curl-www/assets/1446897/2f3ae03c-56ed-4a56-9233-208ca84fab5f)

After:
![Screen Shot 2023-06-24 at 16 04 22](https://github.com/curl/curl-www/assets/1446897/1e10a079-dcb0-40e8-9273-4a8916847ab3)
