### PR TITLE
_comparison-table: remove dupe, clarify, correction

### DIFF
--- a/docs/_comparison-table.html
+++ b/docs/_comparison-table.html
@@ -110,11 +110,10 @@ TITLE(Compare curl with other download tools)
   FEAT( HTTP/1.1 )               YES__ YES__ YES__ YES__ YES__ YES__ YES__ YES__ YES__ ENDLINE
   FEAT( HTTP/2 ALPN )            YES__ no___ YES__ no___ no___ no___ no___ no___ YES__ ENDLINE
   FEAT( HTTP/2 h2c upgrade)      YES__ no___ YES__ no___ no___ no___ no___ no___ UNKNO ENDLINE
-  FEAT( HTTP/2 with proxy )      YES__ no___ no___ no___ no___ no___ no___ no___ UNKNO ENDLINE
+  FEAT( HTTP/2 to proxy )        YES__ no___ no___ no___ no___ no___ no___ no___ UNKNO ENDLINE
   FEAT( HTTP/3 )                 YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( HTTPS )                  YES__ YES__ YES__ YES__ YES__ YES__ YES__ YES__ YES__ ENDLINE
   FEAT( HTTPS Proxy )            YES__ no___ no___ no___ no___ no___ no___ no___ UNKNO ENDLINE
-  FEAT( HTTP/2 with proxy )      YES__ no___ no___ no___ no___ no___ no___ no___ UNKNO ENDLINE
   FEAT( IDN hostnames )          YES__ YES__ YES__ no___ no___ no___ no___ YES__ UNKNO ENDLINE
   FEAT( IMAP )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( In development )         YES__ YES__ YES__ no___ no___ YES__ no___ YES__ YES__ ENDLINE
@@ -124,7 +123,7 @@ TITLE(Compare curl with other download tools)
   FEAT( Metalink )               no___ YES__ YES__ no___ no___ YES__ no___ no___ no___ ENDLINE
   FEAT( MQTT )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( Multilingual Messages )  no___ YES__ YES__ no___ YES__ YES__ no___ no___ UNKNO ENDLINE
-  FEAT( Multiple URLs )          YES__ YES__ YES__ YES__ no___ YES__ no___ no___ no___ ENDLINE
+  FEAT( Multiple URLs )          YES__ YES__ YES__ YES__ YES__ YES__ no___ no___ no___ ENDLINE
   FEAT( Parallel transfers )     YES__ no___ no___ no___ YES__ YES__ YES__ no___ no___ ENDLINE
   FEAT( POP3 )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( Recursive downloads )    no___ YES__ YES__ no___ YES__ no___ YES__ no___ no___ ENDLINE


### PR DESCRIPTION
- "HTTP/2 with proxy" was duplicated
- call it "HTTP/2 to proxy" instead
- lftp supports multiple URLs

Fixes #282
Reported-by: Dan Fandrich