### PR TITLE
CVE-2023-30839.md: minor typo fixes and rewords

### DIFF
--- a/docs/CVE-2023-38039.md
+++ b/docs/CVE-2023-38039.md
@@ -10,9 +10,9 @@ VULNERABILITY
 When curl retrieves an HTTP response, it stores the incoming headers so that
 they can be accessed later via the libcurl headers API.
 
-However, curl did not have a limit in how many or how large headers it would
+However, curl did not have a limit on the size or quantity of headers it would
 accept in a response, allowing a malicious server to stream an endless series
-of headers and eventually cause curl to run out of heap memory.
+of headers to a client and eventually cause curl to run out of heap memory.
 
 INFO
 ----
@@ -39,10 +39,10 @@ AFFECTED VERSIONS
 
 libcurl is used by many applications, but not always advertised as such!
 
-This flaw existed already in 7.83.0 source code but in that release the
+This flaw existed already in the 7.83.0 source code, but in that release the
 feature was still marked **EXPERIMENTAL** and was not enabled in normal
-builds. The label was removed in 7.84.0 why we consider that as the first
-vulnerable version.
+builds. The label was removed in 7.84.0, which is why we consider that the 
+first vulnerable version.
 
 SOLUTION
 ------------
@@ -59,7 +59,7 @@ RECOMMENDATIONS
 
  B - Apply the patch to your local version
 
- C - Monitor response headers and return error if too much
+ C - Monitor response headers and return an error if there are too many
 
 TIMELINE
 --------


### PR DESCRIPTION
This changes a bit of text to be more readable and fixes a couple of typos