### PR TITLE
menu: remove a few libcurl options from the front page menu

### DIFF
--- a/_menu.html
+++ b/_menu.html
@@ -58,17 +58,13 @@
 <div class="dropdown">
   <a class="dropbtn" href="/libcurl/">libcurl</a>
   <div class="dropdown-content">
-    <a href="/libcurl/abi.html">ABI</a>
     <a href="/libcurl/c/">API</a>
-    <a href="/libcurl/competitors.html">Competitors</a>
     <a href="/libcurl/c/example.html">Examples</a>
     <a href="/libcurl/features.html">Features</a>
     <a href="/mail/list.cgi?list=curl-library">Mailing list</a>
-    <a href="/libcurl/relatedlibs.html">Related libs</a>
     <a href="/libcurl/c/symbols-in-versions.html">Symbols</a>
     <a href="/libcurl/using/">Using libcurl</a>
     <a href="/libcurl/c/libcurl-tutorial.html">Tutorial</a>
-    <a href="/libcurl/theysay.html">Testimonials</a>
   </div>
 </div>
 


### PR DESCRIPTION
Mainly to declutter it and make it easier to find the options a user is more likely to want to find directly from this page.

The other options remain accessible from the docs menu in the libcurl section.