### PR TITLE
docs/optionswhen.html: add

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -195,6 +195,7 @@ PAGES = \
  manual.html \
  mk-ca-bundle.html \
  mqtt.html \
+ optionswhen.html \
  projdocs.html \
  protdocs.html \
  reldocs.html \
@@ -257,6 +258,12 @@ manpage.html: _manpage.html $(MAINPARTS) manoptionsdump.gen mandump.gen $(ROOT)/
 
 manoptionsdump.gen:
 	perl generatemanmenu.pl $(DOCROOT)/cmdline-opts > manoptionsdump.gen
+
+optionswhen.html: _optionswhen.html optionswhen.gen
+	$(ACTION)
+
+optionswhen.gen: $(DOCROOT)/options-in-versions optionswhen.pl
+	./optionswhen.pl $< > $@
 
 curl.1: ../cvssource/docs/cmdline-opts/*.d
 	(cd ../cvssource/docs/cmdline-opts && perl gen.pl mainpage *.d) > curl.1

--- a/docs/_alt-svc.html
+++ b/docs/_alt-svc.html
@@ -17,7 +17,7 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", Alt-Svc cache)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Manual</a>
+<br><a href="manual.html">Tutorial</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
 </div>
 

--- a/docs/_bugs.html
+++ b/docs/_bugs.html
@@ -17,8 +17,8 @@ WHERE3(Docs, "/docs/", Project, "/docs/projdocs.html", Report Bugs)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Manual</a>
 <br><a href="knownbugs.html">Known bugs</a>
+<br><a href="manual.html">Tutorial</a>
 </div>
 
 #include "bugs.gen"

--- a/docs/_faq.shtml
+++ b/docs/_faq.shtml
@@ -18,8 +18,8 @@ TITLE(FAQ -- Frequently Asked Questions)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Manual</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
+<br><a href="manual.html">Tutorial</a>
 </div>
 
 #include "faq.gen"

--- a/docs/_hsts.html
+++ b/docs/_hsts.html
@@ -16,9 +16,9 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", HSTS)
 
 <div class="relatedbox">
 <b>Related:</b>
-<br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Manual</a>
+<br><a href="manpage.html">man page</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
+<br><a href="manual.html">Tutorial</a>
 </div>
 
 #include "hsts.gen"

--- a/docs/_http-cookies.html
+++ b/docs/_http-cookies.html
@@ -17,8 +17,8 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", HTTP Cookies)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Manual</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
+<br><a href="manual.html">Tutorial</a>
 </div>
 
 #include "http-cookies.gen"

--- a/docs/_httpscripting.shtml
+++ b/docs/_httpscripting.shtml
@@ -17,8 +17,8 @@ WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", HTTP Scripting)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Manual</a>
 <br><a href="faq.html">FAQ</a>
+<br><a href="manual.html">Tutorial</a>
 </div>
 
 #include "httpscript.gen"

--- a/docs/_irc.html
+++ b/docs/_irc.html
@@ -17,7 +17,7 @@ WHERE2(Docs, "/docs/", IRC)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Manual</a>
+<br><a href="manual.html">Tutorial</a>
 </div>
 
 TITLE(IRC - chat with curl enthusiasts)

--- a/docs/_manpage.html
+++ b/docs/_manpage.html
@@ -19,10 +19,11 @@ WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", Man Page)
 TITLE(curl.1 the man page)
 <div class="relatedbox">
 <b>Related:</b>
-<br><a href="https://github.com/curl/curl/issues/new?title=curl.1%20problem&amp;labels=documentation" target="_new">File a bug about this man page</a>
-<br><a href="manual.html">Manual</a>
 <br><a href="faq.html">FAQ</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=curl.1%20problem&amp;labels=documentation" target="_new">File a bug about this man page</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
+<br><a href="manual.html">Tutorial</a>
+<br><a href="optionswhen.html">When options were added</a>
 </div>
 
 #include "mandump.gen"

--- a/docs/_manual.html
+++ b/docs/_manual.html
@@ -23,7 +23,7 @@ pre {
 #include "_menu.html"
 #include "setup.t"
 
-WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", Manual)
+WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", Tutorial)
 
 <div class="relatedbox">
 <b>Related:</b>

--- a/docs/_mk-ca-bundle.html
+++ b/docs/_mk-ca-bundle.html
@@ -18,9 +18,9 @@ WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", mk-ca-bundle)
 TITLE(mk-ca-bundle the man page)
 <div class="relatedbox">
 <b>Related:</b>
-<br><a href="manual.html">Manual</a>
 <br><a href="faq.html">FAQ</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
+<br><a href="manual.html">Tutorial</a>
 </div>
 
 #include "mkdump.gen"

--- a/docs/_optionswhen.html
+++ b/docs/_optionswhen.html
@@ -1,0 +1,36 @@
+#include "_doctype.html"
+<html>
+<head> <title>curl - When command line options were introduced</title>
+#include "css.t"
+#include "manpage.t"
+</head>
+
+#define CURL_DOCS
+#define DOCS_MANPAGE
+#define TOOL_DOCS
+#define CURL_URL docs/optionswhen.html
+
+#include "_menu.html"
+#include "setup.t"
+
+WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", Options when)
+TITLE(When command line options were introduced)
+<div class="relatedbox">
+<b>Related:</b>
+<br><a href="https://github.com/curl/curl/issues/new?title=curl.1%20problem&amp;labels=documentation" target="_new">File a bug about this man page</a>
+<br><a href="manpage.html">Man page</a>
+<br><a href="faq.html">FAQ</a>
+<br><a href="httpscripting.html">HTTP Scripting</a>
+</div>
+
+curl is continuously developed and new command line options are added over
+time. This list shows which options that were added in which version.
+
+<p>
+
+#include "optionswhen.gen"
+
+#include "_footer.html"
+
+</body>
+</html>

--- a/docs/_releases.html
+++ b/docs/_releases.html
@@ -20,7 +20,6 @@ TITLE(curl releases)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="security.html">curl CVEs</a>
-<br><a href="manual.html">Manual</a>
 <br><a href="faq.html">FAQ</a>
 <br><a href="/changes.html">Changelog</a>
 <br><a href="vulnerabilities.html">Vulnerabilities</a>

--- a/docs/_testcurl.html
+++ b/docs/_testcurl.html
@@ -19,7 +19,6 @@ TITLE(testcurl.1 the man page)
 <b>Related:</b>
 <br><a href="manpage.html">curl.1</a>
 <br><a href="runtests.html">runtests.1</a>
-<br><a href="manual.html">Manual</a>
 <br><a href="faq.html">FAQ</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
 </div>

--- a/docs/optionswhen.pl
+++ b/docs/optionswhen.pl
@@ -1,0 +1,63 @@
+#!/usr/bin/perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# options-in-versions
+my $oinv = $ARGV[0];
+
+my $html = "manpage.html";
+my $changelog = "/changes.html";
+
+my %vers;
+open(O, "<$oinv");
+while(<O>) {
+    if($_ =~ /^(\S+) (\((.*)\)|) +([0-9.]+)/) {
+        my ($long, $sh, $version) = ($1, $3, $4);
+        $vers{$version} = 1;
+        $added{$version} .= "$long ";
+        $short{$long}=$sh;
+    }
+}
+
+sub vernum {
+    my ($ver)= @_;
+    my @a = split(/\./, $ver);
+    return $a[0] * 10000 + $a[1] * 100 + $a[2];
+}
+
+sub verlink {
+    my ($ver)= @_;
+    $ver =~ s/\./_/g;
+    return $ver;
+}
+
+for my $v (sort {vernum($b) <=> vernum($a) } keys %vers) {
+    printf "<b> curl <a href=\"%s#%s\">$v</a></b><ol>\n", $changelog, verlink($v);
+    for my $l (split(/ /, $added{$v})) {
+        printf "<li> <a href=\"%s#%s\">$l%s</a>\n",
+            $html, $short{$l}?"$short{$l}":$l,
+            $short{$l}?" ($short{$l})":"";
+    }
+    print "</ol>\n";
+}


### PR DESCRIPTION
A new page listing all curl versions in a reverse chronological order and the command line options added in that version. With links to the changelog on the version number and to the relevant man page section on the command line option name.

Bonus: the page formerly sometimes called "manual" is now called tutorial everywhere, but the URL remains called "manual.html" at least for now.

## sample screenshot

![Screenshot 2023-09-28 at 18-03-32 curl - When command line options were introduced](https://github.com/curl/curl-www/assets/177011/455dc5d1-5e8c-455e-a6f4-b8374663ed66)