### PR TITLE
symbols-in-versions/by-name: offer new sort

### DIFF
--- a/_menu.html
+++ b/_menu.html
@@ -65,6 +65,7 @@
     <a href="/libcurl/features.html">Features</a>
     <a href="/mail/list.cgi?list=curl-library">Mailing list</a>
     <a href="/libcurl/relatedlibs.html">Related libs</a>
+    <a href="/libcurl/c/symbols-in-versions.html">Symbols</a>
     <a href="/libcurl/using/">Using libcurl</a>
     <a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a>
     <a href="/libcurl/theysay.html">Testimonials</a>

--- a/libcurl/_menu.html
+++ b/libcurl/_menu.html
@@ -27,6 +27,7 @@ VLINK("/libcurl/", libcurl, Front page of the libcurl section)
     <a href="/libcurl/relatedlibs.html">Related libs</a>
     <a href="/libcurl/using/">Using libcurl</a>
     <a href="/libcurl/security.html">Security</a>
+    <a href="/libcurl/c/symbols-in-versions.html">Symbols</a>
     <a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a>
     <a href="/libcurl/theysay.html">Testimonials</a>
   </div>

--- a/libcurl/c/Makefile
+++ b/libcurl/c/Makefile
@@ -141,6 +141,7 @@ PAGES = \
  allexamples.zip \
  options-in-examples.html \
  symbols-in-versions.html \
+ symbols-by-name.html \
  threadsafe.html \
  libcurl-env.html \
  $(MIME) \
@@ -521,8 +522,13 @@ options-in-examples.gen: allex.gen options-used-in-examples.pl
 
 symbols-in-versions.html: _symbols-in-versions.html $(MAINPARTS) symbols-in-versions.gen
 	$(ACTION)
-symbols-in-versions.gen: $(MANROOT)/symbols-in-versions
-	$(TXT2PLAIN) < $< > $@
+symbols-in-versions.gen: $(MANROOT)/symbols-in-versions syminver.pl
+	./syminver.pl $< 1 > $@
+
+symbols-by-name.html: _symbols-by-name.html $(MAINPARTS) symbols-by-name.gen
+	$(ACTION)
+symbols-by-name.gen: $(MANROOT)/symbols-in-versions syminver.pl
+	./syminver.pl $< > $@
 
 curl_mime_init.html: _curl_mime_init.html $(MAINPARTS_CAPI) curl_mime_init.gen
 	$(ACTION)

--- a/libcurl/c/_symbols-by-name.html
+++ b/libcurl/c/_symbols-by-name.html
@@ -1,27 +1,27 @@
 #include "_doctype.html"
 <html>
-<head> <title>libcurl - symbols in versions</title>
+<head> <title>libcurl - symbols by name</title>
 #include "css.t"
 </head>
 
 #define DOCS_SYMBOLS
-#define CURL_URL libcurl/c/symbols-in-versions.html
+#define CURL_URL libcurl/c/symbols-by-name.html
 
 #include "_menu.html"
 #include "setup.t"
 
-WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", Symbols In Versions)
+WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", Symbols By Name)
 
-TITLE(Symbols In Versions)
+TITLE(Symbols By Name)
 <p>
  These symbols are present in libcurl. Here is information about the first
  libcurl version that provides the symbol, the first version in which the
  symbol was marked as deprecated and for a few symbols the last version that
  featured it.
 <p>
- [ <a href="symbols-by-name.html">sort on name</a> | <b>sort on intro version</b> ] 
+ [ sort on name | <a href="symbols-in-versions.html">sort on intro version</a> ] 
 <p>
-#include "symbols-in-versions.gen"
+#include "symbols-by-name.gen"
 
 #include "_footer.html"
 

--- a/libcurl/c/syminver.pl
+++ b/libcurl/c/syminver.pl
@@ -1,0 +1,86 @@
+#!/usr/bin/perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# symbols-in-versions
+my $siv = $ARGV[0];
+
+# sort by version
+my $bynumber = $ARGV[1];
+
+my $html = "manpage.html";
+my $changelog = "/changes.html";
+
+print "<table>\n";
+print "<tr><th>Name</th>".
+    "<th>Added</th>".
+    "<th>Deprecated</th>".
+    "<th>Last</th>".
+    "</tr>\n";
+
+sub vernum {
+    my ($ver)= @_;
+    my @a = split(/\./, $ver);
+    return $a[0] * 10000 + $a[1] * 100 + $a[2];
+}
+
+sub verlink {
+    my ($v)=@_;
+    if($v && ($v ne "-")) {
+        my $link = $v;
+        $link =~ s/\./_/g;
+        return "<a href=\"$changelog#$link\">$v</a>";
+    }
+    return "";
+}
+
+open(O, "<$siv");
+while(<O>) {
+    chomp;
+    if($_ =~ /^(\S+) +([0-9.]+) *([^ ]*) *([0-9.]*)/) {
+        my ($sym, $intro, $depr, $last) = ($1, $2, $3, $4);
+        push @syms, $sym;
+        $sintro{$sym}=$intro;
+        $sdepr{$sym}=$depr;
+        $slast{$sym}=$last;
+    }
+}
+close(O);
+
+my @sorted;
+if($bynumber) {
+    @sorted = reverse sort {vernum($sintro{$a}) <=> vernum($sintro{$b})} @syms;
+}
+else {
+    # byname
+    @sorted = sort @syms;
+}
+
+for my $s (@sorted) {
+    printf "<tr><td>$s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n",
+        verlink($sintro{$s}),
+        verlink($sdepr{$s}),
+        verlink($slast{$s});
+}
+print "</table>\n";


### PR DESCRIPTION
The symbols-in-versions page now sorts the list on intro-version, and there is a new symbols-by-name page for the same list but alpha sorted.

All shown version numbers link to the changelog emtry for that version.