### PR TITLE
docs/tutorial.html: renamed from docs/manual.html

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -108,6 +108,7 @@ RedirectPermanent /help.html https://curl.se/docs/help-us.html
 RedirectPermanent /legal/thename.html https://curl.se/docs/thename.html
 RedirectPermanent /support https://curl.se/support.html
 RedirectPermanent /docs/websockets.html https://curl.se/docs/websocket.html
+RedirectPermanent /docs/manual.html https://curl.se/docs/tutorial.html
 
 RemoveHandler .php
 RemoveHandler .pl

--- a/_menu.html
+++ b/_menu.html
@@ -47,7 +47,7 @@
     <a href="/docs/tooldocs.html">curl tool</a>
       <small>
       <a href="/docs/manpage.html">&nbsp; man page</a>
-      <a href="/docs/manual.html">&nbsp; Tutorial</a>
+      <a href="/docs/tutorial.html">&nbsp; Tutorial</a>
       <a href="/docs/httpscripting.html">&nbsp; HTTP scripting</a>
       </small>
     <a href="/docs/videos/">Videos</a>

--- a/dev/_release-notes.html
+++ b/dev/_release-notes.html
@@ -19,7 +19,7 @@ WHERE2(Development, "/dev/", Pending Release Notes)
 <br><a href="/docs/manpage.html">curl man page</a>
 <br><a href="/snapshots/">Daily Snapshots</a>
 <br><a href="/docs/faq.html">FAQ</a>
-<br><a href="/docs/manual.html">Manual</a>
+<br><a href="/docs/tutorial.html">Tutorial</a>
 <br><a href="/docs/releases.html">Release log</a>
 </div>
 

--- a/dev/_release-procedure.html
+++ b/dev/_release-procedure.html
@@ -16,7 +16,7 @@ WHERE2(Development, "/dev/", Release Procedure)
 <b>Related:</b>
 <br><a href="/changes.html">changelog</a>
 <br><a href="/docs/manpage.html">curl man page</a>
-<br><a href="/docs/manual.html">Manual</a>
+<br><a href="/docs/tutorial.html">Tutorial</a>
 <br><a href="/docs/faq.html">FAQ</a>
 </div>
 

--- a/dev/_testcurl.html
+++ b/dev/_testcurl.html
@@ -18,7 +18,7 @@ TITLE(testcurl.1 the man page)
 <b>Related:</b>
 <br><a href="tests-overview.html">Tests Overview</a>
 <br><a href="runtests.html">runtests.1</a>
-<br><a href="/docs/manual.html">Manual</a>
+<br><a href="/docs/tutorial.html">Tutorial</a>
 </div>
 
 #include "testcurl.gen"

--- a/dev/_tests-overview.html
+++ b/dev/_tests-overview.html
@@ -14,9 +14,9 @@ WHERE2(Development, "/dev/", Tests Overview)
 
 <div class="relatedbox">
 <b>Related:</b>
-<br><a href="testcurl.html">Test curl</a>
 <br><a href="runtests.html">runtests.1</a>
-<br><a href="/docs/manual.html">Manual</a>
+<br><a href="testcurl.html">Test curl</a>
+<br><a href="/docs/tutorial.html">Tutorial</a>
 </div>
 
 #include "testsoverview.gen"

--- a/dev/_todo-release.html
+++ b/dev/_todo-release.html
@@ -18,7 +18,7 @@ TITLE(Things in the pipe for the upcoming releases)
 <br><a href="release-notes.html">RELEASE-NOTES</a>
 <br><a href="/changes.html">changelog</a>
 <br><a href="/docs/manpage.html">curl man page</a>
-<br><a href="/docs/manual.html">Manual</a>
+<br><a href="/docs/tutorial.html">Tutorial</a>
 <br><a href="/docs/faq.html">FAQ</a>
 </div>
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -192,7 +192,7 @@ PAGES = \
  knownbugs.html \
  libs.html \
  manpage.html \
- manual.html \
+ tutorial.html \
  mk-ca-bundle.html \
  mqtt.html \
  optionswhen.html \
@@ -374,7 +374,7 @@ install.html: _install.html $(MAINPARTS) install.gen
 install.gen: $(DOCROOT)/INSTALL.md
 	$(MARKDOWN) < $< > $@
 
-manual.html: _manual.html $(MAINPARTS) manual.gen
+tutorial.html: _tutorial.html $(MAINPARTS) manual.gen
 	$(ACTION)
 
 manual.gen: $(DOCROOT)/MANUAL.md

--- a/docs/_alt-svc.html
+++ b/docs/_alt-svc.html
@@ -17,7 +17,7 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", Alt-Svc cache)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
 </div>
 

--- a/docs/_bugs.html
+++ b/docs/_bugs.html
@@ -18,7 +18,7 @@ WHERE3(Docs, "/docs/", Project, "/docs/projdocs.html", Report Bugs)
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
 <br><a href="knownbugs.html">Known bugs</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 </div>
 
 #include "bugs.gen"

--- a/docs/_faq.shtml
+++ b/docs/_faq.shtml
@@ -19,7 +19,7 @@ TITLE(FAQ -- Frequently Asked Questions)
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 </div>
 
 #include "faq.gen"

--- a/docs/_hsts.html
+++ b/docs/_hsts.html
@@ -18,7 +18,7 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", HSTS)
 <b>Related:</b>
 <br><a href="manpage.html">man page</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 </div>
 
 #include "hsts.gen"

--- a/docs/_http-cookies.html
+++ b/docs/_http-cookies.html
@@ -18,7 +18,7 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", HTTP Cookies)
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 </div>
 
 #include "http-cookies.gen"

--- a/docs/_httpscripting.shtml
+++ b/docs/_httpscripting.shtml
@@ -18,7 +18,7 @@ WHERE3(Docs, "/docs/", Tool, "/docs/tooldocs.html", HTTP Scripting)
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
 <br><a href="faq.html">FAQ</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 </div>
 
 #include "httpscript.gen"

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -42,7 +42,7 @@ SUBTITLE(<a href="tooldocs.html">curl tool documentation</a>)
   <a href="manpage.html">curl man page</a>,
   <a href="httpscripting.html">HTTP Scripting</a>,
   <a href="mk-ca-bundle.html">mk-ca-bundle</a>,
-  <a href="manual.html">Tutorial</a>
+  <a href="tutorial.html">Tutorial</a>
 
 SUBTITLE(<a href="projdocs.html">The project</a>)
 <p>

--- a/docs/_irc.html
+++ b/docs/_irc.html
@@ -17,7 +17,7 @@ WHERE2(Docs, "/docs/", IRC)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 </div>
 
 TITLE(IRC - chat with curl enthusiasts)

--- a/docs/_manpage.html
+++ b/docs/_manpage.html
@@ -22,7 +22,7 @@ TITLE(curl.1 the man page)
 <br><a href="faq.html">FAQ</a>
 <br><a href="https://github.com/curl/curl/issues/new?title=curl.1%20problem&amp;labels=documentation" target="_new">File a bug about this man page</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 <br><a href="optionswhen.html">When options were added</a>
 </div>
 

--- a/docs/_menu.html
+++ b/docs/_menu.html
@@ -73,7 +73,7 @@ VLINK(/docs/, Docs Overview, Documentation Overview)
     <a href="/docs/manpage.html">curl man page</a>
     <a href="/docs/httpscripting.html">HTTP Scripting</a>
     <a href="/docs/mk-ca-bundle.html">mk-ca-bundle</a>
-    <a href="/docs/manual.html">Tutorial</a>
+    <a href="/docs/tutorial.html">Tutorial</a>
     <a href="optionswhen.html">When options were added</a>
   </div>
 </div>

--- a/docs/_mk-ca-bundle.html
+++ b/docs/_mk-ca-bundle.html
@@ -20,7 +20,7 @@ TITLE(mk-ca-bundle the man page)
 <b>Related:</b>
 <br><a href="faq.html">FAQ</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
-<br><a href="manual.html">Tutorial</a>
+<br><a href="tutorial.html">Tutorial</a>
 </div>
 
 #include "mkdump.gen"

--- a/docs/_tooldocs.html
+++ b/docs/_tooldocs.html
@@ -22,7 +22,7 @@ TITLE(Tool Documentation)
 <p>
   The main tool to know and learn here is of course curl. Read the full
   reference <a href="manpage.html">man page</a>, read
-  the <a href="manual.html">tutorial</a> or learn how to
+  the <a href="tutorial.html">tutorial</a> or learn how to
   do <a href="httpscripting.html">HTTP scripting</a> with curl.
 
 <p>

--- a/docs/_tutorial.html
+++ b/docs/_tutorial.html
@@ -18,7 +18,7 @@ pre {
 #define CURL_DOCS
 #define TOOL_DOCS
 #define DOCS_TUTORIAL
-#define CURL_URL docs/manual.html
+#define CURL_URL docs/tutorial.html
 
 #include "_menu.html"
 #include "setup.t"

--- a/rfc/_index.html
+++ b/rfc/_index.html
@@ -17,7 +17,7 @@ TITLE(Specifications that Concerns Curl)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="/docs/manpage.html">man page</a>
-<br><a href="/docs/manual.html">Tutorial</a>
+<br><a href="/docs/tutorial.html">Tutorial</a>
 <br><a href="/docs/faq.html">FAQ</a>
 </div>
 <p>


### PR DESCRIPTION
To fit the name better. Redirect from old name added.