### PR TITLE
resolve action error: spell check

### DIFF
--- a/docs/CVE-2023-38039.md
+++ b/docs/CVE-2023-38039.md
@@ -19,7 +19,7 @@ INFO
 
 Since libcurl allocates memory on the heap to store each header individually,
 the exact number of headers required for this to become a problem will vary
-greatly from case to case. As the headers typically need to be transfered over
+greatly from case to case. As the headers typically need to be transferred over
 a network to curl, the available bandwidth will also affect how likely or how
 fast this problem can be triggered.
 


### PR DESCRIPTION
Action error generated by spell check resolved - transfered to transferred.