### PR TITLE
tidy-up: Mac OS X -> macOS

### DIFF
--- a/dev/_howto.html
+++ b/dev/_howto.html
@@ -110,7 +110,7 @@ We have no automatic building/testing on these platforms:
  <li> BeOS
  <li> HP-UX
  <li> Hurd
- <li> Mac OS X
+ <li> macOS
  <li> OS/2
  <li> OpenBSD
  <li> QNX

--- a/dev/_missing.html
+++ b/dev/_missing.html
@@ -28,7 +28,7 @@ We have no automatic building/testing on these platforms:
  <li> BeOS
  <li> HP-UX
  <li> Hurd
- <li> Mac OS X
+ <li> macOS
  <li> OS/2
  <li> OpenBSD
  <li> QNX

--- a/dl/mktable.pl
+++ b/dl/mktable.pl
@@ -115,9 +115,10 @@ for(sort { lc($a) cmp lc($b) } keys %os) {
         if($p) {
             print "<br>\n";
         }
+        my $r= $osmap{$_};
         my $anch=$_;
         $anch =~ s/[^a-zA-Z0-9]//g;
-        print "<a href=\"#$anch\">$_</a>";
+        print "<a href=\"#$anch\">$r</a>";
         $p++;
     }
 }

--- a/libcurl/_features.html
+++ b/libcurl/_features.html
@@ -48,7 +48,7 @@ SUBTITLE(Portable!)
  same API and feature set on all of them! Using libcurl assures you that you
  can write your application to work on very large amount of systems, including
  but not limited to Solaris, NetBSD, FreeBSD, OpenBSD, Darwin, HPUX, IRIX,
- AIX, Tru64, Linux, UnixWare, HURD, Windows, Amiga, OS/2, BeOs, Mac OS X,
+ AIX, Tru64, Linux, UnixWare, HURD, Windows, Amiga, OS/2, BeOs, macOS,
  Ultrix, QNX, OpenVMS, RISC OS, Novell NetWare, DOS and more...
 
 <a name="thread"></a>

--- a/libcurl/_index.html
+++ b/libcurl/_index.html
@@ -36,7 +36,7 @@ TITLE(libcurl - the multiprotocol file transfer library)
 <p>
  libcurl is highly portable, it builds and works identically on numerous
  platforms, including Solaris, NetBSD, FreeBSD, OpenBSD, Darwin, HPUX, IRIX,
- AIX, Tru64, Linux, UnixWare, HURD, Windows, Amiga, OS/2, BeOs, Mac OS X,
+ AIX, Tru64, Linux, UnixWare, HURD, Windows, Amiga, OS/2, BeOs, macOS,
  Ultrix, QNX, OpenVMS, RISC OS, Novell NetWare, DOS and more...
 </p>
 


### PR DESCRIPTION
Also fixup `Win32`/`Win64` to appear as `Windows 32-bit`/`64-bit` on
the download page sidebar.
