### PR TITLE
docs: update links to "man page source"

### DIFF
--- a/libcurl/c/_CURLINFO_template.html
+++ b/libcurl/c/_CURLINFO_template.html
@@ -25,7 +25,7 @@ TITLE(@template@ explained)
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="https://github.com/curl/curl/issues/new?title=@template%20man%20page:@&amp;labels=documentation" target="_new">File a bug about this page</a>
-<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.3" target="_new">View man page source</a>
+<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 
 #include "@template@.gen"

--- a/libcurl/c/_CURLMOPT_template.html
+++ b/libcurl/c/_CURLMOPT_template.html
@@ -24,7 +24,7 @@ TITLE(@template@ explained)
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="https://github.com/curl/curl/issues/new?title=@template%20man%20page:@&amp;labels=documentation" target="_new">File a bug about this page</a>
-<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.3" target="_new">View man page source</a>
+<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 
 #include "@template@.gen"

--- a/libcurl/c/_CURLOPT_template.html
+++ b/libcurl/c/_CURLOPT_template.html
@@ -25,7 +25,7 @@ TITLE(@template@ explained)
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="https://github.com/curl/curl/issues/new?title=@template@%20man%20page:&amp;labels=documentation" target="_new">File a bug about this page</a>
-<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.3" target="_new">View man page source</a>
+<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 
 #include "@template@.gen"

--- a/libcurl/c/_CURLSHOPT_template.html
+++ b/libcurl/c/_CURLSHOPT_template.html
@@ -26,7 +26,7 @@ TITLE(@template@ explained)
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="curl_share_setopt.html">share options</a>
 <br><a href="https://github.com/curl/curl/issues/new?title=@template@%20man%20page:&amp;labels=documentation" target="_new">File a bug about this page</a>
-<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.3" target="_new">View man page source</a>
+<br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 
 #include "@template@.gen"

--- a/libcurl/c/_curl_easy_cleanup.html
+++ b/libcurl/c/_curl_easy_cleanup.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_cleanup.3
+#define RAW_FILE curl_easy_cleanup.md
 #define BUG_TITLE curl_easy_cleanup%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_duphandle.html
+++ b/libcurl/c/_curl_easy_duphandle.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_duphandle.3
+#define RAW_FILE curl_easy_duphandle.md
 #define BUG_TITLE curl_easy_duphandle%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_escape.html
+++ b/libcurl/c/_curl_easy_escape.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_escape.3
+#define RAW_FILE curl_easy_escape.md
 #define BUG_TITLE curl_easy_escape%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_getinfo.html
+++ b/libcurl/c/_curl_easy_getinfo.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_getinfo.3
+#define RAW_FILE curl_easy_getinfo.md
 #define BUG_TITLE curl_easy_getinfo%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_header.html
+++ b/libcurl/c/_curl_easy_header.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_header.3
+#define RAW_FILE curl_easy_header.md
 #define BUG_TITLE curl_easy_header%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_init.html
+++ b/libcurl/c/_curl_easy_init.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_init.3
+#define RAW_FILE curl_easy_init.md
 #define BUG_TITLE curl_easy_init%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_nextheader.html
+++ b/libcurl/c/_curl_easy_nextheader.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_nextheader.3
+#define RAW_FILE curl_easy_nextheader.md
 #define BUG_TITLE curl_easy_nextheader%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_option_by_id.html
+++ b/libcurl/c/_curl_easy_option_by_id.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_option_by_id.3
+#define RAW_FILE curl_easy_option_by_id.md
 #define BUG_TITLE curl_easy_option_by_id%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_option_by_name.html
+++ b/libcurl/c/_curl_easy_option_by_name.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_option_by_name.3
+#define RAW_FILE curl_easy_option_by_name.md
 #define BUG_TITLE curl_easy_option_by_name%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_option_next.html
+++ b/libcurl/c/_curl_easy_option_next.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_option_next.3
+#define RAW_FILE curl_easy_option_next.md
 #define BUG_TITLE curl_easy_option_next%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_pause.html
+++ b/libcurl/c/_curl_easy_pause.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_pause.3
+#define RAW_FILE curl_easy_pause.md
 #define BUG_TITLE curl_easy_pause%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_perform.html
+++ b/libcurl/c/_curl_easy_perform.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_perform.3
+#define RAW_FILE curl_easy_perform.md
 #define BUG_TITLE curl_easy_perform%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_recv.html
+++ b/libcurl/c/_curl_easy_recv.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_recv.3
+#define RAW_FILE curl_easy_recv.md
 #define BUG_TITLE curl_easy_recv%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_reset.html
+++ b/libcurl/c/_curl_easy_reset.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_reset.3
+#define RAW_FILE curl_easy_reset.md
 #define BUG_TITLE curl_easy_reset%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_send.html
+++ b/libcurl/c/_curl_easy_send.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_send.3
+#define RAW_FILE curl_easy_send.md
 #define BUG_TITLE curl_easy_send%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_setopt.html
+++ b/libcurl/c/_curl_easy_setopt.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_setopt.3
+#define RAW_FILE curl_easy_setopt.md
 #define BUG_TITLE curl_easy_setopt%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_strerror.html
+++ b/libcurl/c/_curl_easy_strerror.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_strerror.3
+#define RAW_FILE curl_easy_strerror.md
 #define BUG_TITLE curl_easy_strerror%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_unescape.html
+++ b/libcurl/c/_curl_easy_unescape.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_unescape.3
+#define RAW_FILE curl_easy_unescape.md
 #define BUG_TITLE curl_easy_unescape%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_easy_upkeep.html
+++ b/libcurl/c/_curl_easy_upkeep.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_easy_upkeep.3
+#define RAW_FILE curl_easy_upkeep.md
 #define BUG_TITLE curl_easy_upkeep%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_escape.html
+++ b/libcurl/c/_curl_escape.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_escape.3
+#define RAW_FILE curl_escape.md
 #define BUG_TITLE curl_escape%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_formadd.html
+++ b/libcurl/c/_curl_formadd.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_formadd.3
+#define RAW_FILE curl_formadd.md
 #define BUG_TITLE curl_formadd%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_formfree.html
+++ b/libcurl/c/_curl_formfree.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_formfree.3
+#define RAW_FILE curl_formfree.md
 #define BUG_TITLE curl_formfree%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_formget.html
+++ b/libcurl/c/_curl_formget.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_formget.3
+#define RAW_FILE curl_formget.md
 #define BUG_TITLE curl_formget%20man%20page:
 #define LIBCURL_DOCS
 #define DOCS_FORMGET

--- a/libcurl/c/_curl_free.html
+++ b/libcurl/c/_curl_free.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_free.3
+#define RAW_FILE curl_free.md
 #define BUG_TITLE curl_free%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_getdate.html
+++ b/libcurl/c/_curl_getdate.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_getdate.3
+#define RAW_FILE curl_getdate.md
 #define BUG_TITLE curl_getdate%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_getenv.html
+++ b/libcurl/c/_curl_getenv.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_getenv.3
+#define RAW_FILE curl_getenv.md
 #define BUG_TITLE curl_getenv%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_global_cleanup.html
+++ b/libcurl/c/_curl_global_cleanup.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_global_cleanup.3
+#define RAW_FILE curl_global_cleanup.md
 #define BUG_TITLE curl_global_cleanup%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_global_init.html
+++ b/libcurl/c/_curl_global_init.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_global_init.3
+#define RAW_FILE curl_global_init.md
 #define BUG_TITLE curl_global_init%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_global_init_mem.html
+++ b/libcurl/c/_curl_global_init_mem.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_global_init_mem.3
+#define RAW_FILE curl_global_init_mem.md
 #define BUG_TITLE curl_global_init_mem%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_global_sslset.html
+++ b/libcurl/c/_curl_global_sslset.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_global_sslset.3
+#define RAW_FILE curl_global_sslset.md
 #define BUG_TITLE curl_global_sslset%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_global_trace.html
+++ b/libcurl/c/_curl_global_trace.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_global_trace.3
+#define RAW_FILE curl_global_trace.md
 #define BUG_TITLE curl_global_trace%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_addpart.html
+++ b/libcurl/c/_curl_mime_addpart.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_addpart.3
+#define RAW_FILE curl_mime_addpart.md
 #define BUG_TITLE curl_mime_addpart%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_data.html
+++ b/libcurl/c/_curl_mime_data.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_data.3
+#define RAW_FILE curl_mime_data.md
 #define BUG_TITLE curl_mime_data%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_data_cb.html
+++ b/libcurl/c/_curl_mime_data_cb.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_data_cb.3
+#define RAW_FILE curl_mime_data_cb.md
 #define BUG_TITLE curl_mime_data_cb%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_encoder.html
+++ b/libcurl/c/_curl_mime_encoder.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_encoder.3
+#define RAW_FILE curl_mime_encoder.md
 #define BUG_TITLE curl_mime_encoder%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_filedata.html
+++ b/libcurl/c/_curl_mime_filedata.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_filedata.3
+#define RAW_FILE curl_mime_filedata.md
 #define BUG_TITLE curl_mime_filedata%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_filename.html
+++ b/libcurl/c/_curl_mime_filename.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_filename.3
+#define RAW_FILE curl_mime_filename.md
 #define BUG_TITLE curl_mime_filename%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_free.html
+++ b/libcurl/c/_curl_mime_free.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_free.3
+#define RAW_FILE curl_mime_free.md
 #define BUG_TITLE curl_mime_free%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_headers.html
+++ b/libcurl/c/_curl_mime_headers.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_headers.3
+#define RAW_FILE curl_mime_headers.md
 #define BUG_TITLE curl_mime_headers%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_init.html
+++ b/libcurl/c/_curl_mime_init.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_init.3
+#define RAW_FILE curl_mime_init.md
 #define BUG_TITLE curl_mime_init%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_name.html
+++ b/libcurl/c/_curl_mime_name.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_name.3
+#define RAW_FILE curl_mime_name.md
 #define BUG_TITLE curl_mime_name%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_subparts.html
+++ b/libcurl/c/_curl_mime_subparts.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_subparts.3
+#define RAW_FILE curl_mime_subparts.md
 #define BUG_TITLE curl_mime_subparts%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mime_type.html
+++ b/libcurl/c/_curl_mime_type.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mime_type.3
+#define RAW_FILE curl_mime_type.md
 #define BUG_TITLE curl_mime_type%20man%20page:
 #define MENU_MIME
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_mprintf.html
+++ b/libcurl/c/_curl_mprintf.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_mprintf.3
+#define RAW_FILE curl_mprintf.md
 #define BUG_TITLE curl_mprintf%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_add_handle.html
+++ b/libcurl/c/_curl_multi_add_handle.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_add_handle.3
+#define RAW_FILE curl_multi_add_handle.md
 #define BUG_TITLE curl_multi_add_handle%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_assign.html
+++ b/libcurl/c/_curl_multi_assign.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_assign.3
+#define RAW_FILE curl_multi_assign.md
 #define BUG_TITLE curl_multi_assign%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_cleanup.html
+++ b/libcurl/c/_curl_multi_cleanup.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_cleanup.3
+#define RAW_FILE curl_multi_cleanup.md
 #define BUG_TITLE curl_multi_cleanup%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_fdset.html
+++ b/libcurl/c/_curl_multi_fdset.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_fdset.3
+#define RAW_FILE curl_multi_fdset.md
 #define BUG_TITLE curl_multi_fdset%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_get_handles.html
+++ b/libcurl/c/_curl_multi_get_handles.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_get_handles.3
+#define RAW_FILE curl_multi_get_handles.md
 #define BUG_TITLE curl_multi_get_handles%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_info_read.html
+++ b/libcurl/c/_curl_multi_info_read.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_info_read.3
+#define RAW_FILE curl_multi_info_read.md
 #define BUG_TITLE curl_multi_info_read%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_init.html
+++ b/libcurl/c/_curl_multi_init.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_init.3
+#define RAW_FILE curl_multi_init.md
 #define BUG_TITLE curl_multi_init%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_perform.html
+++ b/libcurl/c/_curl_multi_perform.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_perform.3
+#define RAW_FILE curl_multi_perform.md
 #define BUG_TITLE curl_multi_perform%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_poll.html
+++ b/libcurl/c/_curl_multi_poll.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_poll.3
+#define RAW_FILE curl_multi_poll.md
 #define BUG_TITLE curl_multi_poll%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_remove_handle.html
+++ b/libcurl/c/_curl_multi_remove_handle.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_remove_handle.3
+#define RAW_FILE curl_multi_remove_handle.md
 #define BUG_TITLE curl_multi_remove_handle%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_setopt.html
+++ b/libcurl/c/_curl_multi_setopt.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_setopt.3
+#define RAW_FILE curl_multi_setopt.md
 #define BUG_TITLE curl_multi_setopt%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_socket.html
+++ b/libcurl/c/_curl_multi_socket.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_socket.3
+#define RAW_FILE curl_multi_socket.md
 #define BUG_TITLE curl_multi_socket%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_socket_action.html
+++ b/libcurl/c/_curl_multi_socket_action.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_socket_action.3
+#define RAW_FILE curl_multi_socket_action.md
 #define BUG_TITLE curl_multi_socket_action%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_strerror.html
+++ b/libcurl/c/_curl_multi_strerror.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_strerror.3
+#define RAW_FILE curl_multi_strerror.md
 #define BUG_TITLE curl_multi_strerror%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_timeout.html
+++ b/libcurl/c/_curl_multi_timeout.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_timeout.3
+#define RAW_FILE curl_multi_timeout.md
 #define BUG_TITLE curl_multi_timeout%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_wait.html
+++ b/libcurl/c/_curl_multi_wait.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_wait.3
+#define RAW_FILE curl_multi_wait.md
 #define BUG_TITLE curl_multi_wait%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_multi_wakeup.html
+++ b/libcurl/c/_curl_multi_wakeup.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_multi_wakeup.3
+#define RAW_FILE curl_multi_wakeup.md
 #define BUG_TITLE curl_multi_wakeup%20man%20page:
 #define MENU_MULTI
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_pushheader_byname.html
+++ b/libcurl/c/_curl_pushheader_byname.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_pushheader_byname.3
+#define RAW_FILE curl_pushheader_byname.md
 #define BUG_TITLE curl_pushheader_byname%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_pushheader_bynum.html
+++ b/libcurl/c/_curl_pushheader_bynum.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_pushheader_bynum.3
+#define RAW_FILE curl_pushheader_bynum.md
 #define BUG_TITLE curl_pushheader_bynum%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_share_cleanup.html
+++ b/libcurl/c/_curl_share_cleanup.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_share_cleanup.3
+#define RAW_FILE curl_share_cleanup.md
 #define BUG_TITLE curl_share_cleanup%20man%20page:
 #define MENU_SHARE
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_share_init.html
+++ b/libcurl/c/_curl_share_init.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_share_init.3
+#define RAW_FILE curl_share_init.md
 #define BUG_TITLE curl_share_init%20man%20page:
 #define MENU_SHARE
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_share_setopt.html
+++ b/libcurl/c/_curl_share_setopt.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_share_setopt.3
+#define RAW_FILE curl_share_setopt.md
 #define BUG_TITLE curl_sahre_setopt%20man%20page:
 #define MENU_SHARE
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_share_strerror.html
+++ b/libcurl/c/_curl_share_strerror.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_share_strerror.3
+#define RAW_FILE curl_share_strerror.md
 #define BUG_TITLE curl_share_strerror%20man%20page:
 #define MENU_SHARE
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_slist_append.html
+++ b/libcurl/c/_curl_slist_append.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_slist_append.3
+#define RAW_FILE curl_slist_append.md
 #define BUG_TITLE curl_slist_append%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_slist_free_all.html
+++ b/libcurl/c/_curl_slist_free_all.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_slist_free_all.3
+#define RAW_FILE curl_slist_free_all.md
 #define BUG_TITLE curl_slist_free_all%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_strequal.html
+++ b/libcurl/c/_curl_strequal.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_strequal.3
+#define RAW_FILE curl_strequal.md
 #define BUG_TITLE curl_strequal%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_unescape.html
+++ b/libcurl/c/_curl_unescape.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_unescape.3
+#define RAW_FILE curl_unescape.md
 #define BUG_TITLE curl_unescape%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_url.html
+++ b/libcurl/c/_curl_url.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_url.3
+#define RAW_FILE curl_url.md
 #define BUG_TITLE curl_url%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_url_cleanup.html
+++ b/libcurl/c/_curl_url_cleanup.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_url_cleanup.3
+#define RAW_FILE curl_url_cleanup.md
 #define BUG_TITLE curl_url_cleanup%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_url_dup.html
+++ b/libcurl/c/_curl_url_dup.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_url_dup.3
+#define RAW_FILE curl_url_dup.md
 #define BUG_TITLE curl_url_dup%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_url_get.html
+++ b/libcurl/c/_curl_url_get.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_url_get.3
+#define RAW_FILE curl_url_get.md
 #define BUG_TITLE curl_url_get%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_url_set.html
+++ b/libcurl/c/_curl_url_set.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_url_set.3
+#define RAW_FILE curl_url_set.md
 #define BUG_TITLE curl_url_set%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_url_strerror.html
+++ b/libcurl/c/_curl_url_strerror.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_url_strerror.3
+#define RAW_FILE curl_url_strerror.md
 #define BUG_TITLE curl_url_strerror%20man%20page:
 #define MENU_URL
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_version.html
+++ b/libcurl/c/_curl_version.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_version.3
+#define RAW_FILE curl_version.md
 #define BUG_TITLE curl_version%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_version_info.html
+++ b/libcurl/c/_curl_version_info.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_version_info.3
+#define RAW_FILE curl_version_info.md
 #define BUG_TITLE curl_version_info%20man%20page:
 #define MENU_EASY
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_ws_meta.html
+++ b/libcurl/c/_curl_ws_meta.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_ws_meta.3
+#define RAW_FILE curl_ws_meta.md
 #define BUG_TITLE curl_ws_meta%20man%20page:
 #define MENU_WS
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_ws_recv.html
+++ b/libcurl/c/_curl_ws_recv.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_ws_recv.3
+#define RAW_FILE curl_ws_recv.md
 #define BUG_TITLE curl_ws_recv%20man%20page:
 #define MENU_WS
 #define LIBCURL_DOCS

--- a/libcurl/c/_curl_ws_send.html
+++ b/libcurl/c/_curl_ws_send.html
@@ -5,7 +5,7 @@
 #include "manpage.t"
 </head>
 
-#define RAW_FILE curl_ws_send.3
+#define RAW_FILE curl_ws_send.md
 #define BUG_TITLE curl_ws_send%20man%20page:
 #define MENU_WS
 #define LIBCURL_DOCS


### PR DESCRIPTION
... as they are now markdown (`.md`), not nroff (`.3`)