### PR TITLE
language cleanups

### DIFF
--- a/.github/workflows/badwords.yml
+++ b/.github/workflows/badwords.yml
@@ -26,4 +26,4 @@ jobs:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
 
     - name: check
-      run: ./.github/scripts/badwords.pl -w ./.github/scripts/badwords.ok < .github/scripts/badwords.txt docs/*.md
+      run: ./.github/scripts/badwords.pl -w ./.github/scripts/badwords.ok < .github/scripts/badwords.txt docs/*.md '*html'

--- a/.htaccess
+++ b/.htaccess
@@ -126,7 +126,7 @@ Header set Content-Security-Policy: "default-src 'self' curl.haxx.se www.curl.se
 # Google Custom Search requires unsafe-eval & unsafe-inline in the CSP which
 # knocks a giant hole in the protection a CSP provides. Therefore, only use
 # that on the pages where custom search is used to mitigate it somewhat. The
-# search page that shows up on the 404 error page won't be matched by this,
+# search page that shows up on the 404 error page will not be matched by this,
 # however. The following link is supposed to be updated when Google fixes this
 # CSP issue and this hack can be removed:
 # https://support.google.com/programmable-search/thread/60663049?hl=en

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # curl-www
 
-This is (most of) the curl.se web site contents. It mostly builds static
+This is (most of) the curl.se website contents. It mostly builds static
 HTML files that are preprocessed.
 
 ## Prerequisites
 
-The web site is a on old custom made setup that mostly builds static HTML
+The website is a on old custom made setup that mostly builds static HTML
 files from a set of source files using (GNU) `make`. The sources files are
 preprocessed with what is basically a souped-up C preprocessor called `fcpp`
 and a set of `perl` scripts. The manpages get converted to HTML with
@@ -27,11 +27,11 @@ Make sure the following tools are in your $PATH.
 
 ## Build
 
-Once you've cloned the Git repo the first time, invoke `sh bootstrap.sh` once
+Once you have cloned the Git repo the first time, invoke `sh bootstrap.sh` once
 to get a symlink and some some initial local files setup, and then you can
-build the web site locally by invoking make in the source root tree.
+build the website locally by invoking make in the source root tree.
 
-Note that this doesn't make you a complete web site mirror, as some scripts
+Note that this does not make you a complete website mirror, as some scripts
 and files are only available on the real actual site, but should give you
 enough to let you load most HTML pages locally.
 

--- a/_404.html
+++ b/_404.html
@@ -28,10 +28,10 @@ WHERE1(404 File not found)
 <p><b>This resource is gone!</b>
 <p>
   Whatever you hoped you were going to get when you asked for this particular
-  URL, it isn't here. We may have removed some old cruft and hope that you
+  URL, it is not here. We may have removed some old cruft and hope that you
   will find your way to the new content instead, you may have pasted a bad URL
   or we may have screwed up somewhere when we edited content on the site.
-  We just can't tell.
+  We just cannot tell.
 
 <p>
   A humble suggestion is that you start over on

--- a/_about.html
+++ b/_about.html
@@ -1,6 +1,6 @@
 #include "_doctype.html"
 <html>
-<head> <title>curl - About curl Web Site</title>
+<head> <title>curl - About curl website</title>
 #include "css.t"
 </head>
 
@@ -13,18 +13,18 @@
 #include "docs/_menu.html"
 
 WHERE3(Docs, "/docs/", Project, "/docs/projdocs.html", About)
-TITLE(About the curl Web Site)
+TITLE(About the curl website)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="/docs/">Online Docs</a>
 <br><a href="/mirror/">Mirrors</a>
 </div>
 <p>
- This web site is dedicated to covering curl, libcurl and related issues only.
+ This website is dedicated to covering curl, libcurl and related issues only.
 
 <p>
- If you have any complaints, ideas or suggestions for this <b>web site</b>,
- don't hesitate to mail feedback to <a
+ If you have any complaints, ideas or suggestions for this <b>website</b>,
+ do not hesitate to mail feedback to <a
  href="mailto:curl-web@haxx.se">curl-web@haxx.se</a> or post it on the <a
  href="//curl.se/mail/">curl-users mailing list</a>. We do make a
  serious effort to please our audience.
@@ -33,7 +33,7 @@ TITLE(About the curl Web Site)
  proper <a href="/mail/">curl mailing list</a>.
 <p>
 
-SUBTITLE(The curl web site contents are...)
+SUBTITLE(The curl website contents are...)
 <ul>
 
  <li> maintained and edited by the team. If you want to join in and help out
@@ -49,9 +49,9 @@ SUBTITLE(The curl web site contents are...)
 
 SUBTITLE(Zero tracking)
 <ul>
- <li> We serve no ads on any curl related web site.
- <li> We run no analytics scripts on any curl related web sites
- <li> We don't log web site visitors.
+ <li> We serve no ads on any curl related website.
+ <li> We run no analytics scripts on any curl related websites
+ <li> We do not log website visitors.
 </ul>
 
 SUBTITLE(Technologies used to build the site)
@@ -77,8 +77,8 @@ SUBTITLE(Technologies used to build the site)
 SUBTITLE(Emails and Spam)
 <p>
  We regularly display email addresses on this site by replacing the '@' sign with a
- textual version.  Research has shown that when we publish addresses in
- plaintext, we get a whole lot more spam.  Sorry for the inconvenience.
+ textual version. Research has shown that when we publish addresses in
+ plaintext, we get a whole lot more spam. Sorry for the inconvenience.
 
 #include "_footer.html"
 </body>

--- a/_book.html
+++ b/_book.html
@@ -18,7 +18,7 @@ TITLE(Everything curl - the book)
 
 <p>
   Learn how to use curl. How to use libcurl. How to build them from source or
-  perhaps how the curl project accepts contributions. There's something for
+  perhaps how the curl project accepts contributions. There is something for
   everyone in this, from the casual first-time users to the experienced
   libcurl hackers.
 <p>

--- a/_changes.html
+++ b/_changes.html
@@ -324,7 +324,7 @@ SUBTITLE(Fixed in 8.7.0 - March 27 2024)
  BGF <a href="https://curl.se/bug/?i=12852">ALTSVC.md: correct a typo</a>
  BGF <a href="https://curl.se/bug/?i=13065">asyn-ares: fix data race warning</a>
  BGF <a href="https://curl.se/bug/?i=12836">asyn-thread: use wakeup_close to close the read descriptor</a>
- BGF <a href="https://curl.se/bug/?i=12888">badwords: use hostname, not host name</a>
+ BGF <a href="https://curl.se/bug/?i=12888">badwords: use hostname, not hostname</a>
  BGF <a href="https://curl.se/bug/?i=12962">BINDINGS: add mcurl, the python binding</a>
  BGF <a href="https://curl.se/bug/?i=13020">bufq: writing into a softlimit queue cannot be partial</a>
  BGF <a href="https://curl.se/bug/?i=12880">c-hyper: add header collection writer in hyper builds</a>
@@ -338,7 +338,7 @@ SUBTITLE(Fixed in 8.7.0 - March 27 2024)
  BGF <a href="https://curl.se/bug/?i=12879">cmake: fix function description in comment</a>
  BGF <a href="https://curl.se/bug/?i=12920">cmake: fix install for older CMake versions</a>
  BGF <a href="https://curl.se/bug/?i=6169">cmake: fix libcurl.pc and curl-config library specifications</a>
- BGF <a href="https://curl.se/bug/?i=12829">cmdline-docs/Makefile: avoid using a fixed temp file name</a>
+ BGF <a href="https://curl.se/bug/?i=12829">cmdline-docs/Makefile: avoid using a fixed temp filename</a>
  BGF <a href="https://curl.se/bug/?i=12884">cmdline-docs: quote and angle bracket cleanup</a>
  BGF <a href="https://curl.se/bug/?i=13015">cmdline-opts/_EXITCODES: sync with libcurl-errors</a>
  BGF <a href="https://curl.se/bug/?i=13040">cmdline-opts/_VARIABLES.md: improve the description</a>
@@ -532,7 +532,7 @@ SUBTITLE(Fixed in 8.6.0 - January 31 2024)
  BGF <a href="https://curl.se/bug/?i=12647">connect: remove margin from eyeballer alloc</a>
  BGF <a href="https://curl.se/bug/?i=12618">content_encoding: change return code to typedef&apos;ed enum</a>
  BGF <a href="https://curl.se/bug/?i=12643">cookie.d: document use of empty string to enable cookie engine</a>
- BGF <a href="https://curl.se/bug/?i=12514">cookie: avoid fopen with empty file name</a>
+ BGF <a href="https://curl.se/bug/?i=12514">cookie: avoid fopen with empty filename</a>
  BGF <a href="https://curl.se/bug/?i=12695">curl.h: CURLOPT_DNS_SERVERS is only available with c-ares</a>
  BGF <a href="https://curl.se/mail/archive-2023-12/0026.html">curl: show ipfs and ipns as supported &quot;protocols&quot;</a>
  BGF <a href="https://curl.se/bug/?i=12727">curl_easy_getinfo.3: remove the wrong time value count</a>
@@ -744,7 +744,7 @@ SUBTITLE(Fixed in 8.5.0 - December 6 2023)
  BGF <a href="https://curl.se/bug/?i=12168">easy: remove duplicate wolfSSH init call</a>
  BGF <a href="https://curl.se/bug/?i=12090">easy_lock: add a pthread_mutex_t fallback</a>
  BGF <a href="https://curl.se/bug/?i=12299">fopen: create new file using old file&apos;s mode</a>
- BGF <a href="https://curl.se/bug/?i=12388">fopen: create short(er) temporary file name</a>
+ BGF <a href="https://curl.se/bug/?i=12388">fopen: create short(er) temporary filename</a>
  BGF <a href="https://curl.se/bug/?i=12140">getenv: PlayStation doesn&apos;t have getenv()</a>
  BGF <a href="https://curl.se/bug/?i=12157">GHA: move mod_h2 version in CI to v2.0.25</a>
  BGF <a href="https://curl.se/bug/?i=12145">hostip: show the list of IPs when resolving is done</a>
@@ -992,9 +992,9 @@ SUBTITLE(Fixed in 8.4.0 - October 11 2023)
  BGF <a href="https://curl.se/bug/?i=11897">tftpd: always use curl&apos;s own tftp.h</a>
  BGF <a href="https://curl.se/bug/?i=11958">tool: use our own stderr variable</a>
  BGF <a href="https://github.com/curl/curl/commit/af3f4e41#r127212213">tool_cb_wrt: fix debug assertion</a>
- BGF <a href="https://curl.se/bug/?i=12048">tool_getparam: accept variable expansion on file names too</a>
+ BGF <a href="https://curl.se/bug/?i=12048">tool_getparam: accept variable expansion on filenames too</a>
  BGF <a href="https://curl.se/bug/?i=11943">tool_setopt: remove unused function tool_setopt_flags</a>
- BGF <a href="https://curl.se/bug/?i=11911">upload-file.d: describe the file name slash/backslash handling</a>
+ BGF <a href="https://curl.se/bug/?i=11911">upload-file.d: describe the filename slash/backslash handling</a>
  BGF <a href="https://curl.se/bug/?i=12031">url: fall back to http/https proxy env-variable if ws/wss not set</a>
  BGF <a href="https://curl.se/bug/?i=11904">url: fix netrc info message</a>
  BGF <a href="https://curl.se/bug/?i=11932">warnless: remove unused functions</a>
@@ -1105,7 +1105,7 @@ SUBTITLE(Fixed in 8.3.0 - September 13 2023)
  BGF <a href="https://curl.se/bug/?i=11609">http3/ngtcp2: shorten handshake, trace cleanup</a>
  BGF <a href="https://curl.se/bug/?i=11618">http3: quiche, handshake optimization, trace cleanup</a>
  BGF <a href="https://curl.se/bug/?i=11678">http: close the connection after a late 417 is received</a>
- BGF <a href="https://sourceforge.net/p/curl/bugs/440/">http: do not require a user name when using CURLAUTH_NEGOTIATE</a>
+ BGF <a href="https://sourceforge.net/p/curl/bugs/440/">http: do not require a username when using CURLAUTH_NEGOTIATE</a>
  BGF <a href="https://curl.se/bug/?i=11342">http: fix sending of large requests</a>
  BGF <a href="https://curl.se/bug/?i=11681">http: remove the p_pragma struct field</a>
  BGF <a href="https://curl.se/bug/?i=11582">http: return error when receiving too large header set</a>
@@ -1252,7 +1252,7 @@ SUBTITLE(Fixed in 8.2.0 - July 19 2023)
  BGF <a href="https://curl.se/bug/?i=11352">cf-socket: move ctx declaration under HAVE_GETPEERNAME</a>
  BGF <a href="https://curl.se/bug/?i=11332">cf-socket: skip getpeername()/getsockname for TFTP</a>
  BGF <a href="https://curl.se/bug/?i=11358">checksrc: modernise perl file open</a>
- BGF <a href="https://curl.se/bug/?i=11437">checksrc: quote the file name to work with &quot;funny&quot; letters</a>
+ BGF <a href="https://curl.se/bug/?i=11437">checksrc: quote the filename to work with &quot;funny&quot; letters</a>
  BGF <a href="https://curl.se/bug/?i=11413">CI: brew fix for openssl in default path</a>
  BGF CI: don&apos;t install impacket if tests are not run
  BGF CI: enable parallel make in more builds
@@ -1389,7 +1389,7 @@ SUBTITLE(Fixed in 8.1.2 - May 30 2023)
  BGF <a href="https://curl.se/bug/?i=11216">page-header: mention curl version and how to figure out current release</a>
  BGF <a href="https://curl.se/bug/?i=11217">page-header: minor wording polish in the URL segment</a>
  BGF scripts/singleuse.pl: add more API calls
- BGF <a href="https://curl.se/bug/?i=11195">urlapi: remove superfluous host name check</a>
+ BGF <a href="https://curl.se/bug/?i=11195">urlapi: remove superfluous hostname check</a>
 </ul>
 
 <a name="8_1_1"></a>
@@ -1421,7 +1421,7 @@ SUBTITLE(Fixed in 8.1.1 - May 23 2023)
  BGF <a href="https://curl.se/bug/?i=11135">select: avoid returning an error on EINTR from select() or poll()</a>
  BGF test425: fix the log directory for the upload
  BGF <a href="https://curl.se/bug/?i=11137">url: provide better error message when URLs fail to parse</a>
- BGF <a href="https://curl.se/bug/?i=11129">urlapi: allow numerical parts in the host name</a>
+ BGF <a href="https://curl.se/bug/?i=11129">urlapi: allow numerical parts in the hostname</a>
  BGF <a href="https://curl.se/bug/?i=11146">vquic.c: make recvfrom_packets static, avoid compiler warning</a>
 </ul>
 
@@ -1473,12 +1473,12 @@ SUBTITLE(Fixed in 8.1.0 - May 17 2023)
  BGF <a href="https://curl.se/bug/?i=10899">content_encoding: only do transfer-encoding compression if asked to</a>
  BGF <a href="https://curl.se/bug/?i=10954">cookie: address PVS nits</a>
  BGF <a href="https://curl.se/bug/?i=10930">cookie: clarify that init with data set to NULL reads no file</a>
- BGF <a href="https://curl.se/mail/archive-2023-04/0008.html">curl: do NOT append file name to path for upload when there&apos;s a query</a>
+ BGF <a href="https://curl.se/mail/archive-2023-04/0008.html">curl: do NOT append filename to path for upload when there&apos;s a query</a>
  BGF <a href="https://curl.se/bug/?i=10850">curl_easy_getinfo.3: typo fix (duplicated &quot;from the&quot;)</a>
  BGF <a href="https://curl.se/bug/?i=10979">curl_easy_unescape.3: rename the argument</a>
  BGF <a href="https://curl.se/bug/?i=11001">curl_path: bring back support for SFTP path ending in /~</a>
  BGF <a href="https://curl.se/bug/?i=10921">curl_url_set.3: mention that users can set content rather freely</a>
- BGF <a href="https://curl.se/bug/?i=11087">CURLOPT_IPRESOLVE.3: this for host names, not IP addresses</a>
+ BGF <a href="https://curl.se/bug/?i=11087">CURLOPT_IPRESOLVE.3: this for hostnames, not IP addresses</a>
  BGF <a href="https://curl.se/bug/?i=10823">data.d: emphasize no conversion</a>
  BGF <a href="https://curl.se/bug/?i=10814">digest: clear target buffer</a>
  BGF <a href="https://curl.se/bug/?i=10834">doc: curl_mime_init() strong easy binding was relaxed in 7.87.0</a>
@@ -1505,7 +1505,7 @@ SUBTITLE(Fixed in 8.1.0 - May 17 2023)
  BGF <a href="https://curl.se/bug/?i=11005">h2/h3: replace `state.drain` counter with `state.dselect_bits`</a>
  BGF <a href="https://curl.se/bug/?i=10956">hash: fix assigning same value</a>
  BGF <a href="https://curl.se/bug/?i=11101">headers: clear (possibly) lingering pointer in init</a>
- BGF <a href="https://curl.se/bug/?i=11018">hostcheck: fix host name wildcard checking</a>
+ BGF <a href="https://curl.se/bug/?i=11018">hostcheck: fix hostname wildcard checking</a>
  BGF <a href="https://curl.se/bug/?i=11030">hostip: add locks around use of global buffer for alarm()</a>
  BGF <a href="https://curl.se/bug/?i=11084">hostip: enforce a maximum DNS cache size independent of timeout value</a>
  BGF <a href="https://curl.se/bug/?i=10847">HTTP-COOKIES.md: mention the #HttpOnly_ prefix</a>
@@ -1527,7 +1527,7 @@ SUBTITLE(Fixed in 8.1.0 - May 17 2023)
  BGF <a href="https://curl.se/bug/?i=10963">KNOWN_BUGS: remove fixed or outdated issues, move non-bugs</a>
  BGF <a href="https://curl.se/bug/?i=10896">lib/cmake: add HAVE_WRITABLE_ARGV check</a>
  BGF <a href="https://curl.se/bug/?i=10851">lib/sha256.c: typo fix in comment (duplicated &quot;is available&quot;)</a>
- BGF <a href="https://curl.se/bug/?i=10922">lib1560: verify that more bad host names are rejected</a>
+ BGF <a href="https://curl.se/bug/?i=10922">lib1560: verify that more bad hostnames are rejected</a>
  BGF <a href="https://curl.se/bug/?i=10720">lib: add `bufq` and `dynhds`</a>
  BGF <a href="https://curl.se/bug/?i=10908">lib: remove CURLX_NO_MEMORY_CALLBACKS</a>
  BGF <a href="https://curl.se/bug/?i=11017">lib: unify the upload/method handling</a>
@@ -1762,7 +1762,7 @@ SUBTITLE(Fixed in 8.0.0 - March 20 2023)
  BGF <a href="https://curl.se/bug/?i=10735">url: fix the SSH connection reuse check</a>
  BGF <a href="https://curl.se/bug/?i=10731">url: only reuse connections with same GSS delegation</a>
  BGF <a href="https://curl.se/bug/?i=10727">url: remove dummy protocol handler</a>
- BGF <a href="https://curl.se/bug/?i=10711">urlapi: &apos;%&apos; is illegal in host names</a>
+ BGF <a href="https://curl.se/bug/?i=10711">urlapi: &apos;%&apos; is illegal in hostnames</a>
  BGF <a href="https://curl.se/bug/?i=10708">urlapi: avoid mutating internals in getter routine</a>
  BGF <a href="https://curl.se/bug/?i=10660">urlapi: parse IPv6 literals without ENABLE_IPV6</a>
  BGF <a href="https://curl.se/bug/?i=10708">urlapi: take const args in _dup and _get functions</a>
@@ -1798,7 +1798,7 @@ SUBTITLE(Fixed in 7.88.1 - February 20 2023)
  BGF <a href="https://curl.se/bug/?i=10518">runtests: fix &quot;uninitialized value $port&quot;</a>
  BGF <a href="https://curl.se/bug/?i=10538">setopt: allow HTTP3 when HTTP2 is not defined</a>
  BGF <a href="https://curl.se/bug/?i=10561">socketpair: allow EWOULDBLOCK when reading the pair check bytes</a>
- BGF <a href="https://curl.se/bug/?i=10537">socks: allow using DoH to resolve host names</a>
+ BGF <a href="https://curl.se/bug/?i=10537">socks: allow using DoH to resolve hostnames</a>
  BGF <a href="https://curl.se/bug/?i=10519">tests-httpd: add proxy tests</a>
  BGF <a href="https://curl.se/bug/?i=10522">tests: make sure gnuserv-tls has SRP support before using it</a>
  BGF <a href="https://curl.se/bug/?i=10509">tests: make the telnet server shut down a socket gracefully</a>
@@ -1827,7 +1827,7 @@ SUBTITLE(Fixed in 7.88.0 - February 15 2023)
  BGF <a href="https://curl.se/bug/?i=10213">cf-socket: keep sockaddr local in the socket filters</a>
  BGF <a href="https://curl.se/bug/?i=10157">cfilters:Curl_conn_get_select_socks: use the first non-connected filter</a>
  BGF <a href="https://curl.se/bug/?i=10326">CI: add a workflow to automatically label pull requests</a>
- BGF <a href="https://curl.se/bug/?i=10317">CI: add pytest GHA to CI test/tests-httpd on a HTTP/3 setup</a>
+ BGF <a href="https://curl.se/bug/?i=10317">CI: add pytest GHA to CI test/tests-httpd on an HTTP/3 setup</a>
  BGF CI: Retry failed downloads to reduce spurious failures
  BGF <a href="https://curl.se/bug/?i=10493">CI: update wolfssl / wolfssh to 5.5.4 / 1.4.12</a>
  BGF <a href="https://curl.se/bug/?i=10128">cmake: bump requirement to 3.7</a>
@@ -1885,7 +1885,7 @@ SUBTITLE(Fixed in 7.88.0 - February 15 2023)
  BGF <a href="https://curl.se/bug/?i=10165">haxproxy: send before TLS handhshake</a>
  BGF <a href="https://curl.se/bug/?i=10455">header.d: add a header file example</a>
  BGF <a href="https://curl.se/bug/?i=10258">hsts.d: explain hsts more</a>
- BGF hsts: handle adding the same host name again
+ BGF hsts: handle adding the same hostname again
  BGF <a href="https://curl.se/bug/?i=10433">HTTP/[23]: continue upload when state.drain is set</a>
  BGF <a href="https://curl.se/bug/?i=10432">http2: aggregate small SETTINGS/PRIO/WIN_UPDATE frames</a>
  BGF http2: fix compiler warning due to uninitialized variable
@@ -2087,7 +2087,7 @@ SUBTITLE(Fixed in 7.87.0 - December 21 2022)
  BGF <a href="https://curl.se/bug/?i=10094">idn: remove Curl_win32_ascii_to_idn</a>
  BGF <a href="https://curl.se/bug/?i=9994">INSTALL: update operating systems and CPU archs</a>
  BGF <a href="https://curl.se/bug/?i=9871">KNOWN_BUGS: remove eight entries</a>
- BGF <a href="https://curl.se/bug/?i=10094">lib1560: add some basic IDN host name tests</a>
+ BGF <a href="https://curl.se/bug/?i=10094">lib1560: add some basic IDN hostname tests</a>
  BGF <a href="https://curl.se/bug/?i=9855">lib: connection filters (cfilter) addition to curl:</a>
  BGF <a href="https://curl.se/bug/?i=9667">lib: feature deprecation warnings in gcc &gt;= 4.3</a>
  BGF <a href="https://curl.se/bug/?i=9835">lib: fix some type mismatches and remove unneeded typecasts</a>
@@ -2153,7 +2153,7 @@ SUBTITLE(Fixed in 7.87.0 - December 21 2022)
  BGF <a href="https://curl.se/bug/?i=9865">tool_operate: when aborting, make sure there is a non-NULL error buffer</a>
  BGF <a href="https://curl.se/bug/?i=10098">tool_paramhlp: free the proto strings on exit</a>
  BGF <a href="https://curl.se/bug/?i=9937">url: move back the IDN conversion of proxy names</a>
- BGF <a href="https://curl.se/bug/?i=10096">urlapi: reject more bad letters from the host name: &+()</a>
+ BGF <a href="https://curl.se/bug/?i=10096">urlapi: reject more bad letters from the hostname: &+()</a>
  BGF <a href="https://curl.se/bug/?i=9946">urldata: change port num storage to int and unsigned short</a>
  BGF <a href="https://curl.se/bug/?i=10061">vms: remove SIZEOF_SHORT</a>
  BGF <a href="https://curl.se/bug/?i=9895">vtls: fix build without proxy support</a>
@@ -2307,7 +2307,7 @@ SUBTITLE(Fixed in 7.86.0 - October 26 2022)
  BGF <a href="https://curl.se/bug/?i=9744">mqtt: return error for too long topic</a>
  BGF <a href="https://curl.se/bug/?i=9751">mqtt: spell out CONNECT in comments</a>
  BGF msh3: change the static_assert to make the code C89
- BGF <a href="https://curl.se/bug/?i=9657">netrc: compare user name case sensitively</a>
+ BGF <a href="https://curl.se/bug/?i=9657">netrc: compare username case sensitively</a>
  BGF <a href="https://curl.se/bug/?i=9789">netrc: replace fgets with Curl_get_line</a>
  BGF <a href="https://curl.se/bug/?i=9709">netrc: use the URL-decoded user</a>
  BGF <a href="https://curl.se/bug/?i=9747">ngtcp2: fix build errors due to changes in ngtcp2 library</a>
@@ -2366,7 +2366,7 @@ SUBTITLE(Fixed in 7.86.0 - October 26 2022)
  BGF <a href="https://curl.se/bug/?i=9503">urlapi: detect scheme better when not guessing</a>
  BGF <a href="https://curl.se/bug/?i=9763">urlapi: fix parsing URL without slash with CURLU_URLENCODE</a>
  BGF <a href="https://curl.se/bug/?i=9408">urlapi: leaner with fewer allocs</a>
- BGF <a href="https://curl.se/bug/?i=9608">urlapi: reject more bad characters from the host name field</a>
+ BGF <a href="https://curl.se/bug/?i=9608">urlapi: reject more bad characters from the hostname field</a>
  BGF <a href="https://curl.se/mail/lib-2022-09/0038.html">winbuild/MakefileBuild.vc: handle spaces in libssh(2) include paths</a>
  BGF <a href="https://curl.se/bug/?i=9512">winbuild: use NMake batch-rules for compilation</a>
  BGF <a href="https://curl.se/bug/?i=9521">windows: add .rc support to autotools builds</a>
@@ -2651,7 +2651,7 @@ SUBTITLE(Fixed in 7.84.0 - June 27 2022)
  BGF <a href="https://curl.se/bug/?i=8870">ngtcp2: send appropriate connection close error code</a>
  BGF <a href="https://curl.se/bug/?i=8789">ngtcp2: support boringssl crypto backend</a>
  BGF <a href="https://curl.se/bug/?i=8968">ngtcp2: use helper funcs to simplify TLS handshake integration</a>
- BGF <a href="https://curl.se/bug/?i=8859">ntlm: provide a fixed fake host name</a>
+ BGF <a href="https://curl.se/bug/?i=8859">ntlm: provide a fixed fake hostname</a>
  BGF <a href="https://curl.se/bug/?i=8991">projects: fix third-party SSL library build paths for Visual Studio</a>
  BGF <a href="https://curl.se/bug/?i=8698">quic: add Curl_quic_idle</a>
  BGF <a href="https://curl.se/bug/?i=8696">quiche: support ca-fallback</a>
@@ -2659,7 +2659,7 @@ SUBTITLE(Fixed in 7.84.0 - June 27 2022)
  BGF <a href="https://curl.se/bug/?i=8945">remote-name.d: mention --output-dir</a>
  BGF <a href="https://curl.se/bug/?i=8959">runtests.pl: add the --repeat parameter to the --help output</a>
  BGF <a href="https://curl.se/bug/?i=8977">runtests: fix skipping tests not done event-based</a>
- BGF <a href="https://curl.se/bug/?i=9013">runtests: skip starting the ssh server if user name is lacking</a>
+ BGF <a href="https://curl.se/bug/?i=9013">runtests: skip starting the ssh server if username is lacking</a>
  BGF <a href="https://curl.se/bug/?i=8952">scripts/copyright.pl: fix the exclusion to not ignore manpages</a>
  BGF <a href="https://curl.se/bug/?i=8846">sectransp: check for a function defined when __BLOCKS__ is undefined</a>
  BGF <a href="https://curl.se/bug/?i=8921">select: return error from &quot;lethal&quot; poll/select errors</a>
@@ -2702,7 +2702,7 @@ SUBTITLE(Fixed in 7.83.1 - May 11 2022)
   RELEASEVIDEO(7.83.1, "https://youtu.be/mnsCTd4cwyI")
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF <a href="https://curl.se/bug/?i=8819">altsvc: fix host name matching for trailing dots</a>
+ BGF <a href="https://curl.se/bug/?i=8819">altsvc: fix hostname matching for trailing dots</a>
  BGF <a href="https://curl.se/bug/?i=8783">cirrus: Update to FreeBSD 12.3</a>
  BGF <a href="https://curl.se/bug/?i=8783">cirrus: Use pip for Python packages on FreeBSD</a>
  BGF <a href="https://curl.se/bug/?i=8759">conn: fix typo &apos;connnection&apos; -&gt; &apos;connection&apos; in two function names</a>
@@ -2733,7 +2733,7 @@ SUBTITLE(Fixed in 7.83.1 - May 11 2022)
  BGF <a href="https://curl.se/bug/?i=8828">ngtcp2: add ca-fallback support for OpenSSL backend</a>
  BGF <a href="https://curl.se/docs/CVE-2022-27781.html">nss: return error if seemingly stuck in a cert loop</a>
  BGF <a href="https://curl.se/mail/lib-2022-04/0059.html">openssl: define HAVE_SSL_CTX_SET_EC_CURVES for libressl</a>
- BGF <a href="https://curl.se/docs/CVE-2022-27778.html">post_per_transfer: remove the updated file name</a>
+ BGF <a href="https://curl.se/docs/CVE-2022-27778.html">post_per_transfer: remove the updated filename</a>
  BGF <a href="https://curl.se/bug/?i=8798">sectransp: bail out if SSLSetPeerDomainName fails</a>
  BGF <a href="https://curl.se/bug/?i=8799">tests/server: declare variable &apos;reqlogfile&apos; static</a>
  BGF <a href="https://curl.se/bug/?i=8802">tests: fix markdown formatting in README</a>
@@ -2741,7 +2741,7 @@ SUBTITLE(Fixed in 7.83.1 - May 11 2022)
  BGF <a href="https://curl.se/docs/CVE-2022-27782.html">tls: check more TLS details for connection reuse</a>
  BGF <a href="https://curl.se/docs/CVE-2022-27782.html">url: check SSH config match on connection reuse</a>
  BGF <a href="https://curl.se/bug/?i=8797">urlapi: address (harmless) UndefinedBehavior sanitizer warning</a>
- BGF <a href="https://curl.se/docs/CVE-2022-27780.html">urlapi: reject percent-decoding host name into separator bytes</a>
+ BGF <a href="https://curl.se/docs/CVE-2022-27780.html">urlapi: reject percent-decoding hostname into separator bytes</a>
  BGF <a href="https://curl.se/bug/?i=8757">x509asn1: make do_pubkey handle EC public keys</a>
 </ul>
 
@@ -2779,7 +2779,7 @@ SUBTITLE(Fixed in 7.83.0 - April 27 2022)
  BGF <a href="https://curl.se/bug/?i=8704">curl: error out if -T and -d are used for the same URL</a>
  BGF <a href="https://curl.se/bug/?i=8565">curl: error out when options need features not present in libcurl</a>
  BGF <a href="https://hackerone.com/reports/1548535">curl: escape &apos;?&apos; in generated --libcurl code</a>
- BGF <a href="https://curl.se/bug/?i=8606">curl: fix segmentation fault for empty output file names.</a>
+ BGF <a href="https://curl.se/bug/?i=8606">curl: fix segmentation fault for empty output filenames.</a>
  BGF <a href="https://curl.se/bug/?i=8694">curl_easy_header: fix typos in documentation</a>
  BGF <a href="https://curl.se/bug/?i=8725">CURLINFO_PRIMARY_PORT.3: clarify which port this is</a>
  BGF <a href="https://curl.se/bug/?i=8753">CURLOPT*TLSAUTH.3: they only work with OpenSSL or GnuTLS</a>
@@ -3039,7 +3039,7 @@ SUBTITLE(Fixed in 7.82.0 - March 5 2022)
  BGF <a href="https://curl.se/bug/?i=8469">schannel: move the algIds array out of schannel.h</a>
  BGF <a href="https://curl.se/bug/?i=8408">scripts/cijobs.pl: output data about all currect CI jobs</a>
  BGF <a href="https://curl.se/bug/?i=8363">scripts/completion.pl: improve zsh completion</a>
- BGF scripts/copyright.pl: support many provided file names on the cmdline
+ BGF scripts/copyright.pl: support many provided filenames on the cmdline
  BGF scripts/delta: check the file delta for current branch
  BGF <a href="https://curl.se/bug/?i=8479">sectransp: mark a 3DES cipher as weak</a>
  BGF <a href="https://curl.se/bug/?i=8377">setopt: do bounds-check before strdup</a>
@@ -3057,7 +3057,7 @@ SUBTITLE(Fixed in 7.82.0 - March 5 2022)
  BGF <a href="https://curl.se/bug/?i=8538">unit1610: init SSL library before calling SHA256 functions</a>
  BGF <a href="https://curl.se/bug/?i=8439">url: exclude zonefrom_url when no ipv6 is available</a>
  BGF <a href="https://curl.se/bug/?i=8241">url: given a user in the URL, find pwd for that user in netrc</a>
- BGF <a href="https://curl.se/bug/?i=8290">url: keep trailing dot in host name</a>
+ BGF <a href="https://curl.se/bug/?i=8290">url: keep trailing dot in hostname</a>
  BGF <a href="https://curl.se/bug/?i=8303">url: make Curl_disconnect return void</a>
  BGF <a href="https://curl.se/bug/?i=8450">urlapi: handle &quot;redirects&quot; smarter</a>
  BGF <a href="https://curl.se/bug/?i=8350">urldata: CONN_IS_PROXIED replaces bits.proxy when proxy can be disabled</a>
@@ -3079,7 +3079,7 @@ SUBTITLE(Fixed in 7.81.0 - January 5 2022)
   RELEASEVIDEO(7.81.0, "https://youtu.be/OfTF8kmcSlA")
 <p> Changes:
 <ul class="changes">
- CHG <a href="https://curl.se/bug/?i=7789">mime: use percent-escaping for multipart form field and file names</a>
+ CHG <a href="https://curl.se/bug/?i=7789">mime: use percent-escaping for multipart form field and filenames</a>
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
@@ -3174,7 +3174,7 @@ SUBTITLE(Fixed in 7.81.0 - January 5 2022)
  BGF <a href="https://curl.se/bug/?i=8038">rustls: remove comment about checking handshaking</a>
  BGF <a href="https://curl.se/bug/?i=8003">rustls: remove incorrect EOF check</a>
  BGF <a href="https://curl.se/bug/?i=8133">sha256/md5: return errors when init fails</a>
- BGF <a href="https://curl.se/bug/?i=8216">socks5: use appropriate ATYP for numerical IP address host names</a>
+ BGF <a href="https://curl.se/bug/?i=8216">socks5: use appropriate ATYP for numerical IP address hostnames</a>
  BGF <a href="https://curl.se/bug/?i=8127">test1156: enable for hyper</a>
  BGF <a href="https://curl.se/bug/?i=8134">test1156: fixup the stdout check for Windows</a>
  BGF <a href="https://curl.se/bug/?i=8128">test1525: tweaked for hyper</a>
@@ -3333,7 +3333,7 @@ SUBTITLE(Fixed in 7.80.0 - November 10 2021)
  BGF <a href="https://curl.se/bug/?i=7917">url: check the return value of curl_url()</a>
  BGF <a href="https://curl.se/bug/?i=7871">url: set &quot;k-&gt;size&quot; -1 at start of request</a>
  BGF <a href="https://curl.se/bug/?i=7862">urlapi: skip a strlen(), pass in zero</a>
- BGF <a href="https://curl.se/bug/?i=7830">urlapi: URL decode percent-encoded host names</a>
+ BGF <a href="https://curl.se/bug/?i=7830">urlapi: URL decode percent-encoded hostnames</a>
  BGF <a href="https://curl.se/bug/?i=7742">version_win32: use actual version instead of manifested version</a>
  BGF <a href="https://curl.se/bug/?i=7683">vtls: Fix a memory leak if an SSL session cannot be added to the cache</a>
  BGF <a href="https://curl.se/bug/?i=7806">wolfssl: use for SHA256, MD4, MD5, and setting DES odd parity</a>
@@ -3515,7 +3515,7 @@ SUBTITLE(Fixed in 7.78.0 - July 21 2021)
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF <a href="https://curl.se/bug/?i=7273">--socks4[a]: clarify where the host name is resolved</a>
+ BGF <a href="https://curl.se/bug/?i=7273">--socks4[a]: clarify where the hostname is resolved</a>
  BGF <a href="https://curl.se/mail/lib-2021-06/0003.html">ares: always store IPv6 addresses first</a>
  BGF <a href="https://curl.se/bug/?i=7248">asyn-ares: remove check for &apos;data&apos; in Curl_resolver_cancel</a>
  BGF <a href="https://curl.se/bug/?i=7133">bearssl: explicitly initialize all fields of Curl_ssl</a>
@@ -3832,7 +3832,7 @@ SUBTITLE(Fixed in 7.77.0 - May 26 2021)
  BGF <a href="https://curl.se/bug/?i=6905">tool_writeout: fix the HTTP_CODE json output</a>
  BGF <a href="https://curl.se/bug/?i=7011">travis: disable the failing libssh build</a>
  BGF <a href="https://curl.se/bug/?i=7026">URL-SYNTAX: update IDNA section for WHATWG spec changes</a>
- BGF <a href="https://curl.se/bug/?i=6863">urlapi: &quot;normalize&quot; numerical IPv4 host names</a>
+ BGF <a href="https://curl.se/bug/?i=6863">urlapi: &quot;normalize&quot; numerical IPv4 hostnames</a>
  BGF <a href="https://curl.se/bug/?i=6654">vauth: factor base64 conversions out of authentication procedures</a>
  BGF <a href="https://curl.se/bug/?i=6843">version: add gsasl_version to curl_version_info_data</a>
  BGF <a href="https://curl.se/bug/?i=7054">version: add OpenLDAP version in the output</a>
@@ -4008,7 +4008,7 @@ SUBTITLE(Fixed in 7.76.0 - March 31 2021)
  BGF url.c: use consistent error message for failed resolve
  BGF <a href="https://github.com/curl/curl/pull/6627#issuecomment-781626205">url: fix memory leak if OOM in the HSTS handling</a>
  BGF <a href="https://github.com/curl/curl/issues/6604#issuecomment-780138219">url: fix possible use-after-free in default protocol</a>
- BGF <a href="https://curl.se/bug/?i=6585">urldata: don&apos;t touch data-&gt;set.httpversion at run-time</a>
+ BGF <a href="https://curl.se/bug/?i=6585">urldata: don&apos;t touch data-&gt;set.httpversion at runtime</a>
  BGF <a href="https://curl.se/bug/?i=6562">urldata: fix build without HTTP and MQTT</a>
  BGF <a href="https://curl.se/bug/?i=6648">urldata: make &apos;actions[]&apos; use unsigned char instead of int</a>
  BGF <a href="https://curl.se/bug/?i=6798">urldata: merge &quot;struct DynamicStatic&quot; into &quot;struct UrlState&quot;</a>
@@ -4051,7 +4051,7 @@ SUBTITLE(Fixed in 7.75.0 - February 3 2021)
  BGF <a href="https://curl.se/bug/?i=6112">cookie: avoid the C1001 internal compiler error with MSVC 14</a>
  BGF <a href="https://curl.se/bug/?i=6380">curl.1: fix typo microsft -&gt; microsoft</a>
  BGF <a href="https://curl.se/bug/?i=6364">curl: fix handling of -q option</a>
- BGF curl: include the file name in --xattr/--remote-time error msgs
+ BGF curl: include the filename in --xattr/--remote-time error msgs
  BGF <a href="https://curl.se/bug/?i=6533">curl: move fprintf outputs to warnf</a>
  BGF <a href="https://curl.se/bug/?i=6527">Curl_chunker: shrink the struct</a>
  BGF <a href="https://curl.se/bug/?i=6360">curl_easy_pause.3: add multiplexed pause effects</a>
@@ -4075,7 +4075,7 @@ SUBTITLE(Fixed in 7.75.0 - February 3 2021)
  BGF <a href="https://curl.se/bug/?i=6356">h2: do not wait for RECV on paused transfers</a>
  BGF HISTORY: added dates to early history
  BGF <a href="https://twitter.com/mholt6/status/1352130240265375744">http: empty reply connection are not left intact</a>
- BGF <a href="https://curl.se/bug/?i=6490">http: get CURLOPT_REQUEST_TARGET working with a HTTP proxy</a>
+ BGF <a href="https://curl.se/bug/?i=6490">http: get CURLOPT_REQUEST_TARGET working with an HTTP proxy</a>
  BGF <a href="https://curl.se/bug/?i=6408">http: have CURLOPT_FAILONERROR fail after all headers</a>
  BGF <a href="https://curl.se/mail/lib-2021-01/0095.html">http: make providing Proxy-Connection header not cause duplicated headers</a>
  BGF <a href="https://curl.se/bug/?i=6328">http: show the request as headers even when split-sending</a>
@@ -4106,7 +4106,7 @@ SUBTITLE(Fixed in 7.75.0 - February 3 2021)
  BGF <a href="https://curl.se/bug/?i=6521">ngtcp2: Fix http3 upload stall</a>
  BGF <a href="https://curl.se/bug/?i=6521">ngtcp2: Fix stack buffer overflow</a>
  BGF <a href="https://curl.se/bug/?i=6296">ngtcp2: make it build it current master again</a>
- BGF <a href="https://curl.se/bug/?i=6445">nss: get the run-time version instead of build-time</a>
+ BGF <a href="https://curl.se/bug/?i=6445">nss: get the runtime version instead of build-time</a>
  BGF <a href="https://curl.se/bug/?i=6540">openssl: lowercase the hostname before using it for SNI</a>
  BGF <a href="https://curl.se/bug/?i=6292">OS400: update ccsidcurl.c</a>
  BGF <a href="https://curl.se/bug/?i=6312">pretransfer: setup the User-Agent header here</a>
@@ -4467,7 +4467,7 @@ SUBTITLE(Fixed in 7.72.0 - August 19 2020)
  BGF <a href="https://curl.se/bug/?i=5729">CURLOPT_NOBODY.3: clarify what setting to 0 means</a>
  BGF <a href="https://curl.se/bug/?i=5744">docs: add date of 7.20 to CURLM_CALL_MULTI_PERFORM mentions</a>
  BGF <a href="https://curl.se/bug/?i=5811">docs: Add video link to docs/CONTRIBUTE.md</a>
- BGF <a href="https://curl.se/bug/?i=5822">docs: change "web site" to "website"</a>
+ BGF <a href="https://curl.se/bug/?i=5822">docs: change "website" to "website"</a>
  BGF <a href="https://curl.se/bug/?i=5788">docs: clarify MAX_SEND/RECV_SPEED functionality</a>
  BGF <a href="https://curl.se/bug/?i=5688">docs: Update a few leftover mentions of DarwinSSL</a>
  BGF <a href="https://curl.se/bug/?i=5704">doh: remove redundant cast</a>
@@ -4703,7 +4703,7 @@ SUBTITLE(Fixed in 7.71.0 - June 24 2020)
  BGF <a href="https://curl.se/bug/?i=5377">url: sort the protocol schemes in rough popularity order</a>
  BGF <a href="https://curl.se/bug/?i=5344">urlapi: accept :: as a valid IPv6 address</a>
  BGF <a href="https://curl.se/bug/?i=5499">urldata: leave the HTTP method untouched in the set.* struct</a>
- BGF <a href="https://curl.se/bug/?i=5576">urlglob: treat literal IPv6 addresses with zone IDs as a host name</a>
+ BGF <a href="https://curl.se/bug/?i=5576">urlglob: treat literal IPv6 addresses with zone IDs as a hostname</a>
  BGF <a href="https://curl.se/bug/?i=5525">user-agent.d: spell out what happens given a blank argument</a>
  BGF <a href="https://curl.se/bug/?i=5391">vauth/cleartext: fix theoretical integer overflow</a>
  BGF <a href="https://curl.se/bug/?i=5558">version.d: expanded and alpha-sorted</a>
@@ -4762,7 +4762,7 @@ SUBTITLE(Fixed in 7.70.0 - April 29 2020)
  BGF <a href="https://curl.se/bug/?i=5126">curl-functions.m4: remove inappropriate AC_REQUIRE</a>
  BGF <a href="https://curl.se/bug/?i=5157">curl.h: remnove CURL_VERSION_ESNI. Never supported nor documented</a>
  BGF <a href="https://curl.se/bug/?i=5279">curl.h: update comment typo</a>
- BGF <a href="https://curl.se/bug/?i=5179">curl: allow both --etag-compare and --etag-save with same file name</a>
+ BGF <a href="https://curl.se/bug/?i=5179">curl: allow both --etag-compare and --etag-save with same filename</a>
  BGF <a href="https://curl.se/bug/?i=4995">curl_setup: define _WIN32_WINNT_[OS] symbols</a>
  BGF <a href="https://curl.se/bug/?i=5181">CURLINFO_CONDITION_UNMET: return true for 304 http status code</a>
  BGF <a href="https://curl.se/bug/?i=5135">CURLINFO_NUM_CONNECTS: improve accuracy</a>
@@ -4889,7 +4889,7 @@ SUBTITLE(Fixed in 7.69.1 - March 11 2020)
  BGF <a href="https://curl.se/bug/?i=5030">sha256: Added SecureTransport implementation</a>
  BGF <a href="https://curl.se/bug/?i=5030">sha256: Added WinCrypt implementation</a>
  BGF <a href="https://curl.se/bug/?i=5061">socks4: fix host resolve regression</a>
- BGF <a href="https://curl.se/bug/?i=5053">socks5: host name resolv regression fix</a>
+ BGF <a href="https://curl.se/bug/?i=5053">socks5: hostname resolv regression fix</a>
  BGF <a href="https://curl.se/bug/?i=5064">tests/server: fix missing use of exe_ext helper function</a>
  BGF <a href="https://curl.se/bug/?i=5065">tests: fix static ip:port instead of dynamic values being used</a>
  BGF <a href="https://curl.se/bug/?i=5035">tests: make sleeping portable by avoiding select</a>
@@ -4911,7 +4911,7 @@ SUBTITLE(Fixed in 7.69.0 - March 4 2020)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF <a href="https://curl.se/bug/?i=4875">altsvc: improved header parser</a>
- BGF <a href="https://curl.se/bug/?i=4898">altsvc: keep a copy of the file name to survive handle reset</a>
+ BGF <a href="https://curl.se/bug/?i=4898">altsvc: keep a copy of the filename to survive handle reset</a>
  BGF <a href="https://curl.se/bug/?i=4936">altsvc: make saving the cache an atomic operation</a>
  BGF altsvc: use h3-27
  BGF <a href="https://curl.se/bug/?i=4925">azure: disable brotli on the macos debug-builds</a>
@@ -5014,7 +5014,7 @@ SUBTITLE(Fixed in 7.69.0 - March 4 2020)
  BGF <a href="https://curl.se/bug/?i=4956">sha256: use crypto implementations when available</a>
  BGF <a href="https://curl.se/bug/?i=4842">singleuse.pl: support new API functions, fix curl_dbg_ handling</a>
  BGF <a href="https://curl.se/bug/?i=4892">smtp: support the SMTPUTF8 extension</a>
- BGF <a href="https://curl.se/bug/?i=4928">smtp: support UTF-8 based host names in MAIL FROM</a>
+ BGF <a href="https://curl.se/bug/?i=4928">smtp: support UTF-8 based hostnames in MAIL FROM</a>
  BGF <a href="https://curl.se/bug/?i=4907">SOCKS: make the connect phase non-blocking</a>
  BGF <a href="https://curl.se/bug/?i=4842">strcase: turn Curl_raw_tolower into static</a>
  BGF <a href="https://curl.se/bug/?i=4920">strerror: increase STRERROR_LEN 128 -> 256</a>
@@ -5239,7 +5239,7 @@ SUBTITLE(Fixed in 7.67.0 - November 6 2019)
  BGF <a href="https://curl.se/bug/?i=4336">curl: load large files with -d @ much faster</a>
  BGF <a href="https://curl.se/bug/?i=4338">docs/HTTP3: fix `--with-ssl` ngtcp2 configure flag</a>
  BGF <a href="https://curl.se/bug/?i=4471">docs: added multi-event.c example</a>
- BGF <a href="https://curl.se/bug/?i=4424">docs: disambiguate CURLUPART_HOST is for host name (ie no port)</a>
+ BGF <a href="https://curl.se/bug/?i=4424">docs: disambiguate CURLUPART_HOST is for hostname (ie no port)</a>
  BGF <a href="https://curl.se/bug/?i=4446">docs: note on failed handles not being counted by curl_multi_perform</a>
  BGF <a href="https://curl.se/bug/?i=4406">doh: allow only http and https in debug mode</a>
  BGF <a href="https://curl.se/bug/?i=4381">doh: avoid truncating DNS QTYPE to lower octet</a>
@@ -5330,7 +5330,7 @@ SUBTITLE(Fixed in 7.66.0 - September 11 2019)
  BGF CMake: remove needless newlines at end of gss variables
  BGF <a href="https://curl.se/bug/?i=4279">CMake: use platform dependent name for dlopen() library</a>
  BGF <a href="https://curl.se/bug/?i=4250">CURLINFO docs: mention that in redirects times are added</a>
- BGF CURLOPT_ALTSVC.3: use a "" file name to not load from a file
+ BGF CURLOPT_ALTSVC.3: use a "" filename to not load from a file
  BGF CURLOPT_ALTSVC_CTRL.3: remove CURLALTSVC_ALTUSED
  BGF <a href="https://curl.se/bug/?i=4273">CURLOPT_HEADERFUNCTION.3: clarify</a>
  BGF <a href="https://curl.se/bug/?i=4197">CURLOPT_HTTP_VERSION: seting this to 3 forces HTTP/3 use directly</a>
@@ -5514,7 +5514,7 @@ SUBTITLE(Fixed in 7.65.1 - June 5 2019)
  BGF <a href="https://curl.se/bug/?i=3945">cmake: support CMAKE_OSX_ARCHITECTURES when detecting SIZEOF variables</a>
  BGF <a href="https://curl.se/bug/?i=3923">config-win32: add support for if_nametoindex and getsockname</a>
  BGF <a href="https://curl.se/bug/?i=3962">conncache: Remove the DEBUGASSERT on length check</a>
- BGF <a href="https://curl.se/bug/?i=3951">conncache: make "bundles" per host name when doing proxy tunnels</a>
+ BGF <a href="https://curl.se/bug/?i=3951">conncache: make "bundles" per hostname when doing proxy tunnels</a>
  BGF <a href="https://curl.se/bug/?i=3939">curl-win32.h: Enable Unix Domain Sockets based on the Windows SDK version</a>
  BGF <a href="https://curl.se/mail/lib-2019-06/0009.html">curl_share_setopt.3: improve wording</a>
  BGF <a href="https://curl.se/bug/?i=3964">dump-header.d: spell out that no headers == empty file</a>
@@ -5635,7 +5635,7 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF scripts: fix typos
  BGF singleipconnect: show port in the verbose "Trying ..." message
  BGF <a href="https://curl.se/bug/?i=3729">smtp: fix compiler warning</a>
- BGF <a href="https://curl.se/bug/?i=3737">socks5: user name and passwords must be shorter than 256</a>
+ BGF <a href="https://curl.se/bug/?i=3737">socks5: username and passwords must be shorter than 256</a>
  BGF socks: fix error message
  BGF <a href="https://curl.se/bug/?i=3752">socksd: new SOCKS 4+5 server for tests</a>
  BGF <a href="https://curl.se/bug/?i=3726">spnego_gssapi: fix return code on gss_init_sec_context() failure</a>
@@ -5661,7 +5661,7 @@ SUBTITLE(Fixed in 7.65.0 - May 22 2019)
  BGF <a href="https://curl.se/bug/?i=3902">url: convert the zone id from a IPv6 URL to correct scope id</a>
  BGF <a href="https://curl.se/bug/?i=3834">urlapi: add CURLUPART_ZONEID to set and get</a>
  BGF <a href="https://curl.se/bug/?i=3905">urlapi: increase supported scheme length to 40 bytes</a>
- BGF <a href="https://curl.se/bug/?i=3880">urlapi: require a non-zero host name length when parsing URL</a>
+ BGF <a href="https://curl.se/bug/?i=3880">urlapi: require a non-zero hostname length when parsing URL</a>
  BGF <a href="https://curl.se/bug/?i=3762">urlapi: stricter CURLUPART_PORT parsing</a>
  BGF <a href="https://curl.se/bug/?i=3817">urlapi: strip off zone id from numerical IPv6 addresses</a>
  BGF <a href="https://curl.se/bug/?i=3741">urlapi: urlencode characters above 0x7f correctly</a>
@@ -5929,13 +5929,13 @@ SUBTITLE(Fixed in 7.63.0 - December 12 2018)
  BGF <a href="https://curl.se/bug/?i=3346">curl_global_sslset(): id == -1 is not necessarily an error</a>
  BGF <a href="https://curl.se/bug/?i=3209">curl_multibyte: fix a malloc overcalculation</a>
  BGF <a href="https://curl.se/bug/?i=3291">curle: move deprecated error code to ifndef block</a>
- BGF <a href="https://curl.se/bug/?i=3361">docs: curl_formadd field and file names are now escaped</a>
+ BGF <a href="https://curl.se/bug/?i=3361">docs: curl_formadd field and filenames are now escaped</a>
  BGF <a href="https://curl.se/bug/?i=3246">docs: escape "\n" codes</a>
  BGF <a href="https://curl.se/bug/?i=3342">doh: fix memory leak in OOM situation</a>
  BGF <a href="https://curl.se/bug/?i=3325">doh: make it work for h2-disabled builds too</a>
  BGF examples/ephiperfifo: report error when epoll_ctl fails
  BGF <a href="https://curl.se/bug/?i=3225">ftp: avoid two unsigned int overflows in FTP listing parser</a>
- BGF <a href="https://curl.se/bug/?i=3022">host names: allow trailing dot in name resolve, then strip it</a>
+ BGF <a href="https://curl.se/bug/?i=3022">hostnames: allow trailing dot in name resolve, then strip it</a>
  BGF <a href="https://curl.se/bug/?i=3349">http2: Upon HTTP_1_1_REQUIRED, retry the request with HTTP/1.1</a>
  BGF <a href="https://curl.se/bug/?i=3359">http: don&#39;t set CURLINFO_CONDITION_UNMET for http status code 204</a>
  BGF <a href="https://curl.se/bug/?i=3353">http: fix HTTP Digest auth to include query in URI</a>
@@ -5977,7 +5977,7 @@ SUBTITLE(Fixed in 7.63.0 - December 12 2018)
  BGF <a href="https://curl.se/bug/?i=3254">tool_doswin: Fix uninitialized field warning</a>
  BGF <a href="https://curl.se/bug/?i=3190">travis: build with clang sanitizers</a>
  BGF <a href="https://curl.se/bug/?i=3198">travis: remove curl before a normal build</a>
- BGF <a href="https://curl.se/bug/?i=3220">url: a short host name + port is not a scheme</a>
+ BGF <a href="https://curl.se/bug/?i=3220">url: a short hostname + port is not a scheme</a>
  BGF <a href="https://curl.se/bug/?i=3218">url: fix IPv6 numeral address parser</a>
  BGF <a href="https://curl.se/bug/?i=3231">urlapi: only skip encoding the first &#39;=&#39; with APPENDQUERY set</a>
 </ul>
@@ -6153,7 +6153,7 @@ SUBTITLE(Fixed in 7.61.1 - September 5 2018)
  BGF <a href="https://curl.se/bug/?i=2925">curl: add http code 408 to transient list for --retry</a>
  BGF <a href="https://curl.se/bug/?i=2739">curl: fix time-of-check, time-of-use race in dir creation</a>
  BGF <a href="https://curl.se/bug/?i=2783">curl: use Content-Disposition before the "URL end" for -OJ</a>
- BGF <a href="https://curl.se/bug/?i=2885">curl: warn the user if a given file name looks like an option</a>
+ BGF <a href="https://curl.se/bug/?i=2885">curl: warn the user if a given filename looks like an option</a>
  BGF <a href="https://curl.se/bug/?i=2908">curl_threads: silence bad-function-cast warning</a>
  BGF <a href="https://curl.se/bug/?i=2731">darwinssl: add support for ALPN negotiation</a>
  BGF <a href="https://curl.se/bug/?i=2788">docs/CURLOPT_URL: fix indentation</a>
@@ -6251,7 +6251,7 @@ SUBTITLE(Fixed in 7.61.0 - July 11 2018)
  BGF <a href="https://curl.se/bug/?i=2587">curl_fnmatch: only allow two asterisks for matching</a>
  BGF <a href="https://curl.se/bug/?i=2590">docs: clarify CURLOPT_HTTPGET</a>
  BGF <a href="https://curl.se/bug/?i=2586">configure: replace a AC_TRY_RUN with CURL_RUN_IFELSE</a>
- BGF <a href="https://curl.se/bug/?i=2586">configure: do compile-time SIZEOF checks instead of run-time</a>
+ BGF <a href="https://curl.se/bug/?i=2586">configure: do compile-time SIZEOF checks instead of runtime</a>
  BGF <a href="https://curl.se/bug/?i=2563">checksrc: make sure sizeof() is used *with* parentheses</a>
  BGF CURLOPT_ACCEPT_ENCODING.3: add brotli and clarify a bit
  BGF <a href="https://curl.se/bug/?i=2592">schannel: make CAinfo parsing resilient to CR/LF</a>
@@ -6412,7 +6412,7 @@ SUBTITLE(Fixed in 7.60.0 - May 16 2018)
  BGF <a href="https://curl.se/bug/?i=2416">http2: handle GOAWAY properly</a>
  BGF tool_help: clarify --max-time unit of time is seconds
  BGF <a href="https://curl.se/bug/?i=2515">curl.1: clarify that options and URLs can be mixed</a>
- BGF <a href="https://curl.se/bug/?i=2514">http2: convert an assert to run-time check</a>
+ BGF <a href="https://curl.se/bug/?i=2514">http2: convert an assert to runtime check</a>
  BGF <a href="https://curl.se/bug/?i=2499">curl_global_sslset: always provide available backends</a>
  BGF <a href="https://curl.se/bug/?i=2445">ftplistparser: keep state between invokes</a>
  BGF Curl_memchr: zero length input can&#39;t match
@@ -6517,7 +6517,7 @@ SUBTITLE(Fixed in 7.59.0 - March 14 2018)
  BGF <a href="https://curl.se/mail/lib-2018-02/0056.html">http: fix the max header length detection logic</a>
  BGF <a href="https://curl.se/bug/?i=2314">header callback: don&#39;t chop headers into smaller pieces</a>
  BGF CURLOPT_HEADER.3: clarify problems with different data sizes
- BGF curl --version: show PSL if the run-time lib has it enabled
+ BGF curl --version: show PSL if the runtime lib has it enabled
  BGF <a href="https://curl.se/mail/lib-2018-02/0072.html">examples/sftpuploadresume: resume upload via CURLOPT_APPEND</a>
  BGF <a href="https://curl.se/bug/?i=2302">Return error if called recursively from within callbacks</a>
  BGF sasl: prefer PLAIN mechanism over LOGIN
@@ -6543,14 +6543,14 @@ SUBTITLE(Fixed in 7.59.0 - March 14 2018)
  BGF curl tool: accept --compressed also if Brotli is enabled and zlib is not
  BGF <a href="https://curl.se/bug/?i=2349">WolfSSL: adding TLSv1.3</a>
  BGF checksrc.pl: add -i and -m options
- BGF CURLOPT_COOKIEFILE.3: "-" as file name means stdin
+ BGF CURLOPT_COOKIEFILE.3: "-" as filename means stdin
 </ul>
 
 <a name="7_58_0"></a>
 SUBTITLE(Fixed in 7.58.0 - January 24 2018)
 <p> Changes:
 <ul class="changes">
- CHG new libssh-powered SSH SCP/SFTP back-end
+ CHG new libssh-powered SSH SCP/SFTP backend
  CHG <a href="https://curl.se/bug/?i=2128">curl-config: add --ssl-backends</a>
 </ul>
 <p> Bugfixes:
@@ -6709,7 +6709,7 @@ SUBTITLE(Fixed in 7.57.0 - November 29 2017)
  BGF <a href="https://curl.se/bug/?i=2098">http2: fix "Value stored to &#39;hdbuf&#39; is never read" scan-build error</a>
  BGF <a href="https://curl.se/bug/?i=2098">http2: fix "Value stored to &#39;end&#39; is never read" scan-build error</a>
  BGF <a href="https://curl.se/bug/?i=2098">Curl_open: fix OOM return error correctly</a>
- BGF <a href="https://curl.se/bug/?i=2073">url: reject ASCII control characters and space in host names</a>
+ BGF <a href="https://curl.se/bug/?i=2073">url: reject ASCII control characters and space in hostnames</a>
  BGF <a href="https://curl.se/bug/?i=2106">examples/rtsp: clear RANGE again after use</a>
  BGF <a href="https://curl.se/bug/?i=2104">connect: improve the bind error message</a>
  BGF <a href="https://curl.se/bug/?i=2097">make: fix "make distclean"</a>
@@ -6927,7 +6927,7 @@ SUBTITLE(Fixed in 7.55.0 - August 9 2017)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF <a href="https://curl.se/docs/CVE-2017-1000101.html">glob: do not parse after a strtoul() overflow range (CVE-2017-1000101)</a>
- BGF <a href="https://curl.se/docs/CVE-2017-1000100.html">tftp: reject file name lengths that don&#39;t fit (CVE-2017-1000100)</a>
+ BGF <a href="https://curl.se/docs/CVE-2017-1000100.html">tftp: reject filename lengths that don&#39;t fit (CVE-2017-1000100)</a>
  BGF <a href="https://curl.se/docs/CVE-2017-1000099.html">file: output the correct buffer to the user (CVE-2017-1000099)</a>
  BGF <a href="https://daniel.haxx.se/blog/2017/06/15/target-independent-libcurl-headers/">includes: remove curl/curlbuild.h and curl/curlrules.h</a>
  BGF <a href="https://curl.se/bug/?i=1565">dist: make the hugehelp.c not get regenerated unnecessarily</a>
@@ -7027,7 +7027,7 @@ SUBTITLE(Fixed in 7.55.0 - August 9 2017)
  BGF <a href="https://curl.se/bug/?i=1717">curl_threads: fix MSVC compiler warning</a>
  BGF travis: build on osx with openssl
  BGF travis: build on osx with libressl
- BGF CURLOPT_NETRC.3: mention the file name on windows
+ BGF CURLOPT_NETRC.3: mention the filename on windows
  BGF <a href="https://curl.se/bug/?i=1711">cmake: set MSVC warning level to 4</a>
  BGF <a href="https://curl.se/mail/lib-2017-08/0008.html">netrc: skip lines starting with &#39;#&#39;</a>
  BGF darwinssl: fix curlssl_sha256sum() compiler warnings on first argument
@@ -7263,7 +7263,7 @@ SUBTITLE(Fixed in 7.54.0 - April 19 2017)
  BGF docs: added examples for CURLINFO_FILETIME.3 and CURLOPT_FILETIME.3
  BGF <a href="https://curl.se/bug/?i=1379">tests/server/util: remove in6addr_any for recent MinGW</a>
  BGF <a href="https://curl.se/bug/?i=1377">multi: make curl_multi_wait avoid malloc in the typical case</a>
- BGF <a href="https://curl.se/bug/?i=1373">include: curl/system.h is a run-time version of curlbuild.h</a>
+ BGF <a href="https://curl.se/bug/?i=1373">include: curl/system.h is a runtime version of curlbuild.h</a>
  BGF easy: silence compiler warning
  BGF <a href="https://curl.se/bug/?i=1381">llist: replace Curl_llist_alloc with Curl_llist_init</a>
  BGF <a href="https://curl.se/bug/?i=1376">hash: move key into hash struct to reduce mallocs</a>
@@ -7792,7 +7792,7 @@ SUBTITLE(Fixed in 7.49.0 - May 18 2016)
  BGF <a href="https://curl.se/bug/?i=606">winbuild: add mbedtls support</a>
  BGF <a href="https://curl.se/mail/archive-2016-04/0021.html">curl: make --ftp-create-dirs retry on failure</a>
  BGF PolarSSL: implement public key pinning
- BGF <a href="https://curl.se/mail/lib-2016-04/0084.html">multi: accidentally used resolved host name instead of proxy</a>
+ BGF <a href="https://curl.se/mail/lib-2016-04/0084.html">multi: accidentally used resolved hostname instead of proxy</a>
  BGF CURLINFO_TLS_SESSION.3: clarify TLS library support before 7.48.0
  BGF <a href="https://curl.se/bug/?i=655">CONNECT_ONLY: don&#39;t close connection on GSS 401/407 responses</a>
  BGF <a href="https://curl.se/bug/?i=779">opts: Fix some syntax errors in example code fragments</a>
@@ -7981,13 +7981,13 @@ SUBTITLE(Fixed in 7.47.0 - January 27 2016)
  BGF <a href="https://curl.se/bug/?i=586">curl_global_init.3: Add Windows-specific info for init via DLL</a>
  BGF <a href="https://curl.se/bug/?i=564">http2: Fix client write for trailers on stream close</a>
  BGF mbedtls: Fix ALPN support
- BGF <a href="https://curl.se/bug/?i=592">connection reuse: IDN host names fixed</a>
+ BGF <a href="https://curl.se/bug/?i=592">connection reuse: IDN hostnames fixed</a>
  BGF <a href="https://curl.se/bug/?i=564">http2: Fix PUSH_PROMISE headers being treated as trailers</a>
  BGF <a href="https://curl.se/mail/lib-2016-01/0031.html">http2: handle the received SETTINGS frame</a>
  BGF <a href="https://curl.se/bug/?i=564">http2: Ensure that http2_handle_stream_close is called</a>
  BGF mbedtls: implement CURLOPT_PINNEDPUBLICKEY
  BGF runtests: Add mbedTLS to the SSL backends
- BGF <a href="https://curl.se/bug/?i=596">IDN host names: Remove the port number before converting to ACE</a>
+ BGF <a href="https://curl.se/bug/?i=596">IDN hostnames: Remove the port number before converting to ACE</a>
  BGF zsh.pl: fail if no curl is found
  BGF scripts: fix zsh completion generation
  BGF <a href="https://curl.se/bug/?i=582">scripts: don&#39;t generate and install zsh completion when cross-compiling</a>
@@ -8107,7 +8107,7 @@ SUBTITLE(Fixed in 7.45.0 - October 7 2015)
  BGF curl.1: Document weaknesses in SSLv2 and SSLv3
  BGF CURLOPT_HTTP_VERSION.3: connection re-use goes before version
  BGF docs: Update the redirect protocols disabled by default
- BGF inet_pton.c: Fix MSVC run-time check failure
+ BGF inet_pton.c: Fix MSVC runtime check failure
  BGF CURLMOPT_PUSHFUNCTION.3: fix argument types
  BGF rtsp: support basic/digest authentication
  BGF rtsp: stop reading empty DESCRIBE responses
@@ -8129,7 +8129,7 @@ SUBTITLE(Fixed in 7.45.0 - October 7 2015)
  BGF <a href="https://curl.se/bug/?i=402">libcurl.m4: Put braces around empty if body</a>
  BGF buildconf.bat: Fixed double blank line in &#39;curl manual&#39; warning output
  BGF sasl: Only define Curl_sasl_digest_get_pair() when CRYPTO_AUTH enabled
- BGF inet_pton.c: Fix MSVC run-time check failure
+ BGF inet_pton.c: Fix MSVC runtime check failure
  BGF CURLOPT_FOLLOWLOCATION.3: mention methods for redirects
  BGF <a href="https://curl.se/bug/?i=401">http2: don&#39;t pass on Connection: headers</a>
  BGF <a href="https://lists.fedoraproject.org/pipermail/devel/2015-September/214117.html">nss: do not directly access SSL_ImplementedCiphers</a>
@@ -8286,7 +8286,7 @@ SUBTITLE(Fixed in 7.43.0 - June 17 2015)
  BGF <a href="https://github.com/curl/curl/issues/254">winbuild: Document the option used to statically link the CRT</a>
  BGF FTP: Make EPSV use the control IP address rather than the original host
  BGF FTP: fix dangling conn->ip_addr dereference on verbose EPSV
- BGF conncache: keep bundles on host+port bases, not only host names
+ BGF conncache: keep bundles on host+port bases, not only hostnames
  BGF runtests.pl: use &#39;h2c&#39; now, no -14 anymore
  BGF curlver: introducing new version number (checking) macros
  BGF <a href="https://github.com/curl/curl/issues/275">openssl: boringssl build brekage, use SSL_CTX_set_msg_callback</a>
@@ -8294,7 +8294,7 @@ SUBTITLE(Fixed in 7.43.0 - June 17 2015)
  BGF <a href="https://github.com/curl/curl/issues/282">curl_easy_unescape.3: update RFC reference</a>
  BGF gnutls: don&#39;t fail on non-fatal alerts during handshake
  BGF testcurl.pl: allow source to be in an arbitrary directory
- BGF CURLOPT_HTTPPROXYTUNNEL.3: only works with a HTTP proxy
+ BGF CURLOPT_HTTPPROXYTUNNEL.3: only works with an HTTP proxy
  BGF <a href="https://github.com/curl/curl/issues/267">SSPI-error: Change SEC_E_ILLEGAL_MESSAGE description</a>
  BGF <a href="https://curl.se/mail/lib-2015-05/0056.html">parse_proxy: switch off tunneling if non-HTTP proxy</a>
  BGF share_init: fix OOM crash
@@ -8360,7 +8360,7 @@ SUBTITLE(Fixed in 7.42.0 - April 22 2015)
 <ul class="bugfixes">
  BGF <a href="https://curl.se/docs/CVE-2015-3143.html">ConnectionExists: for NTLM re-use, require credentials to match</a>
  BGF <a href="https://curl.se/docs/CVE-2015-3145.html">cookie: cookie parser out of boundary memory access</a>
- BGF <a href="https://curl.se/docs/CVE-2015-3144.html">fix_hostname: zero length host name caused -1 index offset</a>
+ BGF <a href="https://curl.se/docs/CVE-2015-3144.html">fix_hostname: zero length hostname caused -1 index offset</a>
  BGF <a href="https://curl.se/docs/CVE-2015-3148.html">http_done: close Negotiate connections when done</a>
  BGF sws: timeout idle CONNECT connections
  BGF nss: improve error handling in Curl_nss_random()
@@ -8977,11 +8977,11 @@ SUBTITLE(Fixed in 7.37.0 - May 21 2014)
  BGF <a href="https://curl.se/mail/lib-2014-04/0145.html">gtls: fix NULL pointer dereference</a>
  BGF cyassl: Use error-ssl.h when available
  BGF <a href="https://curl.se/bug/?i=97">handler: make &#39;protocol&#39; always specified as a single bit</a>
- BGF INFILESIZE: fields in UserDefined must not be changed run-time
+ BGF INFILESIZE: fields in UserDefined must not be changed runtime
  BGF openssl: biomem->data is not zero terminated
  BGF config-win32.h: Fixed HAVE_LONGLONG for Visual Studio .NET 2003 and up
  BGF curl_ntlm_core: Fixed use of long long for VC6 and VC7
- BGF <a href="https://curl.se/mail/lib-2014-04/0161.html">SNI: strip off a single trailing dot from host name</a>
+ BGF <a href="https://curl.se/mail/lib-2014-04/0161.html">SNI: strip off a single trailing dot from hostname</a>
  BGF curl: bail on cookie use when built with disabled cookies
  BGF curl_easy_setopt.3: added the proto for CURLOPT_SSH_KNOWNHOSTS
  BGF <a href="http://thread.gmane.org/gmane.comp.version-control.git/238242">curl_multi_cleanup: ignore SIGPIPE better</a>
@@ -9077,7 +9077,7 @@ SUBTITLE(Fixed in 7.36.0 - March 26 2014)
  BGF polarssl: avoid extra newlines in debug messages
  BGF <a href="https://curl.se/mail/lib-2014-03/0134.html">rtsp: parse "Session:" header properly</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1337">trynextip: don&#39;t store &#39;ai&#39; on failed connects</a>
- BGF Curl_cert_hostcheck: strip trailing dots in host name and wildcard
+ BGF Curl_cert_hostcheck: strip trailing dots in hostname and wildcard
 </ul>
 
 <a name="7_35_0"></a>
@@ -9307,7 +9307,7 @@ SUBTITLE(Fixed in 7.32.0 - August 12 2013)
  BGF <a href="https://curl.se/mail/archive-2013-07/0031.html">curl: make --progress-bar update the line less frequently</a>
  BGF configure: don&#39;t error out on variable confusions (CFLAGS, LDFLAGS etc)
  BGF mk-ca-bundle: skip more untrusted certificates
- BGF <a href="https://curl.se/bug/view.cgi?id=1262">formadd: wrong pointer for file name when CURLFORM_BUFFERPTR used</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1262">formadd: wrong pointer for filename when CURLFORM_BUFFERPTR used</a>
  BGF FTP: when EPSV gets a 229 but fails to connect, retry with PASV
  BGF <a href="https://curl.se/mail/lib-2013-08/0057.html">mk-ca-bundle.1: don&#39;t install on make install</a>
  BGF VMS: lots of updates and fixes of the build procedure
@@ -9356,7 +9356,7 @@ SUBTITLE(Fixed in 7.31.0 - June 22 2013)
  BGF <a href="https://curl.se/bug/view.cgi?id=1221">Curl_cookie_add: handle IPv6 hosts</a>
  BGF ossl_send: SSL_write() returning 0 is an error too
  BGF ossl_recv: SSL_read() returning 0 is an error too
- BGF <a href="https://curl.se/bug/view.cgi?id=1230">Digest auth: escape user names with backslash or &quot; in them</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1230">Digest auth: escape usernames with backslash or &quot; in them</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1233">curl_formadd.3: fixed wrong "end-marker" syntax</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1234">libcurl-tutorial.3: fix incorrect backslash</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=1224">curl_multi_wait: reduce timeout if the multi handle wants to</a>
@@ -9414,7 +9414,7 @@ SUBTITLE(Fixed in 7.30.0 - April 12 2013)
  BGF <a href="https://curl.se/mail/archive-2013-02/0040.html">AddFormData: prevent only directories from being posted</a>
  BGF <a href="https://curl.se/mail/lib-2013-03/0014.html">darwinssl: fix infinite loop if server disconnected abruptly</a>
  BGF metalink: fix improbable crash parsing metalink filename
- BGF show proper host name on failed resolve
+ BGF show proper hostname on failed resolve
  BGF MacOSX-Framework: Make script work in Xcode 4.0 and later
  BGF <a href="https://curl.se/bug/view.cgi?id=1192">strlcat: remove function</a>
  BGF <a href="https://curl.se/mail/lib-2013-02/0145.html">darwinssl: Fix send glitchiness with data > 32 or so KB</a>
@@ -9499,7 +9499,7 @@ SUBTITLE(Fixed in 7.29.0 - February 6 2013)
  BGF <a href="https://curl.se/mail/lib-2013-01/0250.html">imap/pop3/smtp: Fixed failure detection during TLS upgrade</a>
  BGF <a href="https://curl.se/mail/lib-2013-02/0004.html">pop3: Fixed no known authentication mechanism when fallback is required</a>
  BGF <a href="https://curl.se/mail/archive-2013-01/0017.html">formadd: reject trying to read a directory where a file is expected</a>
- BGF <a href="https://curl.se/bug/view.cgi?id=1171">formpost: support quotes, commas and semicolon in file names</a>
+ BGF <a href="https://curl.se/bug/view.cgi?id=1171">formpost: support quotes, commas and semicolon in filenames</a>
  BGF <a href="https://bugzilla.redhat.com/696783">docs: update the comments about loading CA certs with NSS</a>
  BGF <a href="https://bugzilla.redhat.com/896544">docs: fix typos in manpages</a>
  BGF <a href="https://curl.se/mail/lib-2013-01/0295.html">darwinssl: Fix bug where packets were sometimes transmitted twice</a>
@@ -9622,7 +9622,7 @@ SUBTITLE(Fixed in 7.27.0 - July 27 2012)
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF pop3: Fixed the issue of having to supply the user name for all requests
+ BGF pop3: Fixed the issue of having to supply the username for all requests
  BGF configure: fix LDAPS disabling related misplaced closing parenthesis
  BGF cmdline: made -D option work with -O and -J
  BGF configure: Fix libcurl.pc and curl-config generation for static MingW* cross builds
@@ -9635,7 +9635,7 @@ SUBTITLE(Fixed in 7.27.0 - July 27 2012)
  BGF urldata.h: fix cyassl build clash with wincrypt.h
  BGF <a href="https://daniel.haxx.se/blog/2012/07/08/curls-new-http-cookies-docs/">cookies: changed the URL in the cookiejar headers</a>
  BGF http-proxy: keep CONNECT connections alive (for NTLM)
- BGF NTLM SSPI: fixed to work with unicode user names and passwords
+ BGF NTLM SSPI: fixed to work with unicode usernames and passwords
  BGF OOM fix in the curl tool when cloning cmdline options
  BGF fixed some examples to use curl_global_init() properly
  BGF cmdline: stricter numerical option parser
@@ -9725,7 +9725,7 @@ SUBTITLE(Fixed in 7.25.0 - March 22 2012)
  BGF curl-config: only provide libraries with --libs
  BGF <a href="https://curl.se/mail/lib-2012-03/0046.html">LWIP: don&#39;t consider HAVE_ERRNO_H to be winsock</a>
  BGF ssh: tunnel through HTTP proxy if requested
- BGF <a href="https://curl.se/mail/lib-2012-03/0036.html">cookies: strip off [brackets] from numerical ipv6 host names</a>
+ BGF <a href="https://curl.se/mail/lib-2012-03/0036.html">cookies: strip off [brackets] from numerical ipv6 hostnames</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3494091">libcurl docs: version corrections</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3494968">cmake: list_spaces_append_once failure</a>
  BGF <a href="https://curl.se/mail/lib-2012-03/0045.html">resolve with c-ares: don&#39;t resolve IPv6 when not working</a>
@@ -9780,13 +9780,13 @@ SUBTITLE(Fixed in 7.24.0 - January 24 2012)
  BGF <a href="https://curl.se/mail/lib-2011-12/0211.html">appconnect time fixed for non-blocking connect ssl backends</a>
  BGF <a href="https://bugzilla.redhat.com/767490">do not include SSL handshake into time spent waiting for 100-continue</a>
  BGF handle dns cache case insensitive
- BGF <a href="https://curl.se/mail/lib-2011-12/0314.html">use new host name casing for subsequent HTTP requests</a>
- BGF CURLOPT_RESOLVE: avoid adding already present host names
+ BGF <a href="https://curl.se/mail/lib-2011-12/0314.html">use new hostname casing for subsequent HTTP requests</a>
+ BGF CURLOPT_RESOLVE: avoid adding already present hostnames
  BGF <a href="https://curl.se/mail/lib-2011-12/0249.html">SFTP mkdir: use correct permission</a>
  BGF <a href="https://curl.se/bug/view.cgi?id=3463121">resolve: don&#39;t leak pre-populated dns entries</a>
  BGF --retry: Retry transfers on timeout and DNS errors
  BGF <a href="https://curl.se/bug/view.cgi?id=3466497">negotiate with SSPI backend: use the correct buffer for input</a>
- BGF <a href="https://curl.se/mail/lib-2011-12/0249.html">SFTP dir: increase buffer size counter to avoid cut off file names</a>
+ BGF <a href="https://curl.se/mail/lib-2011-12/0249.html">SFTP dir: increase buffer size counter to avoid cut off filenames</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0146.html">TFTP: fix resending (again)</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0160.html">c-ares: don&#39;t include getaddrinfo-using code</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0096.html">FTP: CURLE_PARTIAL_FILE will not close the control channel</a>
@@ -9797,7 +9797,7 @@ SUBTITLE(Fixed in 7.24.0 - January 24 2012)
  BGF <a href="https://curl.se/bug/view.cgi?id=3474308">OpenLDAP: fix LDAP connection phase memory leak</a>
  BGF Telnet: Use correct file descriptor for telnet upload
  BGF Telnet: Remove bogus optimisation of telnet upload
- BGF URL parse: user name with ipv6 numerical address
+ BGF URL parse: username with ipv6 numerical address
  BGF polarssl: show cipher suite name correctly with 1.1.0
  BGF polarssl: havege_rand is not present in version 1.1.0 WARNING, we still use the <a href="https://tls.mbed.org/tech-updates/security-advisories/polarssl-security-advisory-2011-02">old API which is said to be insecure</a>
  BGF <a href="https://curl.se/mail/lib-2012-01/0225.html">gnutls: enforced use of SSLv3</a>
@@ -9837,7 +9837,7 @@ SUBTITLE(Fixed in 7.23.0 - November 15 2011)
  BGF returning abort from the progress function when using the multi interface
    would not properly cancel the transfer and close the connection
  BGF fix libcurl.m4 to not fail with modern gcc versions
- BGF ftp: improved the failed PORT host name resolved error message
+ BGF ftp: improved the failed PORT hostname resolved error message
  BGF TFTP timeout and unexpected block adjustments
  BGF HTTP and GOPHER test server-side connection closing adjustments
  BGF fix endless loop upon transport connection timeout
@@ -9881,7 +9881,7 @@ SUBTITLE(Fixed in 7.22.0 - September 13 2011)
  BGF When using both -J and a single -O with multiple URLs, a missing init
    could cause a segfault
  BGF -J fixed for escaped quotes
- BGF -J fixed for file names with semicolons
+ BGF -J fixed for filenames with semicolons
  BGF progress: reset flags at transfer start to avoid wrong
    CURLINFO_CONTENT_LENGTH_DOWNLOAD
  BGF curl_gssapi: Guard files with HAVE_GSSAPI and rename private header
@@ -9990,7 +9990,7 @@ SUBTITLE(Fixed in 7.21.5 - April 17 2011)
  BGF configure: removed wrongly claimed default paths
  BGF pop3: fixed torture tests to succeed
  BGF symbols-in-versions: many corrections
- BGF if a HTTP request gets retried because the connection was dead, rewind if
+ BGF if an HTTP request gets retried because the connection was dead, rewind if
    any data was sent as part of it
  BGF only probe for working ipv6 once and then re-use that info for further
    requests
@@ -10038,7 +10038,7 @@ SUBTITLE(Fixed in 7.21.4 - February 17 2011)
  BGF Curl_nss_connect: avoid PATH_MAX
  BGF Curl_do: avoid using stale conn pointer
  BGF tftpd test server: avoid buffer overflow report from glibc
- BGF nss: avoid CURLE_OUT_OF_MEMORY given a file name without any slash
+ BGF nss: avoid CURLE_OUT_OF_MEMORY given a filename without any slash
  BGF nss: fix a bug in handling of CURLOPT_CAPATH
  BGF CMake: Use upstream CheckTypeSize module
  BGF OpenSSL get_cert_chain: support larger data sets
@@ -10353,7 +10353,7 @@ SUBTITLE(Fixed in 7.19.7 - November 4 2009)
  BGF CURLOPT_PROXY_TRANSFER_MODE could pass along wrong syntax
  BGF configure --with-gnutls=PATH fixed
  BGF ftp response reader bug on failed control connections
- BGF improved NSS error message on failed host name verifications
+ BGF improved NSS error message on failed hostname verifications
  BGF ftp NOBODY on re-used connection hang
  BGF configure uses pkg-config for cross-compiles as well
  BGF improved NSS detection in configure
@@ -10364,7 +10364,7 @@ SUBTITLE(Fixed in 7.19.7 - November 4 2009)
    query part
  BGF don&#39;t shrink SO_SNDBUF on windows for those who have it set large already
  BGF connect next bug
- BGF invalid file name characters handling on Windows
+ BGF invalid filename characters handling on Windows
  BGF double close() on the primary socket with libcurl-NSS
  BGF GSS negotiate infinite loop on bad credentials
  BGF memory leak in SCP/SFTP connections
@@ -10424,7 +10424,7 @@ SUBTITLE(Fixed in 7.19.5 - May 18 2009)
 <ul class="changes">
  CHG libcurl now closes all dead connections whenever you attempt to open a new
    connection
- CHG libssh2&#39;s version number can now be figured out run-time instead of using
+ CHG libssh2&#39;s version number can now be figured out runtime instead of using
    the build-time fixed number
  CHG CURLOPT_SEEKFUNCTION may now return CURL_SEEKFUNC_CANTSEEK
  CHG curl can now upload with resume even when reading from a pipe
@@ -10444,7 +10444,7 @@ SUBTITLE(Fixed in 7.19.5 - May 18 2009)
  BGF allow creation of four way fat libcurl Mac OS X Framework
  BGF several memory leaks in libcurl+NSS
  BGF improved the CURLOPT_NOBODY set to 0 confusions
- BGF persistent connections when doing FTP over a HTTP proxy
+ BGF persistent connections when doing FTP over an HTTP proxy
  BGF --libcurl bogus strings where other data was pointed to
  BGF crash related to FTP and "Re-used connection seems dead, get a new one"
  BGF CURLINFO_APPCONNECT_TIME with the multi interface
@@ -10460,7 +10460,7 @@ SUBTITLE(Fixed in 7.19.5 - May 18 2009)
  BGF POST, NTLM and following a redirect hang
  BGF libcurl+NSS endless loop on incorrect password for private key
  BGF gzip decompression memory leak
- BGF no_proxy flaw with user name in URL
+ BGF no_proxy flaw with username in URL
 </ul>
 
 <a name="7_19_4"></a>
@@ -10527,7 +10527,7 @@ SUBTITLE(Fixed in 7.19.3 - January 19 2009)
  BGF removed the default use of "Pragma: no-cache"
  BGF fix SCP/SFTP busyloop by using a new libssh2 1.0 function
  BGF bad fclose() after a fatal error in cookie code
- BGF curl_multi_remove_handle() when the handle was in use in a HTTP pipeline
+ BGF curl_multi_remove_handle() when the handle was in use in an HTTP pipeline
  BGF GSS authentication infinite loop problem
  BGF 550 response from SIZE no longer treated as missing file
  BGF ftps:// control connections now use explicit protection level
@@ -10560,7 +10560,7 @@ SUBTITLE(Fixed in 7.19.2 - November 13 2008)
 <ul class="bugfixes">
  BGF build failure when using MSVC 6 makefile and on four platforms more
  BGF crash when using --interface name on Linux systems with a TEQL device
- BGF using the multi interface to download a HTTPS page with libcurl built
+ BGF using the multi interface to download an HTTPS page with libcurl built
    powered by OpenSSL could download "rubbish" instead of actual content
 </ul>
 
@@ -10634,7 +10634,7 @@ SUBTITLE(Fixed in 7.19.0 - September 1 2008)
  BGF SCP or SFTP over socks proxy crashed
  BGF RC4-MD5 cipher now works with NSS-built libcurl
  BGF range requests with --head are now done correctly
- BGF fallback to gettimeofday when monotonic clock is unavailable at run-time
+ BGF fallback to gettimeofday when monotonic clock is unavailable at runtime
  BGF range numbers could be made to wrongly get output as signed
  BGF unexpected 1xx responses hung transfers
  BGF FTP transfers segfault when using different CURLOPT_FTP_FILEMETHOD
@@ -10645,7 +10645,7 @@ SUBTITLE(Fixed in 7.19.0 - September 1 2008)
  BGF --use-ascii now works on Symbian OS, MS-DOS and OS/2
  BGF CURLINFO_SSL_VERIFYRESULT is fixed
  BGF FTP URLs and IPv6 URLs mangled when sent to proxy with CURLOPT_PORT set
- BGF a user name in a proxy URL without a password was parsed incorrectly
+ BGF a username in a proxy URL without a password was parsed incorrectly
  BGF library will now be built with _REENTRANT symbol defined only if needed
  BGF no longer link with gdi32 on Windows cross-compiled targets
  BGF HTTP PUT with -C - sent bad Content-Range: header
@@ -10849,7 +10849,7 @@ SUBTITLE(Fixed in 7.17.1 - October 29 2007)
    contained a port number)
  BGF redirect from HTTP to FTP or TFTP memory problems and leaks
  BGF re-used connections a bit too much when using non-SSL protocols tunneled
-   over a HTTP proxy
+   over an HTTP proxy
  BGF embed the manifest in VC8 builds
  BGF use valgrind in the tests even when the lib is built shared with libtool
  BGF libcurl built with NSS can now ignore the peer verification even when the
@@ -11045,7 +11045,7 @@ SUBTITLE(Fixed in 7.16.1 - January 29 2007)
  BGF multiple TFTP transfers on the same (easy or multi) handle could cause a
    crash
  BGF SIGSEGV when disconnecting on a transfer on a re-used handle when the
-   host name didn&#39;t resolve
+   hostname didn&#39;t resolve
  BGF stack overwrite on 64bit Windows in the chunked decoding department
  BGF HTTP responses on persistent connections without Content-Length nor chunked
    encoding are now considered to be without response body
@@ -11109,7 +11109,7 @@ SUBTITLE(Fixed in 7.16.0 - October 30 2006)
  BGF configure --with-gssapi-libs
  BGF SOCKS proxy connection fixes
  BGF (FTP) a failed upload does not invalidate the control connection
- BGF proxy URL with user name and empty password or no password at all now work
+ BGF proxy URL with username and empty password or no password at all now work
  BGF fixed a socket state problem with *multi_socket()
  BGF (HTTP) NTLM hostname fix
  BGF getsockname usage fixes
@@ -11507,7 +11507,7 @@ SUBTITLE(Fixed in 7.12.3 - December 20 2004)
  BGF curl -E on windows accepts "c:/path" with forward-slash
  BGF several improvements for large file support on windows
  BGF file handle leak in aborted multipart formpost file upload
- BGF -T upload multiple files with backslashes in file names
+ BGF -T upload multiple files with backslashes in filenames
  BGF modified credentials between two requests on a persistent http connection
  BGF large file file:// resumes on Windows
  BGF URLs with username and IPv6 numerical addresses
@@ -11530,7 +11530,7 @@ SUBTITLE(Fixed in 7.12.3 - December 20 2004)
  BGF huge POSTs on VMS
  BGF configure no longer uses pkg-config on cross-compiles
  BGF potential gzip decompress memory leak
- BGF "-C - --fail" on a HTTP page already downloaded
+ BGF "-C - --fail" on an HTTP page already downloaded
  BGF formposting a zero byte file
  BGF use setlocale() for better IDN functionality by default
 </ul>
@@ -11554,7 +11554,7 @@ SUBTITLE(Fixed in 7.12.2 - October 18 2004)
  BGF CURLOPT_FTP_CREATE_MISSING_DIRS works for third party transfers
  BGF memory leak for cookies received with max-age set
  BGF potential memory leaks in the window name resolver
- BGF URLs with ?-letters in the user name or password fields
+ BGF URLs with ?-letters in the username or password fields
  BGF libcurl error message is now provided when send() fails
  BGF no more SIGPIPE on Mac OS X and other SO_NOSIGPIPE-supporting platforms
  BGF HTTP resume was refused if redirected
@@ -11636,7 +11636,7 @@ SUBTITLE(Fixed in 7.12.1 - August 10 2004)
  BGF the msvc curllib.dsp now builds the libcurl.lib file
  BGF builds fine on VMS
  BGF builds fine on NetWare
- BGF HTTP Digest authentication with proxies uses correct user name + password
+ BGF HTTP Digest authentication with proxies uses correct username + password
  BGF builds fine with lcc-win32
 </ul>
 
@@ -11668,7 +11668,7 @@ SUBTITLE(Fixed in 7.12.0 - June 2 2004)
    (which is as high a signed 64 bit number can reach)
  BGF general HTTP authentication improvements
  BGF HTTP Digest authentication with the proxy works
- BGF mulipart formposting with -F and file names with spaces work again
+ BGF mulipart formposting with -F and filenames with spaces work again
  BGF curl_easy_duphandle() now works when ares-enabled
  BGF HTTP Digest authentication works a lot more like the RFC says
  BGF curl works with telnet and stdin properly on Windows
@@ -11709,7 +11709,7 @@ SUBTITLE(Fixed in 7.11.2 - April 26 2004)
  BGF fixed a minor very old progress meter final update bug
  BGF added checks for a working NI_WITHSCOPEID before that is used
  BGF fixed a flaw that prevented ares name resolve timeouts to occur
- BGF getting user name from http_proxy env variable works now
+ BGF getting username from http_proxy env variable works now
  BGF fixed too early name resolve timeouts with ares
  BGF HTTP Digest "re-negotiation" works now
  BGF CURLOPT_FAILONERROR (-f/--fail) works with all kinds of authentication
@@ -11805,7 +11805,7 @@ SUBTITLE(Fixed in 7.11.0 - January 22 2004)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF improved config file parsing for options with required parameters
- BGF using --trace with a bad file name could crash
+ BGF using --trace with a bad filename could crash
  BGF release archive contains compressed help text
  BGF the win32 password prompting supports backspace
  BGF builds natively on AmigaOS (without unix emulation)
@@ -11942,7 +11942,7 @@ SUBTITLE(Fixed in 7.10.7 - August 15 2003)
  BGF FTP persitent download directory re-use problem fixed
  BGF cookie parser now only requires two dots in cookie domain
  BGF FOLLOWLOCATION (or -L) did not always ignore the redirect page properly
- BGF <a href="/docs/security.html#BID8432">information leak</a> fixed.  When proxy authentication is used in a CONNECT
+ BGF <a href="/docs/security.html#BID8432">information leak</a> fixed. When proxy authentication is used in a CONNECT
    request (as used for all SSL connects and otherwise enforced
    tunnel-thru-proxy requests), the same authentication header was also
    wrongly sent to the remote host.
@@ -11973,9 +11973,9 @@ SUBTITLE(Fixed in 7.10.6 - July 28 2003)
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF double slash after the host name on a FTP URL again points out the root dir
+ BGF double slash after the hostname on a FTP URL again points out the root dir
  BGF obscure and rare DNS cache problem was fixed
- BGF multiple FTP connections to the same host with different user names
+ BGF multiple FTP connections to the same host with different usernames
       didn&#39;t work properly
  BGF no more CWD commands without arguments for ftp connections
  BGF curl no longer uses setvbuf() due to portability problems
@@ -12028,7 +12028,7 @@ SUBTITLE(Fixed in 7.10.5 - May 19 2003)
  BGF libcurl now returns CURLE_SSL_CACERT on CA cert problems
  BGF chunked-transfer deflate downloads work
  BGF FTP-server responses to CWD are now more liberally treated
- BGF fixed url parsing when &#39;?&#39; is used after the host name without &#39;/&#39;.
+ BGF fixed url parsing when &#39;?&#39; is used after the hostname without &#39;/&#39;.
  BGF curl -I on ftp files outputs the date with correct time zone (GMT)
  BGF curl -z now works for FTP files (CURLOPT_TIMECONDITION)
  BGF the default DEBUGFUNCTION outputs incoming headers as well
@@ -12061,7 +12061,7 @@ SUBTITLE(Fixed in 7.10.4 - April 2 2003)
  BGF the test suite runs faster and hopefully a bit more reliably
  BGF improved configure check for presence of functions, needed for HPUX
  BGF the curl tool now makes a correct URL escaping when appending to the URL
-   when using -T and the file name is appended to the URL.
+   when using -T and the filename is appended to the URL.
  BGF configure --enable-libgcc now explicitly add -lgcc to the linker
  BGF better configure checks for headers (since some platforms got nasty
    warnings output previously)
@@ -12368,7 +12368,7 @@ SUBTITLE(Fixed in 7.9.3 - January 23 2002)
  BGF bugfixed using proxy specified in an environment variable
  BGF made libcurl support FTP operations without any transfer
  BGF error messages are now stored without newlines
- BGF -T file names get the path stripped before used remotely
+ BGF -T filenames get the path stripped before used remotely
  BGF minor compiling problems fixed for some platforms
 </ul>
 
@@ -12477,7 +12477,7 @@ SUBTITLE(Fixed in 7.8.1 - August 20 2001)
  BGF bugfixed the redirected stderr feature
  BGF more test cases added
  BGF libcurl now verifies the CN name of server certificates when SSLing
- BGF curl -E supports file names with driver letters now on windows
+ BGF curl -E supports filenames with driver letters now on windows
  BGF curl-config --libs now includes the path to the installed libcurl
  BGF file:// with "relative" paths now work like other tools/libs
  BGF curl builds under RISC OS and OpenVMS now
@@ -12652,7 +12652,7 @@ SUBTITLE(Fixed in 7.5.1 - December 11 2000)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF portability fixes for SCO and HPUX
- BGF using an -o file name that is longer than the URL works (<a href="https://curl.se/mail/archive-2000-12/0030.html">patch</a>)
+ BGF using an -o filename that is longer than the URL works (<a href="https://curl.se/mail/archive-2000-12/0030.html">patch</a>)
  BGF multiple URLs and -o or -O works better! (<a href="https://curl.se/mail/archive-2000-12/0031.html">patch</a>)
 </ul>
 
@@ -12764,7 +12764,7 @@ SUBTITLE(Fixed in 7.2.1 - August 31 2000)
 <ul class="bugfixes">
  BGF Linux name resolve check in the configure script is fixed
  BGF -I on ftp was fixed
- BGF ftp files with + in the file name was corrected.
+ BGF ftp files with + in the filename was corrected.
 </ul>
 
 <a name="7_2"></a>
@@ -13011,7 +13011,7 @@ SUBTITLE(Fixed in 5.11 - August 25 1999)
    original URL had cgi-parameters that contained a slash. Nusu&#39;s page
    again.
  BGF Corrected the NO_PROXY usage. It is a list of substrings that if one of
-   them matches the tail of the host name it should connect to, curl should
+   them matches the tail of the hostname it should connect to, curl should
    not use a proxy to connect there.
  BGF Fixed a memory bug with http-servers that sent Location: to a Location:
    page.
@@ -13072,7 +13072,7 @@ SUBTITLE(Fixed in 5.9.1 - July 30 1999)
 <ul class="bugfixes">
  BGF Memory leak in the formdata functions. I added a FormFree() function that
    is now used and supposed to correct this flaw.
- BGF &#39;curl -L https://www.cwa.com.au/&#39; core dumps.  I managed to cure this by
+ BGF &#39;curl -L https://www.cwa.com.au/&#39; core dumps. I managed to cure this by
    correcting the cleanup procedure.
  BGF Now supports longer URLs when following Location:
  BGF Fixed a problem in the upload/POST department: It turned out that http.c
@@ -13130,7 +13130,7 @@ SUBTITLE(Fixed in 5.8 - May 5 1999)
 <p> Changes:
 <ul class="changes">
  CHG curl can now send "If-Modified-Since" headers. Try -z &lt;expression&gt; where
-   expression is a full GNU date expression or a file name to get the date
+   expression is a full GNU date expression or a filename to get the date
    from!
 </ul>
 <p> Bugfixes:
@@ -13268,7 +13268,7 @@ SUBTITLE(Fixed in 5.3 - December 21 1998)
  BGF Brought an MVS patch: -3/--mvs, for ftp upload to the MVS ftp server.
  BGF Brought a correction that fixes the win32 curl bug.
  BGF A bug caused curl to crash on the -A flag
- BGF Added a few defines to make directories/file names get build nicer (with _
+ BGF Added a few defines to make directories/filenames get build nicer (with _
    instead of . and \ instead of / in win32).
  BGF Fixed an FTP bug that occured if the ftp server response line had a
    parenthesis on the line before the (size) info.
@@ -13317,7 +13317,7 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
    an archive from instead of the previous renaming of the current one.
  BGF Mailing list opened (see README).
  BGF Made -v more verbose on the PASV section of ftp transfers. Now it tells
-   host name and IP of the new host (and port number). I also added a section
+   hostname and IP of the new host (and port number). I also added a section
    about PORT vs PASV in the README.
  BGF Introduced automake stuff.
  BGF Just made a successful GET of a document from an SSL-server using my own
@@ -13370,8 +13370,8 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
    specifies a proxy and you wanna fetch something without going through
    that.
  BGF I&#39;m thinking of dropping the -p support. Its really not useful since ports
-   could (and should?) be specified as :&lt;port&gt; appended on the host name
-   instead, both in URLs and to proxy host names.
+   could (and should?) be specified as :&lt;port&gt; appended on the hostname
+   instead, both in URLs and to proxy hostnames.
  BGF curl -L bugs under Windows NT (test with URL http://come.to/scsde).
    This bug is not present in this version anymore.
  BGF Added support for the weird FTP URL type= thing. You can download a file
@@ -13385,7 +13385,7 @@ SUBTITLE(Fixed in 5.0 - December 1 1998)
  BGF The 5beta (and 4.10) under win32 failed if the HOME variable wasn&#39;t set.
  BGF When using a proxy, curl now guesses and uses the protocol part in cases
    like: "curl -x proxy:80 www.site.com". Proxies normally go nuts unless
-   http:// is prepended to the host name, so if curl is used like this, it
+   http:// is prepended to the hostname, so if curl is used like this, it
    guesses protocol and appends the protocol string before passing it to the
    proxy. It already did this when used without proxy.
  BGF Better port usage with SSL through proxy now. If you specified a different
@@ -13412,7 +13412,7 @@ SUBTITLE(Fixed in 4.10 - October 26 1998)
 SUBTITLE(Fixed in 4.9 - October 7 1998)
 <p> Changes:
 <ul class="changes">
- CHG no longer released under the GPL license.  I have now updated the LEGAL
+ CHG no longer released under the GPL license. I have now updated the LEGAL
    file etc and now this is released using the Mozilla Public License
  CHG Added -b/--cookie to read cookies
  CHG Added -c for HTTP resume
@@ -13442,7 +13442,7 @@ SUBTITLE(Fixed in 4.8.4 - September 20 1998)
    g++. I also took the opportunity to clean off some unused variables
    and similar.
  BGF Ralph Beckmann made me aware of a really odd bug
-   now corrected. When curl read a set of headers from a HTTP server, divided
+   now corrected. When curl read a set of headers from an HTTP server, divided
    into more than one read and the first read showed a full line *exactly*
    (i.e ending with a newline), curl did not behave well.
 </ul>
@@ -13474,7 +13474,7 @@ SUBTITLE(Fixed in 4.8.1 - August 7 1998)
    final output on the screen didn&#39;t have to be the final size transfered
    which made it sometimes look odd.
  BGF Thanks to David Long I got rid of a silly
-   bug that happened if a HTTP-page had nothing but header. Appearantly
+   bug that happened if an HTTP-page had nothing but header. Appearantly
    Solaris deals with negative sizes in fwrite() calls a lot better than
    Linux does...
 </ul>
@@ -13655,9 +13655,9 @@ SUBTITLE(Fixed in 3.7 - January 15 1998)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF Now checks the last error code sent from the ftp server after a file has
-   been received or uploaded. Wasn't done previously.
+   been received or uploaded. was not done previously.
  BGF When 'urlget <host>' is used without a 'protocol://' first in the host part,
-   it now checks for host names starting with ftp or gopher and if it does,
+   it now checks for hostnames starting with ftp or gopher and if it does,
    it uses that protocol by default instead of http.
 </ul>
 
@@ -13683,7 +13683,7 @@ SUBTITLE(Fixed in 3.5 - December 15 1997)
 SUBTITLE(Fixed in 3.2 - December 1 1997)
 <p> Changes:
 <ul class="changes">
- CHG FTP directory view supports -l for "list-only" which lists the file names
+ CHG FTP directory view supports -l for "list-only" which lists the filenames
    only.
  CHG All operations support -m for max time usage in seconds allowed.
 </ul>
@@ -13694,13 +13694,13 @@ SUBTITLE(Fixed in 3.2 - December 1 1997)
    progress meter and time control.
  BGF alarm() usage removed completely
  BGF FTP get can now list directory contents if the path ends with a slash '/'.
-   Urlget on a ftp-path that doesn't end with a slash means urlget will
-   attempt getting it as a file name.
+   Urlget on a ftp-path that does not end with a slash means urlget will
+   attempt getting it as a filename.
  BGF FTP upload now allows the size of the uploaded file to be provided, and
    thus it can better check it actually uploaded the whole file. It also
    makes the progress meter for uploads much better!
  BGF Made the parameter parsing fail in cases like 'urlget -r 900' which
-   previously tried to connect to the host named '900'.
+   previously tried to connect to the hostnamed '900'.
 </ul>
 
 <a name="3_1"></a>
@@ -13719,7 +13719,7 @@ SUBTITLE(Fixed in 3.0 - November 1 1997)
  CHG Restructured the source quite a lot.
    Changed the urlget() interface. This way, we will survive changes much
    better. New features can come and old can be removed without us needing
-   to change the interface. I've written a small explanation in urlget.h
+   to change the interface. I have written a small explanation in urlget.h
    that explains it.
  CHG New flags include -t, -T, -O and -h. The -h text is generated by the new
    mkhelp script.
@@ -13749,7 +13749,7 @@ SUBTITLE(Fixed in 2.7 - September 20 1997 )
 <p> Changes:
 <ul class="changes">
  CHG Removed the -l option and introduced the -f option instead. Now I'll
-   rewrite the former -l kludge in an external script that'll use urlget to
+   rewrite the former -l kludge in an external script that will use urlget to
    fetch multipart files like that.
  CHG '-f' is introduced, it means Fail without output in case of HTTP server
    errors (return code >=300).
@@ -13771,7 +13771,7 @@ SUBTITLE(Fixed in 2.6 - September 10 1997 )
 <p> Bugfixes:
 <ul class="bugfixes">
   BGF Made the -l (loop) thing use the new CONF_FAILONERROR which makes
-   urlget() return error code if non-successful. It also won't output anything
+   urlget() return error code if non-successful. It also will not output anything
    then. Now finally removed the HTTP 1.0 and error 404 dependencies.
 </ul>
 
@@ -13809,7 +13809,7 @@ SUBTITLE(Fixed in 2.3 - August 21 1997 )
 <ul class="changes">
  CHG Added "-o" option (output file)
  CHG Added URG_HTTP_NOT_FOUND return code.
- CHG Looping mode ("-l" option). It's easier to get various split files.
+ CHG Looping mode ("-l" option). it is easier to get various split files.
  CHG Changed the -h to be -i instead. -h should be preserved to help use.
 </ul>
 <p> Bugfixes:
@@ -13826,7 +13826,7 @@ SUBTITLE(Fixed in 2.2 - August 14 1997 )
 </ul>
 <p> Bugfixes:
 <ul class="bugfixes">
- BGF The urlget function didn't set the path to url when using proxy.
+ BGF The urlget function did not set the path to url when using proxy.
  BGF Fixed bug with IMC proxy. Now using (almost) complete GET command.
  BGF Made it compile on Solaris. Had to reorganize the includes a bit.
    (so Win32, Linux, SunOS 4 and Solaris 2 compile fine.)
@@ -13868,7 +13868,7 @@ SUBTITLE(Fixed in 1.5 - July 21 1997)
  BGF The skip_header() crap messed it up big-time. By simply removing that
    one we can all of a sudden download anything ;)
  BGF No longer requires a trailing slash on the URLs.
- BGF If the given URL isn't prefixed with 'http://', HTTP is assumed and
+ BGF If the given URL is not prefixed with 'http://', HTTP is assumed and
    given a try!
  BGF 'void main()' is history.
 </ul>
@@ -13918,7 +13918,7 @@ SUBTITLE(Fixed in 1.1 - April 20 1997)
 <p> Bugfixes:
 <ul class="bugfixes">
  BGF Adjusted it slightly to accept named hosts on the command line. We
- wouldn't wanna use IP numbers for the rest of our lifes, would we?
+ would not wanna use IP numbers for the rest of our lifes, would we?
 </ul>
 
 <a name="1_0"></a>

--- a/_donation.html
+++ b/_donation.html
@@ -31,7 +31,7 @@ SUBTITLE(Why)
 <p>
   To ensure that the curl project continues to strive. Even open source
   projects has expenses! You can use curl forever without paying anything, but
-  maybe you think you've got quite a lot and feel you could contribute a
+  maybe you think you have got quite a lot and feel you could contribute a
   little back?
 <p>
   See also Mary Gardiner's excellent

--- a/_download.html
+++ b/_download.html
@@ -61,7 +61,7 @@ SUBTITLE(Packages)
  </td></tr></table>
 <p>
  If you have newer archives or archives for platforms not already present in
- this table, we'd like to add them to this table with a pointer to your
+ this table, we would like to add them to this table with a pointer to your
  location. Mail <a href="mailto:curl-release&#64;haxx.se">curl-release</a> and
  tell us!
 

--- a/_gethelp.html
+++ b/_gethelp.html
@@ -35,7 +35,7 @@ SUBTITLE(Questions?)
   <li> Learn about curl stuff from this set
   of <a href="https://curl.se/docs/videos/">video presentations</a>
   <li> Research the <a href="https://curl.se/docs/">documentation
-  section</a> of this web site
+  section</a> of this website
 </ul>
 
 SUBTITLE(Bugs or issues?)
@@ -52,7 +52,7 @@ SUBTITLE(Changes?)
   the <a href="https://lists.haxx.se/listinfo/curl-library">curl-library
   mailing list</a>
   <li> submit a <a href="https://github.com/curl/curl/pulls">pull-request on github</a>
-  <li> see also the <a href="https://curl.se/dev/">development section</a> of the web site
+  <li> see also the <a href="https://curl.se/dev/">development section</a> of the website
 </ul>
 
 SUBTITLE(Paying for support?)

--- a/_index.html
+++ b/_index.html
@@ -76,7 +76,7 @@ library</b>
 <p><b>Supports...</b>
 <p>DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP,
 LDAPS, MQTT, POP3, POP3S, RTMP, RTMPS, RTSP, SCP, SFTP, SMB, SMBS, SMTP,
-SMTPS, TELNET, TFTP, WS and WSS.  curl supports TLS certificates, HTTP POST,
+SMTPS, TELNET, TFTP, WS and WSS. curl supports TLS certificates, HTTP POST,
 HTTP PUT, FTP uploading, HTTP form based upload, proxies (SOCKS4, SOCKS5, HTTP
 and HTTPS), HTTP/2, HTTP/3, cookies, user+password authentication (Basic,
 Plain, Digest, CRAM-MD5, SCRAM-SHA, NTLM, Negotiate, Kerberos, Bearer tokens

--- a/_news2.html
+++ b/_news2.html
@@ -23,7 +23,7 @@ TITLE(News)
 <!--#exec cmd="./shownews.cgi 25" -->
 
 <p>
-  You'll find some of the older news <a href="oldnews.html">here</a>.
+  you will find some of the older news <a href="oldnews.html">here</a>.
 
 #include "_footer.html"
 </body>

--- a/_newslog.html
+++ b/_newslog.html
@@ -1081,18 +1081,18 @@ are documented in the <a href="changes.html#7_50_3">changelog</a>.
 
  The git repositories on github for
  the <a href="https://github.com/curl/curl">source</a> and
- the <a href="https://github.com/curl/curl-www">web site</a> have now been
+ the <a href="https://github.com/curl/curl-www">website</a> have now been
  moved over to its new home there: the <a href="https://github.com/curl">curl
  organization</a>.
 
 
  NCOLE
 
- NSUBJ(web site over HTTPS)
+ NSUBJ(website over HTTPS)
  NDATE(January 29 2016)
  NCOLS
 
-  The curl web site is now served over HTTPS and with HTTP/2 - with
+  The curl website is now served over HTTPS and with HTTP/2 - with
   certificates from Let's Encrypt. Starting February 3, the curl site
   automatically redirects all http accesses to its https version. No more HTTP
   accesses to contents.
@@ -1198,7 +1198,7 @@ NSUBJ(curl and libcurl 7.45.0)
   since <a href="https://www.spamhaus.org/sbl/query/SBL212408">Spamhaus deems
   our ISP to be irresponsible</a> and blacklists us.
 <p>
-  We have a fixed IP and we've done nothing wrong here, but apparently
+  We have a fixed IP and we have done nothing wrong here, but apparently
   collective punishment is a method.
 
  NCOLE
@@ -1287,7 +1287,7 @@ NSUBJ(curl and libcurl 7.45.0)
  This release comes bundled with no less than four different security
  advisories:
  <ul>
-  <li> <a href="//curl.se/docs/CVE-2015-3144.html">host name out of boundary memory access</a>
+  <li> <a href="//curl.se/docs/CVE-2015-3144.html">hostname out of boundary memory access</a>
   <li> <a href="//curl.se/docs/CVE-2015-3145.html">cookie parser out of boundary memory access</a>
   <li> <a href="//curl.se/docs/CVE-2015-3148.html">Negotiate not treated as connection-oriented</a>
   <li> <a href="//curl.se/docs/CVE-2015-3143.html">Re-using authenticated connection when unauthenticated</a>
@@ -1299,7 +1299,7 @@ NSUBJ(curl and libcurl 7.45.0)
  NDATE(March 2 2015)
  NCOLS
 
-  We're trying to lower barriers and friction for newcomers. We have a new
+  We are trying to lower barriers and friction for newcomers. We have a new
   positive attitude to pull requests and issues filed directly
   at <a href="https://github.com/curl/curl">github</a>. Welcome!
 
@@ -1413,7 +1413,7 @@ NSUBJ(Thanks page remake)
  <a href="https://daniel.haxx.se/blog/2014/10/10/internal-timers-and-timeouts-of-libcurl/">internal timers and timeouts of libcurl</a> - It is time to take a deep dive into the libcurl internals and see how it handles timeouts and timers.
 
 <p>
-  <a href="https://daniel.haxx.se/blog/2014/10/09/coverity-scan-defect-density-0-00/">Coverity scan defect density: 0.00</a> - I cleared off all the pending issues and we're now at zero defects left reported.
+  <a href="https://daniel.haxx.se/blog/2014/10/09/coverity-scan-defect-density-0-00/">Coverity scan defect density: 0.00</a> - I cleared off all the pending issues and we are now at zero defects left reported.
 <p>
   <a href="https://daniel.haxx.se/blog/2014/09/29/a-day-in-the-curl-project/">A day in the curl project</a> - An overview and look to what I spend all the time on in the curl project.
 <p>
@@ -1429,7 +1429,7 @@ NSUBJ(Thanks page remake)
 
   Daniel (curl project leader) is doing a <a
   href="https://www.youtube.com/watch?v=OytGfG9u3Yk">video series</a> about
-  what he's working on at the moment. They are 5-7 minutes each, are posted
+  what he is working on at the moment. They are 5-7 minutes each, are posted
   weekly and include lots of details of what's been happening in the curl
   project.
 
@@ -1460,7 +1460,7 @@ NSUBJ(Thanks page remake)
  that they used 1024 bit RSA.
  <p>
  If you download the latest cacert bundle from the link above right now,
- you'll see that s3.amazonaws.com sites no longer gets verified fine. I guess
+ you will see that s3.amazonaws.com sites no longer gets verified fine. I guess
  that it goes for a few other sites too.
  <p>
  <a href="//curl.se/mail/lib-2014-09/0041.html">Read more</a>.
@@ -1522,13 +1522,13 @@ NSUBJ(Thanks page remake)
 
   Our <a href="/docs/caextract.html">CA extract</a> service is very popular to
   download Mozilla's CA cert bundle in PEM format. Starting now, we also
-  provide a proper HTTPS download link for users who want to be sure there's
+  provide a proper HTTPS download link for users who want to be sure there is
   no foul play going on during the download.
 
 <p>
   The HTTPS download is provided via github so it will also provide an
   alternative hosting site for cases where one or the other has
-  problems. Since there's a chicken-and-egg problem with TLS and CA certs, we
+  problems. Since there is a chicken-and-egg problem with TLS and CA certs, we
   still offer the same download URL as before over plain HTTP as well.
 
 <p>
@@ -1541,7 +1541,7 @@ NSUBJ(Thanks page remake)
  NCOLS
 
    To enhance everyone's ability to contribute with docs, examples, good ideas
-   and other curl related information we've enabled
+   and other curl related information we have enabled
    a <a href="https://github.com/curl/curl/wiki">curl wiki</a> over at
    github.
  <p>
@@ -1683,7 +1683,7 @@ NSUBJ(Thanks page remake)
 <p>
   Extra attention should be put on the <a
   href="docs/CVE-2013-2174.html">libcurl URL decode buffer boundary flaw</a>
-  security advisory we've announced today.
+  security advisory we have announced today.
 
  NCOLE
 
@@ -1698,7 +1698,7 @@ NSUBJ(Thanks page remake)
 <p>
   Extra attention should be put on the <a
   href="docs/CVE-2013-1944.html">libcurl cookie domain tailmatch</a> security
-  advisory we've announced today.
+  advisory we have announced today.
 
  NCOLE
 
@@ -1716,9 +1716,9 @@ NSUBJ(Thanks page remake)
  NDATE(March 23 2013)
  NCOLS
 
-  <i>In this little piece I'll explain why there won't be any version 8 of
-  curl and libcurl in a long time. I won't rule out that it might happen at
-  some point in the future. Just that it won't happen anytime soon and explain
+  <i>In this little piece I'll explain why there will not be any version 8 of
+  curl and libcurl in a long time. I will not rule out that it might happen at
+  some point in the future. Just that it will not happen anytime soon and explain
   the reasons why.</i>
 
   <p>
@@ -1738,7 +1738,7 @@ NSUBJ(Thanks page remake)
 <p>
   Extra attention should be put on the <a
   href="docs/CVE-2013-0249.html">libcurl SASL buffer overflow vulnerability
-  advisory</a> we've announced today.
+  advisory</a> we have announced today.
 
  NCOLE
 
@@ -1748,7 +1748,7 @@ NSUBJ(Thanks page remake)
 
   In his blog post, Daniel explains how <a
   href="https://daniel.haxx.se/blog/2013/01/17/internally-were-all-multi-now/">internally,
-  we're all multi now</a in libcurl. All internals work with and assume
+  we are all multi now</a in libcurl. All internals work with and assume
   non-blocking operations!
 
  NCOLE
@@ -1780,7 +1780,7 @@ NSUBJ(Thanks page remake)
  NCOLS
 
   The <a href="https://sourceforge.net/p/curl/bugs/">bug-tracker on
-  Sourceforge</a> that we've been using for well over a decade has been a
+  Sourceforge</a> that we have been using for well over a decade has been a
   subject of annoyance basically since day 1. It has now gotten a facelift and
   looks slightly better and possibly also works better.
 
@@ -1893,7 +1893,7 @@ NSUBJ(Thanks page remake)
   7.23.1</a>. Read about the single Windows-only fix on the <a
   href="changes.html#7_23_1">changes</a> page.
 <p>
-  Yes, if you're already on 7.23.0 this upgrade only makes sense if you're
+  Yes, if you are already on 7.23.0 this upgrade only makes sense if you are
   using the curl tool on windows.
 
  NCOLE
@@ -2015,14 +2015,14 @@ NSUBJ(Thanks page remake)
  NCOLS
 
   The information about development details and specific docs for curl hackers
-  were previously scattered all over this web site in sometimes rather
+  were previously scattered all over this website in sometimes rather
   illogical ways.
 <p>
   Starting now, we have <a href="/dev/">Development section</a> of this web
   site that is dedicated for all curl and libcurl hackers that work on
   improving our project.
 <p>
-  As a consequence, we've also moved a bunch of pages into the dev section to
+  As a consequence, we have also moved a bunch of pages into the dev section to
   make the "users" sections (for the curl tool and for libcurl) cleaner and
   more focused on what I suspect web users are looking for.
 <p>
@@ -2099,7 +2099,7 @@ NSUBJ(Thanks page remake)
   7.19.7</a>. Read about the news, the fixes and the changes on
   the <a href="changes.html">changes</a> page.
 <p>
-  We're struggling to keep up with the pace of bug reports and patches posted
+  We are struggling to keep up with the pace of bug reports and patches posted
   to us in the project. We will continue to appreciate your help and
   assistance to allow us to distribute the work load on multiple humans.
 <p>
@@ -2112,7 +2112,7 @@ NSUBJ(Thanks page remake)
  NDATE(September 7 2009)
  NCOLS
 
-  The web site curl.se has been moved to a different server, and you may
+  The website curl.se has been moved to a different server, and you may
   suffer from some glitches due to this until everything has been fixed to
   work properly at the new location. Please have patience.
 <p>
@@ -2247,7 +2247,7 @@ NSUBJ(Thanks page remake)
  NDATE(March 2 2008)
  NCOLS
 <p>
-We're planning to apply to <a href="https://developers.google.com/open-source/gsoc/2008/">Google's
+We are planning to apply to <a href="https://developers.google.com/open-source/gsoc/2008/">Google's
 Summer of Code</a> on the behalf of the curl project, to have us participate
 as a mentoring organization 2008.
 <p>
@@ -2271,8 +2271,8 @@ ideas or submit yourself as mentor.
   and changed on the <a href="changes.html">changes</a> page.
 
 <p>
-  There's yet a again a huge effort behind this release. I both hope and think
-  that you'll appreciate it!
+  There is yet a again a huge effort behind this release. I both hope and think
+  that you will appreciate it!
 
  NCOLE
 
@@ -2396,7 +2396,7 @@ ideas or submit yourself as mentor.
  NCOLS
 
   The server hosting our mailing lists and CVS died late Friday evening and
-  with weekend and Christmas coming up, I'm not sure when someone will get a
+  with weekend and Christmas coming up, I am not sure when someone will get a
   chance to go over there and make sure it boots up fine again.
 <p>
   Please bear with us, enjoy Christmas and have a great time!
@@ -2407,8 +2407,8 @@ ideas or submit yourself as mentor.
  NDATE(21 November 2006)
  NCOLS
 
-  There's a <a href="libcurl/ruby/">new ruby binding</a> out, as the former
-  one was totally old and didn't even build anymore...
+  There is a <a href="libcurl/ruby/">new ruby binding</a> out, as the former
+  one was totally old and did not even build anymore...
 
  NCOLE
 
@@ -2418,7 +2418,7 @@ ideas or submit yourself as mentor.
 
   The latest changes provided by the curl team have resulted in <a
   href="download.html">curl and libcurl 7.16.0</a>. Check out what <a
-  href="changes.html">changes</a> it contains. There's one or two slightly
+  href="changes.html">changes</a> it contains. There is one or two slightly
   bigger changes done this time!
 
  NCOLE
@@ -2428,7 +2428,7 @@ ideas or submit yourself as mentor.
  NCOLS
 
   The cool.haxx.se server that hosts the CVS repository as well as all the
-  curl mailing lists (and some additional services) is down. We're working on
+  curl mailing lists (and some additional services) is down. We are working on
   getting it back online as soon as possible. Please be patient.
 <p>
   <b>update:</b> at 17:00 GMT the machine is back alive.
@@ -2439,12 +2439,12 @@ ideas or submit yourself as mentor.
  NDATE(11 October 2006)
  NCOLS
 
-  FTP third party transfer support is now removed. We're working on testing
+  FTP third party transfer support is now removed. We are working on testing
   and fixing bugs now in order to get a public release done "soon". Feel free
   to join in and test a recent daily snapshot to help us make a really fine
   upcoming release.
  <p>
-  There's been quite extensive internal changes since the previous release.
+  There is been quite extensive internal changes since the previous release.
 
  NCOLE
 
@@ -2464,10 +2464,10 @@ ideas or submit yourself as mentor.
  NDATE(15 September 2006)
  NCOLS
 
-  If you're subscribed to any <a href="/mail/">mailing list</a> at
+  If you are subscribed to any <a href="/mail/">mailing list</a> at
   cool.haxx.se using Digest mode, you <a
-  href="//curl.se/mail/lib-2006-09/0133.html">don't get any
-  mails</a> at the moment. Hopefully we'll have this fixed soon.
+  href="//curl.se/mail/lib-2006-09/0133.html">do not get any
+  mails</a> at the moment. Hopefully we will have this fixed soon.
 
  NCOLE
 
@@ -2500,7 +2500,7 @@ ideas or submit yourself as mentor.
  NCOLS
 
   A couple of (lib)curl users and developers are frequently hanging out in the
-  #curl channel on the freenode.net IRC network. You're welcome to stop by!
+  #curl channel on the freenode.net IRC network. you are welcome to stop by!
 
  NCOLE
 
@@ -2538,8 +2538,8 @@ ideas or submit yourself as mentor.
  NDATE(13 January 2006)
  NCOLS
 
-  There's a new service added. Pick any curl.se URL and replace 'curl'
-  with 'curlm' in the URL. When visiting that URL, you'll get bounced to a
+  There is a new service added. Pick any curl.se URL and replace 'curl'
+  with 'curlm' in the URL. When visiting that URL, you will get bounced to a
   suitable mirror near you... <a
   href="http://curlm.haxx.se/">curlm.haxx.se</a> has a list of verified
   up-to-date mirrors only.
@@ -2617,7 +2617,7 @@ ideas or submit yourself as mentor.
  NCOLS
 
 September 2005 was the first month we had more than 100,000 (one hundred
-thousand) unique visitors on the curl web site.
+thousand) unique visitors on the curl website.
 <p>
 curl packages were downloaded more than 20,000 times from the curl.se site
 only during the month.
@@ -2644,7 +2644,7 @@ companies buying ads and people referring to our site from all over.
  NDATE(19 September 2005)
  NCOLS
 
-  We didn't have a backup of the subscribers list of the <a
+  We did not have a backup of the subscribers list of the <a
   href="/mail/">mailing lists</a>. Efforts have been made and some addresses
   have been restored and brought back, but many have been lost. If you want to
   subscribe to the lists, you should verify that you are still subscribed!
@@ -2665,7 +2665,7 @@ companies buying ads and people referring to our site from all over.
   Please allow a few days before all things are back to normal.
 
   <p> It was done by using a security hole in twiki - used for another project
-  on the same server. Aren't the world full of friendly souls? The IP
+  on the same server. are not the world full of friendly souls? The IP
   originated from a country/region that makes it no point in pursuing this
   legal wise.
 
@@ -2685,7 +2685,7 @@ companies buying ads and people referring to our site from all over.
  NDATE(1 September 2005)
  NCOLS
 
-  There's now a separate <a href="/legal/distro-dilemma.html">Distro
+  There is now a separate <a href="/legal/distro-dilemma.html">Distro
   Dilemma</a> document that summarizes the background, the problem and the
   suggested road ahead.
 
@@ -2803,7 +2803,7 @@ companies buying ads and people referring to our site from all over.
  NDATE(14 March 2005)
  NCOLS
 
-  curl-tracker is a new mailing list that'll receive mails from the
+  curl-tracker is a new mailing list that will receive mails from the
   sourceforge trackers. All new submissions and changes to existing entries
   will also be mailed there.
 
@@ -2969,7 +2969,7 @@ companies buying ads and people referring to our site from all over.
  NDATE(29 April 2004)
  NCOLS
 
- We're currently implementing "IDNA" support to libcurl to allow it to
+ We are currently implementing "IDNA" support to libcurl to allow it to
  function with international domain names. We appreciate if you download a
  daily snapshot, try it out and report your mileage!
 
@@ -3033,7 +3033,7 @@ companies buying ads and people referring to our site from all over.
  NDATE(2 March 2004)
  NCOLS
 
-  <a href="//curl.se/mail/archive-2004-03/0013.html">If you've
+  <a href="//curl.se/mail/archive-2004-03/0013.html">If you have
   suffered from the issue 12 bug, please try the patch and report!</a>.
 
  NCOLE
@@ -3088,7 +3088,7 @@ Subscribe to the new mailing lists here:
  NDATE(12 January 2004)
  NCOLS
 
- We're approaching release time for the upcoming curl 7.11.0, and in good old
+ We are approaching release time for the upcoming curl 7.11.0, and in good old
  fashion we offer a <a href="//curl.se/beta/">pre-release</a> of it.
 
  NCOLE
@@ -3137,7 +3137,7 @@ Subscribe to the new mailing lists here:
  NDATE(31 October 2003)
  NCOLS
 
-  Over at cool.haxx.se/curl-daily/, there's now new curl packages put there
+  Over at cool.haxx.se/curl-daily/, there is now new curl packages put there
   every day. The packages are based on the latest CVS version at the time.
 
  NCOLE
@@ -3147,7 +3147,7 @@ Subscribe to the new mailing lists here:
  NCOLS
 
   Announced today: <a href="/competition.html">win 300 US$ by writing a cool
-  curl program</a>. Not only can you win yourself some pocket money, you'll be
+  curl program</a>. Not only can you win yourself some pocket money, you will be
   doing the project a favour!
 
  NCOLE
@@ -3162,11 +3162,11 @@ Subscribe to the new mailing lists here:
 
  NCOLE
 
- NSUBJ(Main Web Site Changes Host)
+ NSUBJ(Main website Changes Host)
  NDATE(24 September 2003)
  NCOLS
 
-  The main curl web site at <a href="//curl.se/">curl.se</a>,
+  The main curl website at <a href="//curl.se/">curl.se</a>,
   is changing host and IP. The move is not expected to be noticeable, but if
   you do find something that looks weird, please get in touch.
 
@@ -3274,7 +3274,7 @@ Subscribe to the new mailing lists here:
  NDATE(6 July 2003)
  NCOLS
 
-  Daniel is on vacation, some things don't run at full speed in the project
+  Daniel is on vacation, some things do not run at full speed in the project
   until he returns in a few weeks.
 
  NCOLE
@@ -3288,9 +3288,9 @@ Subscribe to the new mailing lists here:
   and it is up and working again.
  <p>
   Stay tuned for new details on how to proceed to checkout curl from the new
-  repository. The old one is still around, but won't change
+  repository. The old one is still around, but will not change
  <p>
-  We celebrate this new era with some brand new web site stuff, such as the new
+  We celebrate this new era with some brand new website stuff, such as the new
   logo, new colors and new left-side menu edits.
 
  NCOLE
@@ -3320,7 +3320,7 @@ Subscribe to the new mailing lists here:
  NCOLS
 
   Thanks to friendly helpers, the Digest implementation is now added to
-  libcurl, and now we're taking on the <a
+  libcurl, and now we are taking on the <a
   href="//curl.se/mail/lib-2003-05/0115.html">NTLM challenge</a>.
  <p>
   Help is appreciated.
@@ -3350,7 +3350,7 @@ Subscribe to the new mailing lists here:
  NDATE(6 May 2003)
  NCOLS
 
-  <a href="//curl.se/beta/">7.10.5-pre2</a> is out for testing.  See
+  <a href="//curl.se/beta/">7.10.5-pre2</a> is out for testing. See
   also the <a href="changes.html">changelog</a>.
 
  NCOLE
@@ -3392,7 +3392,7 @@ Subscribe to the new mailing lists here:
  NCOLS
 
   <a href="//curl.se/mail/archive-2003-03/0090.html">curl turned
-  5</a> - he's a big boy now.
+  5</a> - he is a big boy now.
 
  NCOLE
 
@@ -3427,7 +3427,7 @@ Subscribe to the new mailing lists here:
  NDATE(21 Jan 2003)
  NCOLS
 <p>
-I've spent some time on putting together a shell script that I would like
+I have spent some time on putting together a shell script that I would like
 people to run on various operating systems. The script testcurl does:
 <ol>
  <li> updates curl source from CVS
@@ -3438,7 +3438,7 @@ people to run on various operating systems. The script testcurl does:
  <li> removes the build dir
 </ol>
 <p>
-The output from all this should be mailed to the automatic receiver I've
+The output from all this should be mailed to the automatic receiver I have
 setup for this purpose.
 <p>
 Personally, I'll setup and run this script on a Solaris 2.7 host and at least
@@ -3448,7 +3448,7 @@ So, if you have some CPU cycles to spare and some time to set things up,
 please get in touch and help us out.
 <p>
 The collected status of all distributed tests that are collected will of
-course be viewable on the curl web site, and I'm smoothing out the scripts
+course be viewable on the curl website, and I am smoothing out the scripts
 for it right now.
 <p>
 The script is currently available here:
@@ -3534,7 +3534,7 @@ The script is currently available here:
   href="http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/curl/curl/perl/contrib/formfind?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup">formfind</a>
   was updated for the first time in four years. Formfind extracts
   &lt;FORM&gt; tag info from a HTML page and presents it in a readable way. A
-  helpful little tool to use when you're trying to figure out how to automate
+  helpful little tool to use when you are trying to figure out how to automate
   a POST to a site.
 
  NCOLE
@@ -3588,12 +3588,12 @@ The script is currently available here:
 
  NCOLE
 
- NSUBJ(AU web site mirror)
+ NSUBJ(AU website mirror)
  NDATE(15 Oct 2002)
  NCOLS
 
   Jason Andrade runs the brand new Australian <a
-  href="//curl.planetmirror.com/">curl web site mirror</a>. People on
+  href="//curl.planetmirror.com/">curl website mirror</a>. People on
   that side of the globe might enjoy that. He also mirrors all download
   packages for your pleasure.
 
@@ -3637,7 +3637,7 @@ The script is currently available here:
    have been fixed and features have been added. We continue to work hard on
    improving curl and libcurl...
  <p>
-   I'm proud to offer curl 7.10.
+   I am proud to offer curl 7.10.
 
  NCOLE
 
@@ -3654,7 +3654,7 @@ The script is currently available here:
  NDATE(22 Sep 2002)
  NCOLS
 
- Cris Bailiff released Curl::easy v1.35, which lets you use libcurl from perl.  Get it from
+ Cris Bailiff released Curl::easy v1.35, which lets you use libcurl from perl. Get it from
  <a href="//curl.se/libcurl/perl/">//curl.se/libcurl/perl/</a>. Minor
  fix to fixup statistics in progress function callback. Also tested with 7.10-pre3!
 
@@ -3684,7 +3684,7 @@ The script is currently available here:
 
    On August 5th, Mike Benham posted his initial <a
    href="http://online.securityfocus.com/archive/1/286290/2002-07-31/2002-08-06/0">IE
-   security advisory</a> regarding how IE doesn't properly verify SSL
+   security advisory</a> regarding how IE does not properly verify SSL
    certificates.
  <p>
    This has been discussed in curl mailing lists regarding how curl behaves on
@@ -3719,7 +3719,7 @@ The script is currently available here:
  NDATE(7 Aug 2002)
  NCOLS
 
- Cris Bailiff released Curl::easy v1.34, which lets you use libcurl from perl.  Get it from
+ Cris Bailiff released Curl::easy v1.34, which lets you use libcurl from perl. Get it from
  <a href="//curl.se/libcurl/perl/">//curl.se/libcurl/perl/</a>. Another minor
  but potentially important bug fix - Doh! A recommended upgrade.
 
@@ -3730,7 +3730,7 @@ The script is currently available here:
  NCOLS
 
  Kjetil Jacobsen released <a href="http://pycurl.io/">Pycurl</a>
- 7.9.8.3.  Under Python 2.2 or better, Curl and CurlMulti now participate in
+ 7.9.8.3. Under Python 2.2 or better, Curl and CurlMulti now participate in
  garbage collection with the gc module.
 
  NCOLE
@@ -3739,7 +3739,7 @@ The script is currently available here:
  NDATE(15 July 2002)
  NCOLS
 
- Cris Bailiff released Curl::easy v1.30, which lets you use libcurl from perl.  Get it from
+ Cris Bailiff released Curl::easy v1.30, which lets you use libcurl from perl. Get it from
  <a href="//curl.se/libcurl/perl/">//curl.se/libcurl/perl/</a>.
  <p>Adds support for OO style programming, and should be ready for perl 5.8.</p>
 
@@ -3749,7 +3749,7 @@ The script is currently available here:
  NDATE(12 July 2002)
  NCOLS
 
- Kjetil Jacobsen released Pycurl 7.9.8.2.  Get it from
+ Kjetil Jacobsen released Pycurl 7.9.8.2. Get it from
  <a href="http://pycurl.io/">http://pycurl.io/</a>.
 
  NCOLE
@@ -3759,7 +3759,7 @@ The script is currently available here:
  NCOLS
 
  Dan Wood released CURLHandle 1.6.
- CURLHandle is a wrapper around curl 7.9.8.  For more info, see
+ CURLHandle is a wrapper around curl 7.9.8. For more info, see
  <a href="https://web.archive.org/web/20020921200949/curlhandle.sourceforge.net/">
  curlhandle.sourceforge.net</a>.
 
@@ -3769,7 +3769,7 @@ The script is currently available here:
  NDATE(24 June 2002)
  NCOLS
 
-  So, while Daniel is away on vacation, there's a <a
+  So, while Daniel is away on vacation, there is a <a
   href="//curl.se/mail/archive-2002-06/0087.html">bunch of things
   to do to keep Daniel happy</a>.
  <p>
@@ -4008,7 +4008,7 @@ The script is currently available here:
  NDATE(18 March 2002)
  NCOLS
 
- Over on the <a href="//curl.se/beta/">beta page</a>, there's now a
+ Over on the <a href="//curl.se/beta/">beta page</a>, there is now a
  7.9.6 pre-release available. Enjoy!
 
  NCOLE
@@ -4091,8 +4091,8 @@ The script is currently available here:
 
  <ul>
   <li> Read the <a href="//curl.se/q/analysis.html">questionnaire
-       Analysis</a>! If you're the least interested in this project, I think
-       you're obliged to read the analysis to see what we all think about the
+       Analysis</a>! If you are the least interested in this project, I think
+       you are obliged to read the analysis to see what we all think about the
        current situation and about the future. It is quite lengthy as I did
        put some effort into this.
   <li> Help us get the new <a
@@ -4122,7 +4122,7 @@ The script is currently available here:
  NCOLS
 
   Anyone feels like taking care of the <a href="/libcurl/cplusplus/">C++
-  API</a>? It isn't yet functional, but there's an initial chunk of code to
+  API</a>? It is not yet functional, but there is an initial chunk of code to
   build on...
 
  NCOLE
@@ -4143,17 +4143,17 @@ The script is currently available here:
  NCOLS
 
  <p>
-  The fact that there's a company named Curl is not news to us. We've
+  The fact that there is a company named Curl is not news to us. We have
   summarized <a href="/docs/thename.html">the name issue</a> on a web page
   for everyone who want to find out how we ended up like this and if we really
   are targeted for legal problems due to this...
  <p>
   freshmeat.net is the number one site that new curl releases are announced
-  on. It allows users to rate single projects, and I'd like more people to <a
+  on. It allows users to rate single projects, and I would like more people to <a
   href="http://freshmeat.net/rate/1612/">rate curl</a>. Use your heart, is it
   good or is it bad?
  <p>
-  Some companies offer curl support and/or host web sites for you with curl
+  Some companies offer curl support and/or host websites for you with curl
   enabled and available. We intend to collect these companies in the <a
   href="/support.html">support</a> section. If you run a company that would
   match but is missing, we want to know!

--- a/_sponsors.html
+++ b/_sponsors.html
@@ -71,7 +71,7 @@ TITLE(Sponsors)
 <p>
  <a class="x" href="https://www.fastly.com/" rel="sponsored"><img src="pix/fastly.svg" width="500" alt="Fastly"></a>
 <p>
- Fastly delivers the curl web site and web contents to the world.
+ Fastly delivers the curl website and web contents to the world.
 
 <p>
  <a class="x" href="https://www.teamviewer.com/" rel="sponsored"><img src="pix/teamviewer.svg" width="700" alt="Teamviewer"></a>
@@ -81,7 +81,7 @@ TITLE(Sponsors)
 <div class="gold">
 SUBTITLE(Gold sponsor)
 <a class="x" href="https://elastic.co/" rel="sponsored"><img src="pix/gold/elastic-logo.svg" alt="Elastic"></a>
-<p> We're the company behind the Elastic Stack — that's Elasticsearch, Kibana, Beats, and Logstash.
+<p> We are the company behind the Elastic Stack — that is Elasticsearch, Kibana, Beats, and Logstash.
 </div>
 
 <div class="gold">
@@ -119,7 +119,7 @@ SUBTITLE(Silver sponsors)
  <div class="silver"><p> <a class="x" href="https://www.babiel.com/" rel="sponsored" aria-label="Babiel">
 #include "pix/silver/babiel.svg"
 </a></div>
-<!-- Silver-level but opencollective doesn't show (?) -->
+<!-- Silver-level but opencollective does not show (?) -->
  <div class="silver"><p> <a class="x" href="https://www.monkeybreadsoftware.de/" rel="sponsored"><img src="pix/silver/monkeybreadsoftware-2.jpg" alt="monkeybreadsoftware"></a></div>
  <div class="silver"><p> <a class="x" href="https://casino.xyz/" rel="sponsored"><img src="pix/silver/casinoxyz.png" alt="casino.xyz"></a></div>
 <!-- Silver for curl on github -->

--- a/_web-editing.html
+++ b/_web-editing.html
@@ -20,9 +20,9 @@ SUBTITLE(To think of)
   is a simple C-style one, but please take care so that #if and #ifdefs
   have an ending #endif and so on.
 
-<p> The web site contents is synced automatically from git every 20 minutes.
+<p> The website contents is synced automatically from git every 20 minutes.
   Even if you fix a mistake, it will stay that way at least until next update.
-  Don't panic!
+  Do not panic!
 
 <p> The site is hosted by CDN front-ends that fetch content from the master
   server and cache it. It makes some updates to the content to take a while
@@ -50,7 +50,7 @@ SUBTITLE(What to edit/update)
 
 <p> Edit bad language use, bad spelling or confusing use of words.
 
-<p> If the problem is in a page out of control from the web site, chances
+<p> If the problem is in a page out of control from the website, chances
   are that the page is generated automatically from a file in the source code
   archive and then <i>that</i> file could be corrected instead.
 

--- a/ca/listpem.pl
+++ b/ca/listpem.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-opendir(my $dh, ".") || die "can't opendir: $!";
+opendir(my $dh, ".") || die "cannot opendir: $!";
 my @pems = grep { /^cacert-.*pem$/ } readdir($dh);
 closedir $dh;
 

--- a/curl.css
+++ b/curl.css
@@ -482,7 +482,7 @@ p.level1 {
     body {
         background-color: #212121;
         /* Try to keep it a bit light but not too grey,
-           so it doesn't impact people with accessibility needs */
+           so it does not impact people with accessibility needs */
         color: #fbfbfb;
     }
 

--- a/dev/_howto.html
+++ b/dev/_howto.html
@@ -25,13 +25,13 @@ SUBTITLE(Get a Fresh Check-out from git)
   $ ./curl/tests/testcurl.pl
 </pre>
 <p>
- The first time to run <a href="testcurl.html">testcurl.pl</a>, it'll prompt
- you for some info (unless you provide that data using command line
- options). That info is then stored in the file named 'setup' in the current
- directory and will be used when this script is subsequently run. The format
- is easily manually edited using a text editor.
+ The first time to run <a href="testcurl.html">testcurl.pl</a>, it will prompt
+ you for some info (unless you provide that data using command line options).
+ That info is then stored in the filen amed 'setup' in the current directory
+ and will be used when this script is subsequently run. The format is easily
+ manually edited using a text editor.
 <p>
- You'll now see a full compile, build and test perform. Make sure everything
+ you will now see a full compile, build and test perform. Make sure everything
  works out fine.
 
 <p>
@@ -63,12 +63,12 @@ SUBTITLE(Other platforms than Unix)
  On Unix/Linux testcurl.pl assumes a GNU-like build with configure; on Win32
  the MSVC build is default. The testcurl.pl can now take an option
  '<tt>--target=[your_os]</tt>' so you can specify to build targets for other
- platforms.  With this option it should now be very easy to add other
+ platforms. With this option it should now be very easy to add other
  autobuilds for platforms not able to use GNU-like build systems.
 
 SUBTITLE(Build from daily tarballs)
 <p>
- If you can't checkout or update the sources from git easily, another approach
+ If you cannot checkout or update the sources from git easily, another approach
  to automated testing of the latest sources is made by getting the latest <a
  href="https://curl.se/snapshots/">daily tarballs</a> automatically
  instead.

--- a/dev/_index.html
+++ b/dev/_index.html
@@ -27,11 +27,11 @@ TITLE(Developing curl)
   </a>
 </div>
 <p>
- This is the section of the web site devoted to the development of curl and
+ This is the section of the website devoted to the development of curl and
  libcurl. If you are just a "user" of curl or libcurl, this may not be where
  you want to hang out.
 <p>
- There is always development going on in the curl project.  To help out the
+ There is always development going on in the curl project. To help out the
  development team, we provide these services:
 
 SUBTITLE(Generated contents)

--- a/dev/_source.html
+++ b/dev/_source.html
@@ -27,10 +27,10 @@ TITLE(<b>Get</b> the Sources)
 <p>
   The curl sources are kept in a git repository. You can get the most recent
   curl source files from there at any time. git is the version control system
-  we use for the curl project. All files in the release archive that aren't
+  we use for the curl project. All files in the release archive that are not
   generated from other files are kept there, to allow full backtracking of
   older versions. To use git you need a git client, get yours
-  from <a href="https://git-scm.com/">git-scm.com</a>.  Windows users might
+  from <a href="https://git-scm.com/">git-scm.com</a>. Windows users might
   fancy <a href="https://gitforwindows.org/">git for Windows</a>.
 <p>
   This is mostly a feature for you who really want to have a peek in how the

--- a/dev/autocurl.txt
+++ b/dev/autocurl.txt
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Auto-build the daily git extract of curl.  Parameters are:
+# Auto-build the daily git extract of curl. Parameters are:
 #  1: email address to notify when this script runs
 #  2: proxy url (if required)
 #  3: proxy userid (if required)
@@ -50,7 +50,7 @@ TODAY=`env TZ=Etc/GMT+2 date +%Y%m%d`
 
 cd "$BUILD"
 
-# Parse the daily builds index page for today's file name
+# Parse the daily builds index page for today's filename
 NEWCURLURL=`$CURL $CURLOPTS $URL | grep "href=.*$TODAY.tar.bz2" | sed -e 's/^.*href="//' -e 's/".*//'`
 NEWCURL=`basename $NEWCURLURL`
 if [ ! -r "$NEWCURL" ] ; then

--- a/dev/ccwarn.pm
+++ b/dev/ccwarn.pm
@@ -47,7 +47,7 @@ sub checkwarn {
 
         # libtool 2 prefixes lots of "normal" lines with "libool: link: " so we
         # cannot use that simple rule to detect errors. Adding "warning:" reduces
-        # false positives but skip some legitimate warnings that don't contain
+        # false positives but skip some legitimate warnings that do not contain
         # "warning:".
         ($l =~ /^libtool: \w+: warning:/) ||
         ($l =~ /^libtool: link:.*cannot find the library/) ||

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -67,7 +67,7 @@ function setFilterForms(filterinput, systeminput) {
 var linefilter = "";
 var linefiltername = "";
 
-/* Hide all rows on the build page that don't match the given options */
+/* Hide all rows on the build page that do not match the given options */
 function filterBuilds() {
     /* The build filter invalidates the line filters */
     linefilter = "";
@@ -106,7 +106,7 @@ function filterBuilds() {
     }
 }
 
-/* Hide all rows on the build page that don't match the given system */
+/* Hide all rows on the build page that do not match the given system */
 function filterSystemBuilds() {
     /* The system filter invalidates the line filters */
     linefilter = "";

--- a/dev/explainopts.t
+++ b/dev/explainopts.t
@@ -10,7 +10,7 @@ libssh(<b>2</b>), m(<b>E</b>)talink, PSL (<b>1</b>), HTTP2 (<b>F</b>),
 (<b>U</b>)nix Sockets
 
 <p> Text <span class='buildserverprob'>looking like this</span> is for servers
-that couldn't be started for the test round.
+that could not be started for the test round.
 Use the pop-up menu next to Options or Description or click directly on a build
 Description or Name to see only matching builds<noscript> (requires
 Javascript)</noscript>.

--- a/dev/ignores
+++ b/dev/ignores
@@ -1,4 +1,4 @@
-# gcc 2.9 on AIX can't be made to ignore this:
+# gcc 2.9 on AIX cannot be made to ignore this:
 lib/mprintf.c:950: warning: format not a string literal, argument types not checked
 # gcc 2.95.3 cross-compiling for ARM complains on a system header:
 include/bits/confname.h:565: warning: comma at end of enumerator list
@@ -27,9 +27,9 @@ lib/sendf.h:.*: warning: anonymous variadic macros were introduced in C99
 # MIT Kerberos 1.2
 /usr/kerberos/include/.* is not defined
 # NetScape Portable Runtime library 4.7.3 (dependency of NSS)
-nspr.*/prlink.h:.*: warning: function declaration isn't a prototype
+nspr.*/prlink.h:.*: warning: function declaration is not a prototype
 # NSS 3.12.2
-nss/cert.h:.*: warning: function declaration isn't a prototype
+nss/cert.h:.*: warning: function declaration is not a prototype
 # gcc 3.3 bug triggers warnings on some assert statements
 lib/warnless.c:210: warning: statement with no effect
 lib/warnless.c:229: warning: statement with no effect

--- a/dev/log.cgi
+++ b/dev/log.cgi
@@ -61,7 +61,7 @@ if(open(my $logfile, "<$build")) {
                 }
                 elsif($line =~ /^testcurl: TRANSFER CONTROL/) {
                     if($line =~ /^testcurl: .+ CHAR LINEo{1066}LINE_END/) {
-                        # Don't show the transfer control line if complete
+                        # Do not show the transfer control line if complete
                         next;
                     }
                     $state = 2;

--- a/dev/summarize.pl
+++ b/dev/summarize.pl
@@ -267,7 +267,7 @@ exit 0;
 my $warning=0;
 
 sub endofsingle {
-    my ($file) = @_; # the single build file name
+    my ($file) = @_; # the single build filename
 
     if ($skipbuild) {
         print STDERR "Skipping $file\n";
@@ -300,7 +300,7 @@ sub endofsingle {
         $libressl = 1;
     }
     # PolarSSL confusingly renamed itself during the 1.x time frame
-    # so don't be fooled
+    # so do not be fooled
     elsif($libcurl =~ /mbedTLS\/(?!1\.)/i) {
         $mbedtls = 1;
     }
@@ -535,7 +535,7 @@ sub singlefile {
             $buildid = $1;
             print STDERR " - build $buildid\n";
         }
-        # we don't check for state here to allow this to abort all
+        # we do not check for state here to allow this to abort all
         # states
         elsif($line =~ /^testcurl: STARTING HERE/) {
             # mail headers here
@@ -558,7 +558,7 @@ sub singlefile {
                     $state = 3;
                 }
                 elsif($line =~ /^testcurl: NOTES =/) {
-                    # Don't include this line in the build code. It doesn't
+                    # Do not include this line in the build code. It does not
                     # affect the build in any way, and it allows the builder to
                     # include varying information (e.g. local build ID or link)
                     # as additional debugging info while maintaining the same
@@ -573,7 +573,7 @@ sub singlefile {
             }
             elsif($state == 3) {
                 if($line =~ /^testcurl: configure created \(dummy message\)/) {
-                    # This isn't an autoconf build at all--we need to include
+                    # This is not an autoconf build at all--we need to include
                     # the contents of the config header files to make
                     # a unique buildcode. This is more brittle as it is
                     # sensitive to changes to the config file headers, but
@@ -888,9 +888,9 @@ sub singlefile {
                 $trackmem=1;
             }
 
-            if($line =~ /don't know how to make 'vc-(x64-)?winssl/) {
+            if($line =~ /do not know how to make 'vc-(x64-)?winssl/) {
                 # This is a completely misconfigured autobuild that is using an
-                # outdated build target, making it impossible to build. Don't
+                # outdated build target, making it impossible to build. Do not
                 # pollute the autobuilds page by even displaying it.
                 $skipbuild = 1;
             }

--- a/dev/update.pl
+++ b/dev/update.pl
@@ -15,7 +15,7 @@ if(open(MD5, "<md5")) {
     close(MD5);
 }
 
-# if there's a logfile named 'p' now, it is new!
+# if there is a logfile named 'p' now, it is new!
 my $new=0;
 for(keys %logfile) {
     if($logfile{$_} eq "p") {

--- a/dl/dlfix.pl
+++ b/dl/dlfix.pl
@@ -25,7 +25,7 @@ sub updatethis {
         print "Checking $name at $version, for OS ".$$ref{'os'}."\n";
 
         if($$ref{'file'} ne $file) {
-            print "... file names differ: $$ref{'file'} vs $file\n";
+            print "... filenames differ: $$ref{'file'} vs $file\n";
             $$ref{'file'}=$file; # set the actual one
             $mod++;
         }

--- a/dl/dtime.pm
+++ b/dl/dtime.pm
@@ -5,20 +5,20 @@
 ;#      $time = timegm($sec,$min,$hours,$mday,$mon,$year);
 
 ;# These routines are quite efficient and yet are always guaranteed to agree
-;# with localtime() and gmtime().  We manage this by caching the start times
-;# of any months we've seen before.  If we know the start time of the month,
-;# we can always calculate any time within the month.  The start times
+;# with localtime() and gmtime(). We manage this by caching the start times
+;# of any months we have seen before. If we know the start time of the month,
+;# we can always calculate any time within the month. The start times
 ;# themselves are guessed by successive approximation starting at the
 ;# current time, since most dates seen in practice are close to the
-;# current date.  Unlike algorithms that do a binary search (calling gmtime
+;# current date. Unlike algorithms that do a binary search (calling gmtime
 ;# once for each bit of the time value, resulting in 32 calls), this algorithm
-;# calls it at most 6 times, and usually only once or twice.  If you hit
-;# the month cache, of course, it doesn't call it at all.
+;# calls it at most 6 times, and usually only once or twice. If you hit
+;# the month cache, of course, it does not call it at all.
 
-;# timelocal is implemented using the same cache.  We just assume that we're
-;# translating a GMT time, and then fudge it when we're done for the timezone
-;# and daylight savings arguments.  The timezone is determined by examining
-;# the result of localtime(0) when the package is initialized.  The daylight
+;# timelocal is implemented using the same cache. We just assume that we are
+;# translating a GMT time, and then fudge it when we are done for the timezone
+;# and daylight savings arguments. The timezone is determined by examining
+;# the result of localtime(0) when the package is initialized. The daylight
 ;# savings offset is currently assumed to be one hour.
 
 ;# Both routines return -1 if the integer limit is hit. I.e. for dates
@@ -84,7 +84,7 @@ sub week {
     # struct tm stores yday 0 based, we need it 1 based
     $tyday++;
 
-    # silly americans begin the week on sundays. ISO doesn't
+    # silly americans begin the week on sundays. ISO does not
     if( 0 == $twday ) {
         # it it IS a sunday, make it sunday!
         $twday = 7;

--- a/dl/mktable.pl
+++ b/dl/mktable.pl
@@ -270,7 +270,7 @@ for $per (@sall) {
 
     my $contenttype;
     if ($$per{'size'} > 0) {
-        # If the file is served locally, or if it's a remote binary file
+        # If the file is served locally, or if it is a remote binary file
         # (which a known size indicates), include its content type in the link
         $contenttype=$formats{$$per{'pack'}};
         if ($contenttype) {

--- a/dl/mod_entry.cgi
+++ b/dl/mod_entry.cgi
@@ -48,7 +48,7 @@ else {
 lheader($title, "<script type=\"text/javascript\" src=\"mod.js\"></script>\n");
 
 if (CGI::param("action")) {
-    # get the pre- values if they're set instead of the "original" ones
+    # get the pre- values if they are set instead of the "original" ones
     for(keys %data) {
         my $d = CGI::param("pre-".$_);
         if(($d ne "new") && ($data{$_} eq "")) {
@@ -170,7 +170,7 @@ sub my_show_form()
                 "mingw32 / cygwin / Borland / etc");
 
     alternative("Image", "img",
-                "file name of image for this OS/flavour");
+                "filename of image for this OS/flavour");
 
     alternative("CPU", "cpu",
                 "i386 / i686 / PowerPC / StrongARM / etc");
@@ -190,7 +190,7 @@ sub my_show_form()
     alternative("Importance", "prio",
                 "A higher number to get sorted higher when other things equal.");
 
-    alternative("File/URL", "file", "file name / URL", 50);
+    alternative("File/URL", "file", "filename / URL", 50);
 
     alternative("curl version", "curl",
                 "7.10.3 or similar");

--- a/dl/pbase.pm
+++ b/dl/pbase.pm
@@ -15,18 +15,18 @@
 # Commercial use: Send me an email and tell me that you use it.
 #
 # pbase has borrowed main functionality, the database file format and some
-# other ideas of "dbase" made by Bjorn.Stenberg@haxx.se.  dbase is an
+# other ideas of "dbase" made by Bjorn.Stenberg@haxx.se. dbase is an
 # executable standalone database handler, while pbase is a perl-included
 # version.
 #
 # How it works:
-#  The principle with pbase is hash-arrays.  The whole database is stored
-# as one array of hash-arrays (named $Database).  One hash-array corresponds
-# to one row of a database table.  Each field of a database table corresponds
+#  The principle with pbase is hash-arrays. The whole database is stored
+# as one array of hash-arrays (named $Database). One hash-array corresponds
+# to one row of a database table. Each field of a database table corresponds
 # to an item of the hash-array.
-#  The database is loaded only once.  The user can decide to select parts of
-# the database into selections.  You can always get back an old selection if
-# you've stored the current selection with the "clone_selection"-function.
+#  The database is loaded only once. The user can decide to select parts of
+# the database into selections. You can always get back an old selection if
+# you have stored the current selection with the "clone_selection"-function.
 #  Every function (except delete) only acts on the current selection.
 #
 #  Each row of the database selection is numbered from 0 to size()-1. The user
@@ -37,7 +37,7 @@
 #
 #  When the user gets a row, he actually gets a reference to a hash-array. This
 # could be used for direct changes or copied to a temporary local hash-array.
-# I don't care.
+# I do not care.
 #
 #  The format of the database is compatible to "Frexx dbase" by Bjorn Stenberg.
 # First line is "- 0123456789ABCDEF" where the numbers build the ID of the row.
@@ -45,8 +45,8 @@
 # containing the data, with \n, \r, \t escaped to readable form.
 #
 #  A template file is used (if existing) to be able to decide which fields you
-# database shall have.  If no template (*.tem) file is found, then all fields
-# are accepted and treated as strings.  The template file shall have the same
+# database shall have. If no template (*.tem) file is found, then all fields
+# are accepted and treated as strings. The template file shall have the same
 # name as the database except ending with ".tem" instead of ".db".
 #  The format of the template file is like this:
 # -----------------------------------
@@ -64,7 +64,7 @@
 #  Large database files can be parsed with the parse-functions.
 #
 #  A database file is locked when opened, and unlocked when closed. So only one
-# user can access a database.  Remember to keep your actions small and fast.
+# user can access a database. Remember to keep your actions small and fast.
 #
 # ==============================
 # History:
@@ -83,7 +83,7 @@
 # v1.2 1999-Dec-14  Kjell Ericson - made it possible to select with greater or less
 #                                    than, using "<" or ">" (see "-").
 # v1.3 2000-Jan-24  Kjell Ericson - Added find()
-# v1.4 2000-Jan-24  Kjell Ericson - sort("-...") didn't work.
+# v1.4 2000-Jan-24  Kjell Ericson - sort("-...") did not work.
 # v1.5 2000-Feb-29  Björn Stenberg - removed some warnings.
 # v1.6 2000-Mar-02  Kjell Ericson - removed more warnings (not all).
 # v1.7 2000-Mar-11  Kjell Ericson - Adding more comments.
@@ -92,7 +92,7 @@
 # v1.10 2003-Mar-14 Kjell Ericson - Added find_all
 # v1.12 2003-Mar-17 Kjell Ericson - Fast get("id")
 # v1.12 2003-Mar-17 Kjell Ericson - Bugfix av get("id")
-# v1.13 2003-Mar-27 Kjell Ericson - Don't save empty items.
+# v1.13 2003-Mar-27 Kjell Ericson - Do not save empty items.
 # ==============================
 
 
@@ -150,7 +150,7 @@ package pbase;
 # Let's define the file lock possibilities.
 $LOCK_SH = 1;# Shared
 $LOCK_EX = 2;# Exclusive
-$LOCK_NB = 4;# Don't block when locking
+$LOCK_NB = 4;# Do not block when locking
 $LOCK_UN = 8;# Unlock
 $use_lock = 1; #set to 1 if locks shall be used
 $version="1.13";
@@ -288,7 +288,7 @@ sub clone_selection
 #  \___|_|\___/|___/\___|
 # Closes the lock on the database file.
 # You can call this function and still use the database object to read from.
-# You shouldn't change or save it (unspecified behaviour).
+# You should not change or save it (unspecified behaviour).
 #
 # Input: nothing
 # Output: nothing
@@ -591,7 +591,7 @@ sub get_id
 #
 # Get the type of a fieldname.
 # Returns 'string', 'int' or 'bin' if the field exist.
-# Returns an empty string ("") if the field doesn't exist.
+# Returns an empty string ("") if the field does not exist.
 #
 # Input: fieldname
 # Output: typename
@@ -648,7 +648,7 @@ sub internal_sort_function
 # | |/ _ \ / _` |/ _` |
 # | | (_) | (_| | (_| |
 # |_|\___/ \__,_|\__,_|
-# backward compatility - so far...  See open()
+# backward compatility - so far... See open()
 # Will produce a row in the pbase_error.log file.
 # Input: filename
 # Output: Database size or -1 for error
@@ -668,8 +668,8 @@ sub load
 #                   |_____|               |_|
 # Internal function that load the template file (if existing)
 # If a template file is found, the object-global variable $self->{use_template}
-# is set to '1'.  The %template hasharray is set with the names
-# and corresponding types.  No type-checking is done.
+# is set to '1'. The %template hasharray is set with the names
+# and corresponding types. No type-checking is done.
 #
 # Input: filename
 # Output: 0 if no template file is found.
@@ -771,11 +771,11 @@ sub new
 #| (_) | |_) |  __/ | | |
 # \___/| .__/ \___|_| |_|
 #      |_|
-# Open a database for read and write.  The whole database is read into memory.
-# A new file will be created if the database doesn't exist.
+# Open a database for read and write. The whole database is read into memory.
+# A new file will be created if the database does not exist.
 # The database file will be locked for security until a call to close() is
 # made. You can make a direct call to close() and still be able to read
-# from the database object.  But don't try to change or save the database then.
+# from the database object. But do not try to change or save the database then.
 #
 # Input: filename
 # Output: Database size or -1 for error
@@ -966,7 +966,7 @@ sub parse_next
 #| .__/ \__,_|_|  |___/\___|___\___/| .__/ \___|_| |_|
 #|_|                      |_____|   |_|
 # Open a new database to parse. Use parse_next() to get one database row
-# returned in sequence.  This is good to have when the database is very
+# returned in sequence. This is good to have when the database is very
 # large and you only want to calculate some statistic.
 # Shall have a corresponding call to parse_close().
 # Input: database name
@@ -1005,7 +1005,7 @@ sub parse_open
 #
 # Note: If you append to the database might you get two rows containing the
 #       same id. When opening the database again will only the latest remain.
-#       This can though be useful for large databases where you don't want to
+#       This can though be useful for large databases where you do not want to
 #       rewrite the whole database file when only changing one row.
 #
 sub save
@@ -1071,7 +1071,7 @@ sub save
 # / __|/ _ \ |/ _ \/ __| __|
 # \__ \  __/ |  __/ (__| |_
 # |___/\___|_|\___|\___|\__|
-# Remove rows of the current selection that doesn't fit the criteria
+# Remove rows of the current selection that does not fit the criteria
 # Input: Hasharray containing the field-name and a regex-pattern that it must
 #        match. A minus-sign in front of a field name will negate the match
 # Output: Size of the current selection
@@ -1201,7 +1201,7 @@ sub size
 # \__ \ (_) | |  | |_
 # |___/\___/|_|   \__|
 # Sort the current selection
-# Input: array of which fields to sort on.  A minus-sign infront of
+# Input: array of which fields to sort on. A minus-sign infront of
 #        the field-name will revert the sort order.
 # Output: nothing
 #

--- a/dl/remcheck.pl
+++ b/dl/remcheck.pl
@@ -156,7 +156,7 @@ sub geturl {
     }
 
     if($head) {
-        # we don't cache HEAD requests
+        # we do not cache HEAD requests
         $curlcmd .= " --head";
         #logmsg " issue a HEAD request\n";
     }
@@ -178,7 +178,7 @@ sub geturl {
             while((shift @content) !~ /^[\x0A\x0D]*$/ ) {}
         }
     } else {
-        # we don't cache HEAD requests
+        # we do not cache HEAD requests
         if(@content) {
             # store the content in the hash
             @{$urlhash{$url}}=@content;
@@ -244,7 +244,7 @@ for $ref (@all) {
         $localpackage++;
     }
     elsif($churl && ($churl ne "-")) {
-        # there's a URL to check
+        # there is a URL to check
 
         if(!islastfewversions($$ref{'curl'})) {
 
@@ -291,7 +291,7 @@ for $ref (@all) {
 
             $$ref{'remcheck'} = timestamp();
 
-            # there's a regex to check for in the downloaded page
+            # there is a regex to check for in the downloaded page
             $chregex = CGI::unescapeHTML($chregex);
 
             logmsg sprintf(" Check regex <b><tt>%s</tt></b>\n",
@@ -312,7 +312,7 @@ for $ref (@all) {
                 if($l =~ /$chregex/) {
                     my $r = $1;
                     if($versionembedded) {
-                        # '$version' was part of the URL and thus we don't
+                        # '$version' was part of the URL and thus we do not
                         # need/want to extract it from the regex match
                         $r = $version;
                     }
@@ -345,7 +345,7 @@ for $ref (@all) {
             }
         }
         else {
-            # since there's no regex, just do a head request to verify the
+            # since there is no regex, just do a head request to verify the
             # file's mere existence
             @data = geturl($churl, 1);
 
@@ -400,7 +400,7 @@ for $ref (@all) {
                 # so we update the download URL as well!
                 $$ref{'file'}=$churl;
             }
-            # store the size, whether it's known or unknown (blank)
+            # store the size, whether it is known or unknown (blank)
             $$ref{'size'}=$cl;
             logmsg " Store size: " . ($cl || "unknown") . " bytes\n";
 
@@ -428,7 +428,7 @@ logmsg "$uptodate remote packages found up-to-date with database versions\n";
 logmsg "<div class=\"buildfail\">$failedcheck packages failed to get checked</div>\n";
 logmsg "$localpackage packages are local and taken care of differently\n";
 logmsg "$oldies checks were skipped due to old release number\n";
-logmsg "<div class=\"buildfail\">$regexmisses regexes didn't match on successful URL fetches</div>\n";
+logmsg "<div class=\"buildfail\">$regexmisses regexes did not match on successful URL fetches</div>\n";
 logmsg "$hidden packages were skipped since they are 'hidden'\n";
 
 if($missing) {

--- a/dl/stuff.pm
+++ b/dl/stuff.pm
@@ -70,7 +70,7 @@ sub inputstuff::save_input
         if ($id) {
             my $ref=$db->get("id"=>$id);
             if ($$ref{"modify_time"} != CGI::param("modify_time")) {
-                $warning_message="Your changes aren't saved, someone else ".
+                $warning_message="Your changes are not saved, someone else ".
                     "changes the contents before you!";
             } else {
                 $db->change("id", $id, %data);
@@ -95,7 +95,7 @@ sub inputstuff::save_input
         } elsif ($id ne "") {
             my $ref=$db->get("id"=>$id);
             if ($$ref{"modify_time"} != CGI::param("modify_time")) {
-                $warning_message="Your changes aren't saved, someone else ".
+                $warning_message="Your changes are not saved, someone else ".
                     "changes the contents before you!";
             } elsif (!$db->delete("id", $id)) {
                 if ($db->save() == -1) {

--- a/docs/CVE-2009-0037.md
+++ b/docs/CVE-2009-0037.md
@@ -27,8 +27,8 @@ server. `Location: scp://name:passwd@host/a;date >/tmp/test;`.
 
 Files on servers other than the one running libcurl are also accessible when
 credentials for those servers are stored in the .netrc file of the user
-running libcurl.  This is most common for FTP servers, but can occur with
-any protocol supported by libcurl.  Files on remote SSH servers are also
+running libcurl. This is most common for FTP servers, but can occur with
+any protocol supported by libcurl. Files on remote SSH servers are also
 accessible when the user has an unencrypted SSH key.
 
 INFO

--- a/docs/CVE-2015-3236.md
+++ b/docs/CVE-2015-3236.md
@@ -29,7 +29,7 @@ accidentally use those credentials in a subsequent request if done to the same
 hostname and connection as was previously accessed.
 
 An example case would be first requesting a password protected resource from
-one section of a web site, and then do a second request of a public resource
+one section of a website, and then do a second request of a public resource
 from a completely different part of the site without authentication. This flaw
 would then inadvertently leak the credentials in the second request.
 

--- a/docs/CVE-2016-0754.md
+++ b/docs/CVE-2016-0754.md
@@ -95,7 +95,7 @@ preference:
  B - Apply the patch to your version and rebuild.
 
  C - If you cannot do (A) or (B) it is suggested you do not use `-J` on
-     Windows.  If you choose to continue to use `-O` without `-J` it is your
+     Windows. If you choose to continue to use `-O` without `-J` it is your
      responsibility to check that the URL you pass does not have a remote file
      name that could be exploited.
 

--- a/docs/CVE-2017-1000101.md
+++ b/docs/CVE-2017-1000101.md
@@ -62,7 +62,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on June 14, 2017.  We contacted
+It was reported to the curl project on June 14, 2017. We contacted
 distros@openwall on August 1.
 
 curl 7.55.0 was released on August 9 2017, coordinated with the publication of

--- a/docs/CVE-2017-1000254.md
+++ b/docs/CVE-2017-1000254.md
@@ -70,7 +70,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on September 24, 2017.  We contacted
+It was reported to the curl project on September 24, 2017. We contacted
 distros@openwall on September 25.
 
 curl 7.56.0 was released on October 4 2017, coordinated with the publication

--- a/docs/CVE-2017-1000257.md
+++ b/docs/CVE-2017-1000257.md
@@ -63,7 +63,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on October 6, 2017.  We contacted
+It was reported to the curl project on October 6, 2017. We contacted
 distros@openwall on October 17.
 
 curl 7.56.1 was released on October 23 2017, coordinated with the publication

--- a/docs/CVE-2017-7468.md
+++ b/docs/CVE-2017-7468.md
@@ -74,7 +74,7 @@ TIMELINE
 ---------
 
 It was [first reported to the curl
-project](https://github.com/curl/curl/issues/1341) on March 21, 2017.  We
+project](https://github.com/curl/curl/issues/1341) on March 21, 2017. We
 contacted distros@openwall on April 10.
 
 libcurl 7.54.0 was released on April 19 2017, coordinated with the publication

--- a/docs/CVE-2017-8816.md
+++ b/docs/CVE-2017-8816.md
@@ -67,7 +67,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on November 6, 2017.  We contacted
+It was reported to the curl project on November 6, 2017. We contacted
 distros@openwall on November 21.
 
 curl 7.57.0 was released on November 29 2017, coordinated with the publication

--- a/docs/CVE-2017-8817.md
+++ b/docs/CVE-2017-8817.md
@@ -65,7 +65,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on November 10, 2017.  We contacted
+It was reported to the curl project on November 10, 2017. We contacted
 distros@openwall on November 21.
 
 curl 7.57.10 was released on November 29 2017, coordinated with the

--- a/docs/CVE-2017-8818.md
+++ b/docs/CVE-2017-8818.md
@@ -71,7 +71,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on November 18, 2017.  We contacted
+It was reported to the curl project on November 18, 2017. We contacted
 distros@openwall on November 24.
 
 curl 7.57.0 was released on November 29 2017, coordinated with the publication

--- a/docs/CVE-2017-9502.md
+++ b/docs/CVE-2017-9502.md
@@ -67,7 +67,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on June 4, 2017.  We contacted MITRE on
+It was reported to the curl project on June 4, 2017. We contacted MITRE on
 June 7.
 
 libcurl 7.54.1 was released on June 14 2017, coordinated with the publication

--- a/docs/CVE-2018-14618.md
+++ b/docs/CVE-2018-14618.md
@@ -68,7 +68,7 @@ TIMELINE
 ---------
 
 It was [publicly reported](https://github.com/curl/curl/issues/2756) to the
-curl project on July 18, 2018.  We contacted distros@openwall on August 27.
+curl project on July 18, 2018. We contacted distros@openwall on August 27.
 
 curl 7.61.1 was released on September 5 2018, coordinated with the publication
 of this advisory.

--- a/docs/CVE-2018-16839.md
+++ b/docs/CVE-2018-16839.md
@@ -70,7 +70,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on September 6, 2018.  We contacted
+It was reported to the curl project on September 6, 2018. We contacted
 distros@openwall on October 22.
 
 curl 7.62.0 was released on October 31 2018, coordinated with the publication

--- a/docs/CVE-2018-16840.md
+++ b/docs/CVE-2018-16840.md
@@ -52,7 +52,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on October 14, 2018.  We contacted
+It was reported to the curl project on October 14, 2018. We contacted
 distros@openwall on October 22.
 
 curl 7.62.0 was released on October 31 2018, coordinated with the publication

--- a/docs/CVE-2018-16842.md
+++ b/docs/CVE-2018-16842.md
@@ -68,7 +68,7 @@ preference:
 TIMELINE
 ---------
 
-It was reported to the curl project on October 27, 2018.  We contacted
+It was reported to the curl project on October 27, 2018. We contacted
 distros@openwall on October 28.
 
 curl 7.62.0 was released on October 31 2018, coordinated with the publication

--- a/docs/CVE-2020-8284.md
+++ b/docs/CVE-2020-8284.md
@@ -8,7 +8,7 @@ VULNERABILITY
 -------------
 
 When curl performs a passive FTP transfer, it first tries the `EPSV` command
-and if that is not supported, it falls back to using `PASV`.  Passive mode is
+and if that is not supported, it falls back to using `PASV`. Passive mode is
 what curl uses by default.
 
 A server response to a `PASV` command includes the (IPv4) address and port

--- a/docs/CVE-2023-38546.md
+++ b/docs/CVE-2023-38546.md
@@ -33,7 +33,7 @@ INFO
 The Common Vulnerabilities and Exposures (CVE) project has assigned the name
 CVE-2023-38546 to this issue.
 
-CWE-73: External Control of File Name or Path
+CWE-73: External Control of filename or Path
 
 Severity: Low
 

--- a/docs/_caextract.html
+++ b/docs/_caextract.html
@@ -33,11 +33,11 @@ TITLE(CA certificates extracted from Mozilla)
 
 <p>
  This PEM file contains the datestamp of the conversion and we only make a new
- conversion if there's a change in either the script or the source file. This
+ conversion if there is a change in either the script or the source file. This
  service checks for updates every day. Here's
  the <a href="../ca/cacert.pem.sha256">sha256sum</a> of the current PEM file.
 
-SUBTITLE(File name)
+SUBTITLE(filename)
 <p>
  Some programs will expect this file to be named <tt>ca-bundle.crt</tt> (in
  the correct path). curl on windows has a system to find it if
@@ -62,7 +62,7 @@ SUBTITLE(CA certificate store license)
 
 SUBTITLE(Automated downloads from here)
 <p>
- We don't mind you downloading the PEM file from us in an automated fashion.
+ We do not mind you downloading the PEM file from us in an automated fashion.
 
 <p>
  A suitable curl command line to only download it when it has changed:
@@ -70,7 +70,7 @@ SUBTITLE(Automated downloads from here)
   curl <a href="/docs/manpage.html#--etag-compare">--etag-compare</a> etag.txt <a href="/docs/manpage.html#--etag-save">--etag-save</a> etag.txt <a href="/docs/manpage.html#-O">--remote-name</a> https://curl.se/ca/cacert.pem
 </pre>
 
-Or if you use an ancient curl version that doesn't support etags:
+Or if you use an ancient curl version that does not support etags:
 <pre>
   curl <a href="/docs/manpage.html#-O">--remote-name</a> <a href="/docs/manpage.html#-z">--time-cond</a> cacert.pem https://curl.se/ca/cacert.pem
 </pre>

--- a/docs/_companies.html
+++ b/docs/_companies.html
@@ -367,7 +367,7 @@ Broadcom Nexus.
 <li> <a href="https://www.kaseya.com/">Kaseya</a> uses libcurl
 
 <li> <a href="https://www.kencast.com/">kencast inc.</a> - <i>"uses libcurl in
-a scripting extension library.  We also use it in our upload/download manager
+a scripting extension library. We also use it in our upload/download manager
 module in our product."</i>
 
 <li> <a href="https://www.kerio.com/">Kerio Technologies</a> uses curl in Kerio MailServer
@@ -412,7 +412,7 @@ href="http://www.networkassociates.com/us/products/mcafee/antivirus/desktop/vire
 on Mac OS X
 
 <li> <a href="https://vivamedia.se/">MediaAnalys/Viva Media</a> uses curl for
-scanning customers&#39; web sites.
+scanning customers&#39; websites.
 
 <li> "at <b>Meetecho</b> we use curl for a few things in the Janus WebRTC
 Server: mainly as the RTSP stack in the Streaming plugin, but also for the

--- a/docs/_copyright.html
+++ b/docs/_copyright.html
@@ -30,7 +30,7 @@ TITLE(Copyright - License)
  Curl and libcurl are licensed under the license below, which is inspired by MIT/X,
  but not identical.
 <p>
- There are other computer-related projects using the name curl as well.  For
+ There are other computer-related projects using the name curl as well. For
  details, check out <a href="thename.html">our position on the curl name
  issue</a>.
 

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -27,7 +27,7 @@ SUBTITLE(The book: Everything curl)
   libcurl and the associated project.
 <p>
   Learn how to use curl. How to use libcurl. How to build them from source or
-  perhaps how the curl project accepts contributions. There's something for
+  perhaps how the curl project accepts contributions. There is something for
   everyone in this, from the casual first-time users to the experienced
   libcurl hackers.
 
@@ -57,7 +57,7 @@ SUBTITLE(<a href="projdocs.html">The project</a>)
 <a href="knownbugs.html">Known Bugs</a>,
 <a href="/logo/">Logo</a>,
 <a href="todo.html">TODO</a>,
-<a href="/about.html">Web Site Info</a>
+<a href="/about.html">website Info</a>
 
 SUBTITLE(<a href="reldocs.html">Releases</a>)
 <p>

--- a/docs/_irc.html
+++ b/docs/_irc.html
@@ -47,14 +47,14 @@ SUBTITLE(How to speak)
 
 SUBTITLE(What if nobody responds)
 <p>
-  There's no guarantee anyone wants to respond or that anyone who reads right
+  There is no guarantee anyone wants to respond or that anyone who reads right
   now even knows the answer to your question. Consider maybe post your
   questions or thoughts on a <a href="/mail/">suitable mailing list?</a>
 
 SUBTITLE(Screenshot)
 <p>
   A screenshot example of a discussion in the #curl channel from early April
-  2021.  Seen here in action is the Linux IRC
+  2021. Seen here in action is the Linux IRC
   client <a href="https://hexchat.github.io/">hexchat</a>. The time stamps on
   the left are shown using the local time zone of Daniel ('bagder') Stenberg.
 <p>

--- a/docs/_menu.html
+++ b/docs/_menu.html
@@ -34,7 +34,7 @@ VLINK(/docs/, Docs Overview, Documentation Overview)
     <a href="/docs/knownbugs.html">Known Bugs</a>
     <a href="/logo/">Logo</a>
     <a href="/docs/todo.html">TODO</a>
-    <a href="/about.html">Web Site Info</a>
+    <a href="/about.html">website Info</a>
   </div>
 </div>
 

--- a/docs/_projdocs.html
+++ b/docs/_projdocs.html
@@ -27,7 +27,7 @@ TITLE(Project Documentation)
   The <a href="governance.html">governance</a> explains how we make decisions
   and who decides what in the project.
 <p>
-  If a problem isn't already a <a href="knownbugs.html">known bug</a> or
+  If a problem is not already a <a href="knownbugs.html">known bug</a> or
   something mentioned in the <a href="todo.html">TODO</a>, you
   can <a href="bugs.html">report the bug</a>.
 <p>
@@ -40,7 +40,7 @@ TITLE(Project Documentation)
 
 <p>
   Meta info:
-  Project <a href="history.html">history</a>, <a href="/about.html">web site
+  Project <a href="history.html">history</a>, <a href="/about.html">website
   info</a>, <a href="/donation.html">how to
   donate</a>, <a href="code-of-conduct.html">Code of conduct</a>
   and <a href="/logo/">the logo</a>.

--- a/docs/_reldocs.html
+++ b/docs/_reldocs.html
@@ -28,7 +28,7 @@ TITLE(Release Documentation)
   The <a href="releases.html">Release Table</a> lists all releases, with
   release date, number of bug fixes and so on.
 <p>
-  On the <a href="security.html">curl CVE page</a>, you'll find all publicized
+  On the <a href="security.html">curl CVE page</a>, you will find all publicized
   security problems listed and thoroughly described and
   the <a href="vulnerabilities.html">vulnerabilities</a> table shows which
   versions that are vulnerable to each problem. Published following the curl

--- a/docs/_ssl-compared.html
+++ b/docs/_ssl-compared.html
@@ -217,7 +217,7 @@ offers less roundtrip handshakes.
 <p>
 
 <b>TLS SRP:</b> SRP means "Secure Remote Password" and it is a method of
-performing client-side authentication with a TLS server by using a user name
+performing client-side authentication with a TLS server by using a username
 and password, sometimes coupled with a certificate. It is not yet widely
 supported, but for the engines that do support it, you can provide the
 credentials to curl by using the CURLOPT_TLSAUTH_USERNAME and
@@ -242,7 +242,7 @@ using the CURLOPT_CAINFO option.
 <b>Uses Certificate/Key Database:</b> Some engines, such as Apple's Security
 framework, use a central database instead of separate files to store
 certificates and keys. Apple's Security framework database, for instance, is
-called the Keychain. For engines that use a database and don't also support
+called the Keychain. For engines that use a database and do not also support
 files, the CURLOPT_CAINFO option is ignored.
 <p>
 
@@ -270,7 +270,7 @@ tokens/databases.
 <b>FIPS-140:</b> FIPS-140 is a security standard used by the United States and
 Canada for transferring information that is sensitive but not classified. If
 yes, and you are using curl or a libcurl-based application in the US or
-Canadian government, or in a government contractor, then it's okay for you to
+Canadian government, or in a government contractor, then it is okay for you to
 use the engine when building curl/libcurl.
 <p>
 

--- a/docs/_thename.html
+++ b/docs/_thename.html
@@ -57,7 +57,7 @@ TITLE(Who Owns the Name Curl?)
 <div class="quote">
 Hi
 <p>
-First, I'd like to say that I greatly appriciate your approach and I am
+First, I would like to say that I greatly appriciate your approach and I am
 indeed willing to participate in a dialogue to work things out. We too, of
 course, recognize the confusions our duplicate uses of the name 'curl' might
 cause. We have a section in our FAQ document for this reason that clearly
@@ -80,8 +80,8 @@ main installations and recently, they have also been adopted in the Open
 Packages project which in practise eventually might make them pre-requisite
 for all freely available BSD operating systems as well.
 <p>
-I'm willing to offer a distinct-looking "box" or similar, on the front page
-of the web site at curl.se, that informs visitors about your
+I am willing to offer a distinct-looking "box" or similar, on the front page
+of the website at curl.se, that informs visitors about your
 project/product and a link to your site. To clearly show that we are not you.
 I would of course enjoy something similar from you.
 <p>

--- a/docs/videos/videolist.txt
+++ b/docs/videos/videolist.txt
@@ -48,7 +48,7 @@ TAGS test suite, testing
 DESC The curl test suite and how testing is done in the project
 ENDOFVIDEO
 
-VIDEO Creating console oriented web sites
+VIDEO Creating console oriented websites
 EVENT curl-up 2017
 URL https://curl.se/video/curlup-2017/2017-03-18_04_Igor_Chubin_creating_console_oriented_web_sites.mp4
 THUMB creating-console-websites-2017.jpg
@@ -70,7 +70,7 @@ WHO Christian Schmitz
 DESC Experiences in writing a libcurl wrapper
 ENDOFVIDEO
 
-VIDEO The curl web site
+VIDEO The curl website
 EVENT curl-up 2017
 URL https://curl.se/video/curlup-2017/2017-03-18_06_Dan_Fandrich_Daniel_Stenberg_curl_website.mp4
 THUMB curl-website-2017.jpg
@@ -78,7 +78,7 @@ THUMBSIZE width="250" height="188"
 DURATION 29 minutes
 DATE 2017-03-18
 WHO Dan Fandrich and Daniel Stenberg
-DESC The curl web site and infrastructure
+DESC The curl website and infrastructure
 ENDOFVIDEO
 
 VIDEO How Google uses curl
@@ -180,7 +180,7 @@ THUMBSIZE width="250" height="188"
 DURATION 20 minutes
 DATE 2017-03-19
 WHO Stefan Eissing
-DESC How he uses curl to test Apache's HTTP/2 support
+DESC How he uses curl to test Apache is HTTP/2 support
 ENDOFVIDEO
 
 VIDEO Doing HTTP/2 with libcurl
@@ -380,7 +380,7 @@ THUMBSIZE width="250" height="141"
 DURATION 35 minutes
 DATE 2018-04-15
 WHO Lucas Pardue
-DESC Why there's an Alt-Svc header, how it works and how it changes everything
+DESC Why there is an Alt-Svc header, how it works and how it changes everything
 ENDOFVIDEO
 
 VIDEO Fuzzing curl
@@ -439,7 +439,7 @@ THUMBSIZE width="250" height="140"
 DURATION 12 minutes
 DATE 2019-03-30
 WHO Daniel Stenberg
-DESC How to deprecate things, what we're deprecating and how we introduce experimental features.
+DESC How to deprecate things, what we are deprecating and how we introduce experimental features.
 ENDOFVIDEO
 
 VIDEO Governance and money
@@ -636,7 +636,7 @@ THUMBSIZE width="250" height="141"
 DATE 2021-02-11
 DURATION 1h01
 WHO Josh Aas, Sean McArthur, Daniel Stenberg
-DESC The motivation for and challenges with integrating the Hyper HTTP Rust back-end into curl.
+DESC The motivation for and challenges with integrating the Hyper HTTP Rust backend into curl.
 ENDOFVIDEO
 
 VIDEO cURL, FIPS, and Windows! Oh My!
@@ -817,7 +817,7 @@ THUMBSIZE width="250" height="140"
 DURATION 0h21
 DATE 2022-09-15
 WHO Sean McArthur
-DESC Brief recap of an HTTP backend in curl. What we've done, highlight community members that have fixed things. Ways curl has improved hyper, and vice versa. How anyone can join us, and try it out early. Sean is the lead developer of the Hyper project.
+DESC Brief recap of an HTTP backend in curl. What we have done, highlight community members that have fixed things. Ways curl has improved hyper, and vice versa. How anyone can join us, and try it out early. Sean is the lead developer of the Hyper project.
 ENDOFVIDEO
 
 VIDEO QUIC and HTTP/3 with curl and wolfSSL

--- a/docs/vuln.pm
+++ b/docs/vuln.pm
@@ -23,7 +23,7 @@
     "CVE-2024-0853.html|8.5.0|8.5.0|OCSP verification bypass with TLS session reuse|CVE-2024-0853|20240131|20231229|CWE-299: Improper Check for Certificate Revocation|540|TLS|-|both|low|https://hackerone.com/reports/2298922",
     "CVE-2023-46219.html|7.84.0|8.4.0|HSTS long filename clears contents|CVE-2023-46219|20231206|20231102|CWE-311: Missing Encryption of Sensitive Data|540|HSTS|-|both|low|https://hackerone.com/reports/2236133",
     "CVE-2023-46218.html|7.46.0|8.4.0|cookie mixed case PSL bypass|CVE-2023-46218|20231206|20231017|CWE-201: Information Exposure Through Sent Data|2540|cookie|-|both|medium|https://hackerone.com/reports/2212193",
-    "CVE-2023-38546.html|7.9.1|8.3.0|cookie injection with none file|CVE-2023-38546|20231011|20230914|CWE-73: External Control of File Name or Path|540|cookies|-|lib|low|https://hackerone.com/reports/2148242",
+    "CVE-2023-38546.html|7.9.1|8.3.0|cookie injection with none file|CVE-2023-38546|20231011|20230914|CWE-73: External Control of filename or Path|540|cookies|-|lib|low|https://hackerone.com/reports/2148242",
     "CVE-2023-38545.html|7.69.0|8.3.0|SOCKS5 heap buffer overflow|CVE-2023-38545|20231011|20230930|CWE-122: Heap-based Buffer Overflow|4660|SOCKS5|OVERFLOW|both|high|https://hackerone.com/reports/2187833",
     "CVE-2023-38039.html|7.84.0|8.2.1|HTTP headers eat all memory|CVE-2023-38039|20230913|20230717|CWE-770: Allocation of Resources Without Limits or Throttling|2540|HTTP|-|both|medium|https://hackerone.com/reports/2072338",
     # CVE-2023-32001 is no longer considered a security problem
@@ -80,7 +80,7 @@
     "CVE-2020-8231.html|7.29.0|7.71.1|wrong connect-only connection|CVE-2020-8231|20200819|20200731|CWE-825: Expired Pointer Dereference|500|internal|-|lib|low|https://hackerone.com/reports/948876",
     "CVE-2020-8177.html|7.20.0|7.70.0|curl overwrite local file with -J|CVE-2020-8177|20200624|20200530|CWE-641: Improper Restriction of Names for Files and Other Resources|700|tool|-|tool|medium|https://hackerone.com/reports/887462",
     "CVE-2020-8169.html|7.62.0|7.70.0|Partial password leak over DNS on HTTP redirect|CVE-2020-8169|20200624|20200515|CWE-200: Exposure of Sensitive Information to an Unauthorized Actor|400|HTTP|-|both|medium|https://hackerone.com/reports/874778",
-    # CVE-2019-15601 is no longer considered a security problem so it shouldn't
+    # CVE-2019-15601 is no longer considered a security problem so it should not
     # be listed here: https://daniel.haxx.se/blog/2020/03/16/warning-curl-users-on-windows-using-file/
     "CVE-2019-5481.html|7.52.0|7.65.3|FTP-KRB double free|CVE-2019-5481|20190911|20190903|CWE-415: Double Free|200|FTP|DOUBLE_FREE|both|medium|https://hackerone.com/reports/686823",
     "CVE-2019-5482.html|7.19.4|7.65.3|TFTP small blocksize heap buffer overflow|CVE-2019-5482|20190911|20190829|CWE-122: Heap-based Buffer Overflow|250|TFTP|OVERFLOW|lib|medium|https://hackerone.com/reports/684603",

--- a/last20threads.pl
+++ b/last20threads.pl
@@ -24,7 +24,7 @@ my %listrealname = ('archive' => 'curl-users',
                     'curlpp' => 'curlpp',
                     'curlppdev' => 'curlpp-devel');
 
-opendir(DIR, $tree) || die "can't opendir $tree: $!";
+opendir(DIR, $tree) || die "cannot opendir $tree: $!";
 my @archives = grep { /^(.*)-(\d\d\d\d)-(\d\d)$/ && -d "$tree/$_" } readdir(DIR);
 closedir DIR;
 
@@ -191,7 +191,7 @@ sub parsehtmlfile {
 sub getthreads {
     my ($dir) = @_;
 
-    opendir(DIR, $dir) || die "can't opendir $dir: $!";
+    opendir(DIR, $dir) || die "cannot opendir $dir: $!";
     my @mails = grep { /^(\d+)\.html$/ && -f "$dir/$_" } readdir(DIR);
     closedir DIR;
 

--- a/latest.pm
+++ b/latest.pm
@@ -9,7 +9,7 @@ our $wwwdir="/var/www/html/download";
 our $dldir="../download";
 our $curl="curl";
 
-# they're all hashed on 'type'
+# they are all hashed on 'type'
 our %high;
 our %file;
 our %size;
@@ -263,7 +263,7 @@ sub gettype {
 sub scanstatus {
     my ($dir)=@_;
 
-    opendir(DIR, $dir) || die "can't opendir $dir: $!";
+    opendir(DIR, $dir) || die "cannot opendir $dir: $!";
     my @curls = grep { /^(lib|)curl/ && -f "$dir/$_" } readdir(DIR);
     closedir DIR;
 

--- a/libcurl/_competitors.html
+++ b/libcurl/_competitors.html
@@ -78,7 +78,7 @@ See demo/urlfetch.cpp in commoncpp2-1.3.19.tar.gz
 
 <b><a href="https://notroj.github.io/neon/">neon</a></b> (LGPL) <a href="neon.html">comparison with neon</a> <br>
 <ul><li>
-  An HTTP and WebDAV client library, with a C interface. I've mainly heard
+  An HTTP and WebDAV client library, with a C interface. I have mainly heard
   and seen people use this with WebDAV as their main interest. This is one
   of the two alternatives used by the Subversion project.
 </li></ul>
@@ -105,7 +105,7 @@ See demo/urlfetch.cpp in commoncpp2-1.3.19.tar.gz
 
 <b><a href="https://www.gnu.org/software/wget/">wget</a></b> (GPL)<br>
 <ul><li>
-  While not a library at all, I've been told that people sometimes extract the
+  While not a library at all, I have been told that people sometimes extract the
   network code from it and base their own hacks from there.
 </li></ul>
 

--- a/libcurl/_features.html
+++ b/libcurl/_features.html
@@ -83,7 +83,7 @@ SUBTITLE(Supports IPv6)
 
 <p> There is nothing in particular needed to get IPv6 to be used, the library
  API remains exactly the same and adjusts to IPv4/IPv6 dynamically. You can
- use host names that only have AAAA DNS records, or you can use IPv6 IP-only
+ use hostnames that only have AAAA DNS records, or you can use IPv6 IP-only
  style addresses like <tt>[::1]</tt>.
 
 <a name="support"></a>
@@ -97,13 +97,13 @@ SUBTITLE(Well Supported)
  We have a public bug tracker and known bugs are mostly fixed very swiftly.
 <p>
  We also provide very detailed documentation on all operations, not just in
- every release archive but also available on the web site(s).
+ every release archive but also available on the website(s).
 <p>
  You can get paid support from one of the listed <a href="/support.html">curl
  support</a> companies.
 <p>
  Since the code is free and available, any skilled programmer can fix and
- improve the tool and library whenever. If you can't, you can hire one.
+ improve the tool and library whenever. If you cannot, you can hire one.
 
 <a name="fast"></a>
 SUBTITLE(Fast)
@@ -140,14 +140,14 @@ SUBTITLE(Stable API and ABI)
  seriously</b>. We have a few rules when it comes to API and ABI compatibility
  and they are:<ol>
 
-<li> We don't break API or ABI compatibility
+<li> We do not break API or ABI compatibility
 
-<li> Seriously, we really don't and we work very hard to provide alternatives
+<li> Seriously, we really do not and we work very hard to provide alternatives
 that introduce new ways instead of breaking old
 
 <li> A few times in the beginning of our project we felt forced to break
 existing behavior and we did API and ABI bumps. It was painful and hard and
-bad and we <b>really really</b> don't want to do it again. Ever. We have not
+bad and we <b>really really</b> do not want to do it again. Ever. We have not
 done it since 2006.
 
 </ol>

--- a/libcurl/_index.html
+++ b/libcurl/_index.html
@@ -61,7 +61,7 @@ TITLE(libcurl - the multiprotocol file transfer library)
  You use libcurl with the provided <a href="c/">C API</a>. The curl team works
  hard to keep the <a href="features.html#stableapi">API and ABI stable</a>.
  If you prefer using libcurl from your other favorite language, chances are
- there's already a <a href="bindings.html">binding</a> written for it.
+ there is already a <a href="bindings.html">binding</a> written for it.
 
 <p><b>Howto</b>
 <p>

--- a/libcurl/_libwww.html
+++ b/libcurl/_libwww.html
@@ -23,7 +23,7 @@ TITLE(Notes About Libwww compared to libcurl)
 
 <p>
  These are only some quick notes. If you have additional experiencies and
-comments you want to share with the world, we're all ears!
+comments you want to share with the world, we are all ears!
 
 <ul>
 
@@ -42,7 +42,7 @@ comments you want to share with the world, we're all ears!
 
  <li> libcurl supports more protocols
 
- <li> libwww offers caching and HTML parsing, which libcurl doesn't
+ <li> libwww offers caching and HTML parsing, which libcurl does not
 
 </ul>
 
@@ -52,11 +52,11 @@ comments you want to share with the world, we're all ears!
 
 <div class="quote">
 <i>
-Having used both, I'd recommend libcurl and definitely not libwww.
+Having used both, I would recommend libcurl and definitely not libwww.
 <p>
-libcurl is easy to use and gives good performance.  libwww is a nightmare to
+libcurl is easy to use and gives good performance. libwww is a nightmare to
 use, performs poorly (no overlapped I/O support, for example), and is
-practically undocumented (on top of which it's a very complex library).
+practically undocumented (on top of which it is a very complex library).
 libwww is really a platform for network protocol development, not a library
 for basic access to well known network protocol stacks.
 </i>
@@ -70,14 +70,14 @@ intermediate complexity (supporting post requests, xml parsing, authentication
 etc.)  and figuring out that the problems I encountered were due to libwww and
 not my code.
 <p>
-I switched to libcurl, rewrote the same code in a week and haven't
+I switched to libcurl, rewrote the same code in a week and have not
 looked back.
 <p>
-Perhaps this library has some features that libcurl doesn't, though I didn't
-have to use them for my needs.  However, for libwww to survive, someone has to
+Perhaps this library has some features that libcurl does not, though I did not
+have to use them for my needs. However, for libwww to survive, someone has to
 focus on these features and let libcurl do the rest.
 <p>
-Personally, I can't find any reason to suggest libwww to anyone.
+Personally, I cannot find any reason to suggest libwww to anyone.
 </i>
 </div>
 

--- a/libcurl/_mail.html
+++ b/libcurl/_mail.html
@@ -30,7 +30,7 @@ TITLE(libcurl Mailing List)
   module.
 
 <p>
-  If you're into general curl stuff, you'll be better off on the <a
+  If you are into general curl stuff, you will be better off on the <a
   href="/mail/subscribe.html">curl-users mailing list</a>.
 
 #include "_footer.html"

--- a/libcurl/_neon.html
+++ b/libcurl/_neon.html
@@ -26,14 +26,14 @@ TITLE(Notes About neon compared to libcurl)
  These are some notes about libcurl compared against <a
 href="https://web.archive.org/web/webdav.org/neon/">neon</a>. If you have
 additional experiencies and comments you want to share with the world,
-we're all ears!
+we are all ears!
 
 <ul>
 
  <li> libcurl is more portable (VMS, OS/400, etc)
 
- <li> neon lacks support for: NTLM on non-windows, it doesn't offer SSL
-  built to use NSS, it doesn't support cookies, it doesn't support compression
+ <li> neon lacks support for: NTLM on non-windows, it does not offer SSL
+  built to use NSS, it does not support cookies, it does not support compression
   deflating and it only supports HTTP(S) as transfer protocol
 
  <li> neon offers WebDAV support
@@ -42,7 +42,7 @@ we're all ears!
 
 <i>"I found that libneon is actually a bit more efficient (maybe 33% fewer CPU
 cycles in a similar setup as above), but I think only because it does blocking
-reads.  libneon is also a lot more work to use, as it forces the user to
+reads. libneon is also a lot more work to use, as it forces the user to
 implement more of the HTTP session state machine."</i> - Matt Gruenke
 
 #include "_footer.html"

--- a/libcurl/_theysay.html
+++ b/libcurl/_theysay.html
@@ -53,18 +53,18 @@ software house would need. Strongly recommended.
  Michael Haephrati, CEO, Secured Globe, Inc. New York
 
 <li> We have hundreds of emails going out every hour being sent to multiple
-recipients, without curl handling it we wouldn't be able to do it quite so
-smoothly at all. Our team highly appreciate the work you've put in over the many
+recipients, without curl handling it we would not be able to do it quite so
+smoothly at all. Our team highly appreciate the work you have put in over the many
 years, curl does all we need and more.
 <p>
 Jeff Cohen, Lead Developer <a href="https://cleanersnearme.co.uk">Cleaners
 Near Me Ltd</a>
 
-<li> We're running one of Germany's largest coupon portals
+<li> We are running one of Germany's largest coupon portals
 @ <a href="https://www.gutscheine.org/">Gutscheine.org</a>.
 <p>
   For all our backend data processing as well as for various updating jobs
-  we're using curl via the PHP bindings. Some of the things we use the library
+  we are using curl via the PHP bindings. Some of the things we use the library
   for are:
   <ul>
     <li> Downloading external data feeds
@@ -73,7 +73,7 @@ Near Me Ltd</a>
   </ul>
   The quality of the library as well as of the documentation available helps
   us run a stable operation without having to worry too much about the kind of
-  server we're dealing with.
+  server we are dealing with.
 <p>
 - Andre Lungstrass, Gutscheine.org
 
@@ -85,20 +85,20 @@ expansion tool PhraseExpander.
 <a href="https://www.phraseexpander.com/">PhraseExpander</a>
 
 <li> <a href="https://www.xonasoftware.com/">XonaSoftware</a>'s product,
-Situate, focuses on IT process automation.  Our unique application of workflow
+Situate, focuses on IT process automation. Our unique application of workflow
 technology allows IT process to be modeled graphically from a palette of tasks
-that do the heavy lifting.  We use libcurl to move files as part of our
-managed file transfer.  We also use libcurl to automate interactions with
+that do the heavy lifting. We use libcurl to move files as part of our
+managed file transfer. We also use libcurl to automate interactions with
 websites, listen for incoming mail, etc. libcurl is an incredible,
-well-designed product. It's exceptionally flexible and very easy to use.
+well-designed product. it is exceptionally flexible and very easy to use.
 <p>
 - Mike Mazzolini, Founder, XonaSoftware, Inc.
 
-<li> I'm a professional C++ PC and console game developer and Libcurl is my
+<li> I am a professional C++ PC and console game developer and Libcurl is my
 go-to library when I want to communicate with a web service for cloud or
-web based game features.  Libcurl has allowed me to implement game side
+web based game features. Libcurl has allowed me to implement game side
 communication in platform independent ways at several well known game
-development studios.  The features I've used Libcurl to implement include:
+development studios. The features I have used Libcurl to implement include:
 
 <ul>
 <li> Sharing user generated content
@@ -112,7 +112,7 @@ maximize profits for several companies I have worked for in the past 10
 years
 </ul>
 <p>
-Libcurl is mature, reliable, and easy to use.  It is definitely a tool
+Libcurl is mature, reliable, and easy to use. It is definitely a tool
 every serious game developer should have in their tool chest.
 <p>
 - Alan Wolfe, Software Engineer, Blizzard Entertainment
@@ -121,12 +121,12 @@ every serious game developer should have in their tool chest.
 <p>
 Our product, <a href="https://www.gdocsdrive.com">GDocsDrive</a>, employs
 libcurl for all the HTTP communication with Google cloud storage through
-Google Document List API.  And libcurl is proven to be very robust and
+Google Document List API. And libcurl is proven to be very robust and
 powerful in our programming experience, especially in a multi-thread
-environment.  Actually, before we decided to use libcurl as the HTTP library
+environment. Actually, before we decided to use libcurl as the HTTP library
 for your project, we struggled a lot on choosing between libcurl and
 WinInet. Today I would say that we are happy and lucky that we eventually
-choose libcurl.  Libcurl works for all different http requests and the
+choose libcurl. Libcurl works for all different http requests and the
 callback function mechanism really makes the code neat and comfortable to
 write. It saves us lots of programming effort.
 <p>
@@ -148,7 +148,7 @@ MMVC project.
 
 <li> I am using libcurl as the backend of my news notification program
 which provides popups of new news via rss feeds. I have to say libcurl has
-been the easiest thing to use that I've seen, and I will continue to use it in
+been the easiest thing to use that I have seen, and I will continue to use it in
 later versions of my applications. Kudos to the developers!
 <p> - Don Neumann <a href="http://www.quietearth.us/newsnotification.htm">News
 notification</a>
@@ -160,7 +160,7 @@ notification</a>
 <p> - Jonathan Arnold <a href="http://www.insors.com/">inSORS</a>
 
 <li> libcurl allows us to build next generation Internet applications
- without worrying about the Internet.  libcurl elegantly and reliable handles
+ without worrying about the Internet. libcurl elegantly and reliable handles
  all of our uploading and downloading so we can worry about creating great new
  software.
 <p> - Matt Veenstra <a href="https://www.tribalmedia.com/">tribalmedia</a>
@@ -201,7 +201,7 @@ last but not least, its developers are competent and willing to help.
 <p> - Michele Bini, Florence, Italy
 
 <li> Thanks a lot for a <u>very</u> useful library!  (soooo much more
-stable and powerful than widely used alternatives, it's not even funny! Helped
+stable and powerful than widely used alternatives, it is not even funny! Helped
 me tremendously in getting net transfers just right)
 <p> - <a href="//curl.se/mail/archive-2008-03/0008.html">Andreas
 Mohr</a>

--- a/libcurl/_wininet.html
+++ b/libcurl/_wininet.html
@@ -23,50 +23,50 @@ TITLE(Notes About WinInet compared to libcurl)
 
 <ul>
 
- <li> there's a <a href="https://support.microsoft.com/en-us/kb/238425">tech note
+ <li> there is a <a href="https://support.microsoft.com/en-us/kb/238425">tech note
  from Microsoft</a> that says not to use WinInet from system context.
 
  <li> Even if you ignore the tech note, there are a bunch of annoyances with
- using WinInet from system context.  The biggest of which is proxy settings.
+ using WinInet from system context. The biggest of which is proxy settings.
  In general, the settings are stored per user, so if you find yourself in
- system context, the correct settings may not be there.  Or, if you need to
- impersonate another user, you're in the same boat.  Gotta love the plain text
- config file.  I am curious if people worry about their proxy credentials
+ system context, the correct settings may not be there. Or, if you need to
+ impersonate another user, you are in the same boat. Gotta love the plain text
+ config file. I am curious if people worry about their proxy credentials
  lying around in plain text, or if they encrypt them, or what.
 
  <li> Even with the correct settings, there are certain versions of IE (I
- think it's 6, and maybe with some service packs) that don't work properly
+ think it is 6, and maybe with some service packs) that do not work properly
  when communicating to proxies with basic authentication.
 
- <li> There are so many sweet features with curl that aren't available with
+ <li> There are so many sweet features with curl that are not available with
  WinInet. Like for example support for more protocols.
 
- <li> I've never tried to deal with Microsoft for WinInet support, but the
+ <li> I have never tried to deal with Microsoft for WinInet support, but the
  curl support (i.e. the <a href="/mail/">libcurl mailing list</a>, and Daniel
  in particular) is <i>really</i> good.
 
- <li> Even if portability isn't a concern now, it might be later.  And,
- there's more than just code portability.  If you get good with curl, you'll
- have a useful skill if you work on other platforms.  I doubt we'll see
+ <li> Even if portability is not a concern now, it might be later. And,
+ there is more than just code portability. If you get good with curl, you will
+ have a useful skill if you work on other platforms. I doubt we will see
  WinInet ported anywhere else anytime soon.
 
- <li> We had some servers in-house and others outside our main network.  Each
- one needed its own proxy and id/password settings for connecting.  WinInet
- will only store one current configuration.  This meant that we couldn't
+ <li> We had some servers in-house and others outside our main network. Each
+ one needed its own proxy and id/password settings for connecting. WinInet
+ will only store one current configuration. This meant that we could not
  connect to both an internal and external server at the same time.
 
  <li> Another issue was trying to explain to people that when they messed up
  their IE settings, the application would fail.
 
- <li> Some of our customers did not USE Internet Explorer.  It was installed,
- but not configured.  This meant they had to set up and configure the beast
+ <li> Some of our customers did not USE Internet Explorer. It was installed,
+ but not configured. This meant they had to set up and configure the beast
  that is IE, even if they would never use it.
 
 </ul>
 
 <p> A quote from <a href="https://www.abisource.com/mailinglists/abiword-dev/2003/Oct/0391.html">Leonard Rosenthol</a> on the abiword development mailing list:
 <div class="quote">
-<i> WinInet is fine for a "hack", but isn't usable for serious I/O - libcurl is
+<i> WinInet is fine for a "hack", but is not usable for serious I/O - libcurl is
 MUCH more robust, flexible, and faster.</i>
 </div>
 

--- a/libcurl/c/_curl_easy_header.html
+++ b/libcurl/c/_curl_easy_header.html
@@ -16,7 +16,7 @@
 #include "setup.t"
 
 WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", curl_easy_header)
-TITLE(curl_easy_header - get a HTTP header)
+TITLE(curl_easy_header - get an HTTP header)
 #include "libcurl-related.t"
 #include "curl_easy_header.gen"
 #include "_footer.html"

--- a/libcurl/c/_curl_mime_filename.html
+++ b/libcurl/c/_curl_mime_filename.html
@@ -16,7 +16,7 @@
 #include "setup.t"
 
 WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", curl_mime_filename)
-TITLE(curl_mime_filename - set a mime part remote file name)
+TITLE(curl_mime_filename - set a mime part remote filename)
 #include "libcurl-related.t"
 #include "curl_mime_filename.gen"
 #include "_footer.html"

--- a/libcurl/c/_curl_version_info.html
+++ b/libcurl/c/_curl_version_info.html
@@ -16,7 +16,7 @@
 #include "setup.t"
 
 WHERE3(libcurl, "/libcurl/", API, "/libcurl/c/", curl_version_info)
-TITLE(curl_version_info - returns run-time libcurl version info)
+TITLE(curl_version_info - returns runtime libcurl version info)
 #include "libcurl-related.t"
 #include "curl_version_info.gen"
 #include "_footer.html"

--- a/libcurl/c/_index.html
+++ b/libcurl/c/_index.html
@@ -59,7 +59,7 @@ TITLE(The Easy interface)
 <p>
  When all is setup, you tell libcurl to <a
  href="curl_easy_perform.html">perform</a> the transfer. It will then do the
- entire operation and won't return until it is done or failed.
+ entire operation and will not return until it is done or failed.
 <p>
  After the performance is made, you may <a href="curl_easy_getinfo.html">get
  information</a> about the transfer and then you <a

--- a/libcurl/c/_options-in-examples.html
+++ b/libcurl/c/_options-in-examples.html
@@ -22,7 +22,7 @@ TITLE(Options Used By Examples)
 <br><a href="./">API</a>
 </div>
 <p>
- This list shows examples that use specific options.  If there's no example
+ This list shows examples that use specific options. If there is no example
  listed for the given option, please consider to write one up and send us!
 <p>
 #include "options-in-examples.gen"

--- a/libcurl/c/_tls-options.html
+++ b/libcurl/c/_tls-options.html
@@ -23,7 +23,7 @@ TITLE(TLS related options and the backends they work with)
 </div>
 <p>
   libcurl can use different TLS backends, selected at both build-time and
-  run-time. This table shows all TLS related options and details the set of
+  runtime. This table shows all TLS related options and details the set of
   TLS backends that work with it.
 <p>
  The <b>OpenSSL</b> column also covers BoringSSL, libressl, quictls, AWS-LC

--- a/libcurl/c/curlopt2href.pl
+++ b/libcurl/c/curlopt2href.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Convert various "bare" mentions of curl symbols into links.  This primarily
+# Convert various "bare" mentions of curl symbols into links. This primarily
 # adds links to the example sections which otherwise are hard to highlight
 # correctly in nroff syntax.
 #

--- a/libcurl/c/mkallfunc.pl
+++ b/libcurl/c/mkallfunc.pl
@@ -2,7 +2,7 @@
 
 my $docsdir = $ARGV[0];
 
-opendir(my $dh, $docsdir) || die "Can't opendir $some_dir: $!";
+opendir(my $dh, $docsdir) || die "cannot opendir $some_dir: $!";
 my @manp = grep { /^curl_.*\.md/ } readdir($dh);
 closedir $dh;
 

--- a/libcurl/c/mkexam.pl
+++ b/libcurl/c/mkexam.pl
@@ -6,7 +6,7 @@ my $template="_example-templ.html";
 
 my $dir="../../cvssource/docs/examples";
 
-opendir(DIR, $dir) || die "can't opendir $dir: $!";
+opendir(DIR, $dir) || die "cannot opendir $dir: $!";
 my @samps = grep { /\.(c|cpp)\z/ && -f "$dir/$_" } readdir(DIR);
 closedir DIR;
 

--- a/libcurl/c/mkopts.pl
+++ b/libcurl/c/mkopts.pl
@@ -2,7 +2,7 @@
 
 my $dir="../../cvssource/docs/libcurl/opts";
 
-opendir(DIR, $dir) || die "can't opendir $dir: $!";
+opendir(DIR, $dir) || die "cannot opendir $dir: $!";
 my @opts = grep { /^C.*\.md\z/ && -f "$dir/$_" } readdir(DIR);
 closedir DIR;
 

--- a/libcurl/c/options-used-in-examples.pl
+++ b/libcurl/c/options-used-in-examples.pl
@@ -3,7 +3,7 @@
 $root="../../cvssource";
 $dir="$root/docs/examples";
 
-opendir(DIR, $dir) || die "can't opendir $dir: $!";
+opendir(DIR, $dir) || die "cannot opendir $dir: $!";
 my @samps = grep { /\.(c|cpp)\z/ && -f "$dir/$_" } readdir(DIR);
 closedir DIR;
 

--- a/mail/_lost.html
+++ b/mail/_lost.html
@@ -19,7 +19,7 @@ TITLE(Lost Mailing List Data)
   existing mailing list info and all lists of then currently subscribed
   users. He did this vicious act by exploiting a security hole in the twiki
   installation we have on the same server that hosts the curl mailing lists
-  (cool.haxx.se).  Lots of other data was erased as well but that did
+  (cool.haxx.se). Lots of other data was erased as well but that did
   fortunately not affect this project.
 <p>
   With the hole fixed, we restored backups only to discover that we had messed
@@ -31,7 +31,7 @@ TITLE(Lost Mailing List Data)
 <p>
   This had several immediate side-effects:
 <ol>
-  <li> people who haven't posted nor subscribed recently were lost completely
+  <li> people who have not posted nor subscribed recently were lost completely
   <li> some people that had already unsubscribed wrongly got re-added
   <li> everyone got a new password set for the membership on the list (and thus
       for their preference edits etc)
@@ -42,7 +42,7 @@ TITLE(Lost Mailing List Data)
  have to bear the initial flood of people sending 'unsubscribe' request to the
  list (against all sense and knowledge).
 <p>
- The mailing list archives weren't affected. They are even hosted on a
+ The mailing list archives were not affected. They are even hosted on a
  different server.
 
 #include "_footer.html"

--- a/mail/_mail.html
+++ b/mail/_mail.html
@@ -21,7 +21,7 @@ TITLE(Get help using mailing lists)
 </div>
 <p>
   Mailing lists is the preferred method of communication with and within the
-  curl project. If you have a questions on how to do things, if things don't
+  curl project. If you have a questions on how to do things, if things do not
   work out the way you expect them to or if you want to contribute patches or
   offer other help.
 
@@ -42,7 +42,7 @@ TREVEN
   NEWCOL <a href="https://lists.haxx.se/listinfo/curl-library">curl-library</a></td>
 
   NEWCOL The primary development list. How to <b>use libcurl</b>,
-         libcurl bugs and how to develop libcurl even more.  Related libs,
+         libcurl bugs and how to develop libcurl even more. Related libs,
          tools and subjects. </td>
 
   NEWCOL <a href="https://curl.se/mail/list.cgi?list=curl-library">curl-library archives</a>

--- a/mail/_mailman.html
+++ b/mail/_mailman.html
@@ -37,7 +37,7 @@ TITLE(The <MM-List-Name> mailing list)
  all its contents becoming publicly available.
 
 <p> If you intend to particiate and respond to mails sent to the list, <i>do
- not</i> use the digest mode as they're next to impossible to reply to in a
+ not</i> use the digest mode as they are next to impossible to reply to in a
  sensible way.
 
 <p>You can subscribe to the list, or change your existing subscription, in the
@@ -45,7 +45,7 @@ TITLE(The <MM-List-Name> mailing list)
 
 <h2>Subscribe to the <MM-List-Name> mailing list</h2>
 
-<p> Subscribe to <MM-List-Name> by filling out the following form.  You will
+<p> Subscribe to <MM-List-Name> by filling out the following form. You will
  be sent email requesting confirmation. The list of members is only visible to
  admins.
 

--- a/mail/list.cgi
+++ b/mail/list.cgi
@@ -68,7 +68,7 @@ sub listarchives {
     my ($prefix, $listname)=@_;
 
     my $some_dir=".";
-    opendir(DIR, $some_dir) || die "can't opendir $some_dir: $!";
+    opendir(DIR, $some_dir) || die "cannot opendir $some_dir: $!";
     my @dirs = sort {$a cmp $b} grep { /^$prefix-/ && -d "$some_dir/$_" } readdir(DIR);
     closedir DIR;
 
@@ -125,7 +125,7 @@ MOO
         $none=1;
     }
     else {
-        print "$list? Are you playing with me? There's no such list!";
+        print "$list? Are you playing with me? There is no such list!";
         $none=1;
     }
 

--- a/mail/mailman.t
+++ b/mail/mailman.t
@@ -10,7 +10,7 @@
  <h1 class="pagetitle"><MM-List-Name> -- <MM-List-Description></h1>
 <div class="relatedbox">
 <b>Related:</b>
-<br><a href="https://curl.se/">curl web site</a>
+<br><a href="https://curl.se/">curl website</a>
 <br><a href="https://curl.se/mail/list.cgi?list=<MM-List-Name>"><MM-List-Name> archives</a>
 <br><a href="https://curl.se/mail/">Mailing Lists</a>
 </div>
@@ -36,7 +36,7 @@
 
 <h2>Subscribing to <MM-List-Name></h2>
 
-<p> Subscribe to <MM-List-Name> by filling out the following form.  You will
+<p> Subscribe to <MM-List-Name> by filling out the following form. You will
  be sent email requesting confirmation. The list of members is only visible to
  admins.
 

--- a/mirror/_index.html
+++ b/mirror/_index.html
@@ -13,7 +13,7 @@ WHERE2(Download, "/download.html", How To Mirror)
 
 TITLE(How To Mirror)
 <p>
-  We don't use website mirrors anymore.
+  We do not use website mirrors anymore.
 
 #include "_footer.html"
 </body>

--- a/mk-download.pl
+++ b/mk-download.pl
@@ -3,10 +3,10 @@
 require "./date.pm";
 
 my $dir="download";
-opendir(DIR, $dir) || die "can't opendir $dir: $!";
+opendir(DIR, $dir) || die "cannot opendir $dir: $!";
 my @files = readdir(DIR);
 closedir DIR;
-opendir(DIR, "$dir/archeology") || die "can't opendir $dir/archeology: $!";
+opendir(DIR, "$dir/archeology") || die "cannot opendir $dir/archeology: $!";
 while (readdir DIR) {
    push @files, "archeology/$_";
 }

--- a/mk-sponsors.pl
+++ b/mk-sponsors.pl
@@ -78,7 +78,7 @@ while(<SP>) {
 close(SP);
 
 if($sec != $images) {
-    print STDERR "_sponsors.html count ($sec) doesn't match online count: $count ($images with images)\n";
+    print STDERR "_sponsors.html count ($sec) does not match online count: $count ($images with images)\n";
 }
 
 

--- a/tiny/_index.html
+++ b/tiny/_index.html
@@ -20,7 +20,7 @@ TITLE(tiny-curl)
     <li> focused on providing a library for HTTP(S) GET
     <li> provides the familiar and known libcurl API
     <li> targets RTOSes and systems "too small to run regular Linux"
-    <li> provides ports to RTOSes that "real curl" don't support: FreeRTOS and Micrium so far
+    <li> provides ports to RTOSes that "real curl" do not support: FreeRTOS and Micrium so far
     <li> GPLv3 licensed
   </ul>
 

--- a/windows/_microsoft.html
+++ b/windows/_microsoft.html
@@ -68,7 +68,7 @@ SUBTITLE(A Powershell alias)
  The curl tool comes installed <i>in addition to</i> the
  dreaded <a href="https://daniel.haxx.se/blog/2016/08/19/removing-the-powershell-curl-alias/">curl
  alias</a> that plagues Powershell users since it is an alias that runs the
- invoke-webrequest command and therefore isn't acting much like curl at all.
+ invoke-webrequest command and therefore is not acting much like curl at all.
 <p>
  A work-around is to invoke curl as "curl.exe" to prevent powershell from
  treating it as an alias.


### PR DESCRIPTION
- remove contractions
- write "hostname" and "website" per project standard
- and some more