### PR TITLE
libcurl: add libcurl-env-dbg.html

### DIFF
--- a/.github/scripts/cleanspell.pl
+++ b/.github/scripts/cleanspell.pl
@@ -50,7 +50,7 @@ while(<F>) {
     $_ =~ s/CURLSHE_[A-Z0-9_]*//g;
     $_ =~ s/CURLSHOPT_[A-Z0-9_]*//g;
     $_ =~ s/CURLSSH_[A-Z0-9_]*//g;
-        $_ =~ s/CURLSSLBACKEND_[A-Z0-9_]*//g;
+    $_ =~ s/CURLSSLBACKEND_[A-Z0-9_]*//g;
     $_ =~ s/CURLU_[A-Z0-9_]*//g;
     $_ =~ s/CURLUE_[A-Z0-9_]*//g;
     $_ =~ s/CURLUPART_[A-Z0-9_]*//g;
@@ -62,7 +62,7 @@ while(<F>) {
     $_ =~ s/curl_mime_(subparts|addpart|filedata|data_cb)//g;
     $_ =~ s/curl_ws_(send|recv|meta)//g;
     $_ =~ s/curl_url_(dup)//g;
-    $_ =~ s/libcurl-env//g;
+    $_ =~ s/libcurl-env(-dbg)?//g;
     $_ =~ s/(^|\W)((tftp|https|http|ftp):\/\/[a-z0-9\-._~%:\/?\#\[\]\@!\$&'()*+,;=]+)//gi;
     $_ =~ s/^- Reported-by:.*//;
     $_ =~ s/^- Patched-by:.*//;

--- a/libcurl/c/Makefile
+++ b/libcurl/c/Makefile
@@ -143,6 +143,7 @@ PAGES = \
  symbols-in-versions.html \
  threadsafe.html \
  libcurl-env.html \
+ libcurl-env-dbg.html \
  $(MIME) \
  $(URLAPI) \
  $(EASY_OPTION) \
@@ -366,6 +367,11 @@ libcurl-easy.gen: $(MANROOT)/libcurl-easy.3 curlopt2href.pl
 libcurl-env.html: _libcurl-env.html $(MAINPARTS) libcurl-env.gen
 	$(ACTION)
 libcurl-env.gen: $(MANROOT)/libcurl-env.3 curlopt2href.pl
+	$(MAN2HTML) < $< >$@
+
+libcurl-env-dbg.html: _libcurl-env-dbg.html $(MAINPARTS) libcurl-env-dbg.gen
+	$(ACTION)
+libcurl-env-dbg.gen: $(MANROOT)/libcurl-env-dbg.3 curlopt2href.pl
 	$(MAN2HTML) < $< >$@
 
 libcurl-share.html: _libcurl-share.html $(MAINPARTS) libcurl-share.gen

--- a/libcurl/c/_libcurl-env-dbg.html
+++ b/libcurl/c/_libcurl-env-dbg.html
@@ -1,0 +1,23 @@
+#include "_doctype.html"
+<html>
+<head> <title>libcurl - environment debug variables</title>
+#include "css.t"
+#include "manpage.t"
+</head>
+
+#define LIBCURL_DOCS
+#define DOCS_ENV
+#define CURL_URL libcurl/c/libcurl-env-dbg.html
+
+#include "_menu.html"
+#include "setup.t"
+
+WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", Environment debug variables)
+
+TITLE(Environment variables libcurl DEBUGBUILD understands)
+
+#include "libcurl-env-dbg.gen"
+#include "_footer.html"
+
+</body>
+</html>


### PR DESCRIPTION
- Generate libcurl-env-dbg.html from libcurl-env-dbg.3 (added in 8.4.0).

I did not add a 'Environment vars (debug)' link to the 'Docs' dropdown menu because I think it's too niche. There is a menu entry for 'Environment vars' that links to libcurl-env.html and that page links to libcurl-env-dbg.html.

Closes #xxxx