### PR TITLE
windows: make the scripts sort names better

### DIFF
--- a/windows/mkfiles.pl
+++ b/windows/mkfiles.pl
@@ -117,8 +117,21 @@ for(@files) {
     }
 }
 
+sub num {
+    my ($t)=@_;
+    if($t =~ /^(\d)\.(\d+)\.(\d+)_(\d+)/) {
+        return 1000000*$1 + 10000*$2 + 100+$3 + $4;
+    }
+    return 0;
+}
+
+sub sortit {
+    return num($a) <=> num($b);
+}
+
+
 my $gen=0;
-for my $version (reverse sort @versions) {
+for my $version (reverse sort { num($a) <=> num($b) } @versions) {
     print "#define CURL_WINDOWS_VERSION $version\n";
     if($version =~ /([0-9.]*)_(\d)/) {
         $gen = $2;

--- a/windows/unpack.pl
+++ b/windows/unpack.pl
@@ -9,7 +9,15 @@ opendir(DIR, $uploadpath) || exit;
 my @ul = grep { /$pattern/ } readdir(DIR);
 closedir DIR;
 
-my @sul = reverse sort @ul;
+sub num {
+    my ($t)=@_;
+    if($t =~ /.*(\d)\.(\d+)\.(\d+)_(\d+)/) {
+        return 1000000*$1 + 10000*$2 + 100+$3 + $4;
+    }
+    return 0;
+}
+
+my @sul = reverse sort {num($a) <=> num($b)} @ul;
 
 sub filetime {
     my ($filename)=@_;


### PR DESCRIPTION
When we reach double-digit _[num], we need more clever sort than just perl's default sort.

Reported-by: Viktor Szakats
Fixes #293