### PR TITLE
docs/security: show the severity filter status

### DIFF
--- a/docs/_security.html
+++ b/docs/_security.html
@@ -58,12 +58,16 @@ SUBTITLE(Past vulnerabilities)
 <p>
 
 #if SEVERITY == 1
+(The table below has been filtered to show Medium+ severity)
 #include "seclist-m.gen"
 #elif SEVERITY == 2
+(The table below has been filtered to show High+ severity)
 #include "seclist-h.gen"
 #elif SEVERITY == 3
+(The table below has been filtered to show Critical severity)
 #include "seclist-c.gen"
 #else
+(The table below shows vulnerabilities of all severity levels)
 #include "seclist.gen"
 #endif
 SUBTITLE(Retracted security vulnerabilities)


### PR DESCRIPTION
- Add a sentence above the vulnerability table that lets the user know whether or not the table has a severity filter applied.

Example: (The table below has been filtered to show High+ severity)

This is a follow-up to 90850a74 which added generated security pages for different severity levels. security-m.html (Medium), security-h.html (High) and security-c.html (Critical).

When I google search for `curl cves` the second result is a link to security-h.html. It may not be immediately obvious that the table is filtered and not showing all vulnerabilities.

Closes #xxxx

---

I don't have a build curl-www to see the output so I'm not 100% sure this is correct