### PR TITLE
CVE-2023-38545.md: add additional info

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -175,6 +175,7 @@ DNS
 dns
 dnsop
 DoH
+DoS
 doxygen
 drftpd
 dsa
@@ -652,6 +653,7 @@ runtime
 Ruslan
 rustc
 rustls
+RyotaK
 Sagula
 SanDisk
 SAS

--- a/docs/CVE-2023-38545.md
+++ b/docs/CVE-2023-38545.md
@@ -91,6 +91,22 @@ Severity: High
 
 HackerOne: https://hackerone.com/reports/2187833
 
+ADDITIONAL INFO
+---------------
+
+Since the posting of this advisory, security researcher
+[RyotaK](https://hackerone.com/ryotak?type=user) has
+[notified](https://github.com/curl/curl-www/pull/308) that even if the buffer
+size is large enough to prevent heap overflow an attacker can still use the
+integer overflow of hostname length in conjunction with a crafted hostname
+longer than 255 characters to make the handshake complete successfully.
+
+In this scenario the crafted hostname contains a destination hostname, port and
+arbitrary data. The SOCKS server successfully connects to that host, sends the
+arbitrary data and then curl sends the "expected" request data on that same
+connection. The impact is limited because curl does not allow control
+characters and null in the hostname.
+
 AFFECTED VERSIONS
 -----------------
 


### PR DESCRIPTION
(Seems plausible but I have yet to try it myself.)

[RyotaK](https://hackerone.com/ryotak?type=user) on HackerOne reports successful SOCKS handshake with hostname larger than 255 and without buffer overflow by using a crafted hostname to set the remaining data in the handshake. If the handshake completes successfully then I would think the remaining data in the hostname is sent as data to the destination host. This is limited impact because as I noted in the text whitespace cannot be sent and only high port numbers