### PR TITLE
[update] openssl Native cert check as GnuTLS.

### DIFF
--- a/docs/_ssl-compared.html
+++ b/docs/_ssl-compared.html
@@ -71,7 +71,7 @@ to use.
 
  <tbody>
  FEAT(Supported)          YES__ YES__ YES__ YES__ YES__ YES__ no___ YES__ ENDLINE
- FEAT(Native cert check)  no___ YES__ YES__ YES__ YES__ YES__ YES__ YES__ ENDLINE
+ FEAT(Native cert check)  YES__ YES__ YES__ YES__ YES__ YES__ YES__ YES__ ENDLINE
  FEAT(CRL)                MAN__ MAN__ MAN__ MAN__ AUTO_ AUTO_ MAN__ MAN__ ENDLINE
  FEAT(TLSv1.0)            YES__ YES__ YES__ YES__ YES__ YES__ YES__ YES__ ENDLINE
  FEAT(TLSv1.1)            YES__ YES__ YES__ YES__ YES__ YES__ YES__ YES__ ENDLINE


### PR DESCRIPTION
openssl can do native cert from curl 8.3.0.
gnutls can do native cert from curl 8.5.0.