### PR TITLE
footer: remove Fastly tracking

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -119,7 +119,7 @@ AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
 Header set X-Content-Type-Options: "nosniff"
-Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se www.fastly-insights.com fastly-insights.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se"
+Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se"
 
 # Google Custom Search requires unsafe-eval & unsafe-inline in the CSP which
 # knocks a giant hole in the protection a CSP provides. Therefore, only use
@@ -130,7 +130,7 @@ Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se
 # https://support.google.com/programmable-search/thread/60663049?hl=en
 # The hash is for the inline script in sitesearch.t
 <FilesMatch "^search\.html$|^list\.cgi$">
-Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se www.fastly-insights.com fastly-insights.com cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se www.fastly-insights.com fastly-insights.com cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
+Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se curl.se cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.haxx.se www.curl.se curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
 </FilesMatch>
 Header always append X-Frame-Options SAMEORIGIN
 

--- a/_footer.html
+++ b/_footer.html
@@ -1,3 +1,2 @@
 </div>
 </div>
-<script defer src="https://www.fastly-insights.com/insights.js?k=8cb1247c-87c2-4af9-9229-768b1990f90b" type="text/javascript"></script>


### PR DESCRIPTION
It broken some time in the last two years because some of the hosts it
now uses conflict with our CSP. Since nobody at curl seems to use the
tracking statistics, just remove it.

This is an alternative to #301.