### PR TITLE
htaccess: give fastly-insights.com a CSP wildcard

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -119,7 +119,7 @@ AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
 Header set X-Content-Type-Options: "nosniff"
-Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se www.fastly-insights.com fastly-insights.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se"
+Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se *.fastly-insights.com fastly-insights.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se"
 
 # Google Custom Search requires unsafe-eval & unsafe-inline in the CSP which
 # knocks a giant hole in the protection a CSP provides. Therefore, only use
@@ -130,7 +130,7 @@ Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se
 # https://support.google.com/programmable-search/thread/60663049?hl=en
 # The hash is for the inline script in sitesearch.t
 <FilesMatch "^search\.html$|^list\.cgi$">
-Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se www.fastly-insights.com fastly-insights.com cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se www.fastly-insights.com fastly-insights.com cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
+Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se *.fastly-insights.com fastly-insights.com cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se *.fastly-insights.com fastly-insights.com cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
 </FilesMatch>
 Header always append X-Frame-Options SAMEORIGIN
 


### PR DESCRIPTION
This should fix the tracking script.

HOWEVER, since nobody noticed that this was broken for up to 2 years, is it
even needed?  There's no point in tracking users on the site if nobody is using
the information.