### PR TITLE
windows: make 32-bit download optional

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -55,11 +55,13 @@ Size: CURL_WIN64A_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN64A
 #endif
 
+#ifdef CURL_WIN32_ZIP
 <p class="windl">
   <a href="CURL_WIN32_ZIP"><img src="/pix/GS-Download-icon.svg" alt="Download 32-bit curl" width="90" height="90" style="float:left;"></a>
   <a href="CURL_WIN32_ZIP" class="windl">curl for 32-bit</a> <br>
 Size: CURL_WIN32_ZIP_SIZE<br>
 sha256: SHA256_CURL_WIN32
+#endif
 
 SUBTITLE(Fixed URLs)
 <p>
@@ -69,7 +71,9 @@ SUBTITLE(Fixed URLs)
 #ifdef CURL_WIN64A_ZIP
 <a download="curl-win64a-latest.zip" href="latest.cgi?p=win64a-mingw.zip">curl for win64 ARM64</a><br>
 #endif
+#ifdef CURL_WIN32_ZIP
 <a download="curl-win32-latest.zip" href="latest.cgi?p=win32-mingw.zip">curl for win32</a><br>
+#endif
 
 SUBTITLE(Specifications)
 <p>


### PR DESCRIPTION
Prepare the download page for releases without 32-bit binaries.

Refs:
https://github.com/curl/curl-for-win/commit/08a2dad52e28f39123c15d55708079a4edf243f7
https://github.com/curl/curl-for-win/discussions/68#discussioncomment-8982982
