### PR TITLE
Fix typos and reword in CVE-2023-32001.md

### DIFF
--- a/docs/CVE-2023-32001.md
+++ b/docs/CVE-2023-32001.md
@@ -11,18 +11,18 @@ libcurl can be told to save cookie, HSTS and/or alt-svc data to files. When
 doing this, it called `stat()` followed by `fopen()` in a way that made it
 vulnerable to a TOCTOU race condition problem.
 
-By exploiting this flaw, an attacker could trick the victim to create or
-overwrite protected files holding this data in ways it was not intended to.
+By exploiting this flaw, an attacker could trick the victim into creating or
+overwriting protected files holding this data in ways it was not intended to.
 
 INFO
 ----
 
-The attacker needs permissions and rights enough to be able to create or
+The attacker needs permissions and rights sufficient enough to be able to create or
 rename directory entries in the directory the victim saves their files.
 
 This race condition modifies the behavior of symbolic link files in affected
-components, they might be followed instead of being overwritten when the
-condition is met leading to undesired and potentially destructive behavior.
+components, since they might be followed instead of being overwritten when the
+condition is met, leading to both undesired and potentially destructive behavior.
 
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2023-32001 to this issue.


### PR DESCRIPTION
This PR fixes typos and does some minor rewords for comprehension in CVE-2023-32001.md.