### PR TITLE
links: update the "file a bug" links to include the docs template

### DIFF
--- a/docs/_manpage.html
+++ b/docs/_manpage.html
@@ -20,7 +20,7 @@ TITLE(curl.1 the manpage)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="faq.html">FAQ</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=curl.1%20problem&amp;labels=documentation" target="_new">File a bug about this manpage</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=curl%20manpage:&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this manpage</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
 <br><a href="tutorial.html">Tutorial</a>
 <br><a href="optionswhen.html">When options were added</a>

--- a/libcurl/c/_CURLINFO_template.html
+++ b/libcurl/c/_CURLINFO_template.html
@@ -24,7 +24,7 @@ TITLE(@template@ explained)
 <br><a href="easy_getinfo_options.html">info options</a>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template%20man%20page:@&amp;labels=documentation" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View manpage source</a>
 </div>
 

--- a/libcurl/c/_CURLMOPT_template.html
+++ b/libcurl/c/_CURLMOPT_template.html
@@ -23,7 +23,7 @@ TITLE(@template@ explained)
 <b>Related:</b>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template%20man%20page:@&amp;labels=documentation" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View manpage source</a>
 </div>
 

--- a/libcurl/c/_CURLOPT_template.html
+++ b/libcurl/c/_CURLOPT_template.html
@@ -24,7 +24,7 @@ TITLE(@template@ explained)
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20man%20page:&amp;labels=documentation" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View manpage source</a>
 </div>
 

--- a/libcurl/c/_CURLSHOPT_template.html
+++ b/libcurl/c/_CURLSHOPT_template.html
@@ -25,7 +25,7 @@ TITLE(@template@ explained)
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="curl_share_setopt.html">share options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20man%20page:&amp;labels=documentation" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View manpage source</a>
 </div>
 

--- a/libcurl/c/_curl_easy_cleanup.html
+++ b/libcurl/c/_curl_easy_cleanup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_cleanup.md
-#define BUG_TITLE curl_easy_cleanup%20man%20page:
+#define BUG_TITLE curl_easy_cleanup%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_CLEANUP

--- a/libcurl/c/_curl_easy_duphandle.html
+++ b/libcurl/c/_curl_easy_duphandle.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_duphandle.md
-#define BUG_TITLE curl_easy_duphandle%20man%20page:
+#define BUG_TITLE curl_easy_duphandle%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_DUPHANDLE

--- a/libcurl/c/_curl_easy_escape.html
+++ b/libcurl/c/_curl_easy_escape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_escape.md
-#define BUG_TITLE curl_easy_escape%20man%20page:
+#define BUG_TITLE curl_easy_escape%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_ESCAPE

--- a/libcurl/c/_curl_easy_getinfo.html
+++ b/libcurl/c/_curl_easy_getinfo.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_getinfo.md
-#define BUG_TITLE curl_easy_getinfo%20man%20page:
+#define BUG_TITLE curl_easy_getinfo%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_GETINFO

--- a/libcurl/c/_curl_easy_header.html
+++ b/libcurl/c/_curl_easy_header.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_header.md
-#define BUG_TITLE curl_easy_header%20man%20page:
+#define BUG_TITLE curl_easy_header%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_easy_init.html
+++ b/libcurl/c/_curl_easy_init.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_init.md
-#define BUG_TITLE curl_easy_init%20man%20page:
+#define BUG_TITLE curl_easy_init%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_INIT

--- a/libcurl/c/_curl_easy_nextheader.html
+++ b/libcurl/c/_curl_easy_nextheader.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_nextheader.md
-#define BUG_TITLE curl_easy_nextheader%20man%20page:
+#define BUG_TITLE curl_easy_nextheader%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_easy_option_by_id.html
+++ b/libcurl/c/_curl_easy_option_by_id.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_by_id.md
-#define BUG_TITLE curl_easy_option_by_id%20man%20page:
+#define BUG_TITLE curl_easy_option_by_id%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_option_by_name.html
+++ b/libcurl/c/_curl_easy_option_by_name.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_by_name.md
-#define BUG_TITLE curl_easy_option_by_name%20man%20page:
+#define BUG_TITLE curl_easy_option_by_name%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_option_next.html
+++ b/libcurl/c/_curl_easy_option_next.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_next.md
-#define BUG_TITLE curl_easy_option_next%20man%20page:
+#define BUG_TITLE curl_easy_option_next%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_pause.html
+++ b/libcurl/c/_curl_easy_pause.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_pause.md
-#define BUG_TITLE curl_easy_pause%20man%20page:
+#define BUG_TITLE curl_easy_pause%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_PAUSE

--- a/libcurl/c/_curl_easy_perform.html
+++ b/libcurl/c/_curl_easy_perform.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_perform.md
-#define BUG_TITLE curl_easy_perform%20man%20page:
+#define BUG_TITLE curl_easy_perform%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_PERFORM

--- a/libcurl/c/_curl_easy_recv.html
+++ b/libcurl/c/_curl_easy_recv.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_recv.md
-#define BUG_TITLE curl_easy_recv%20man%20page:
+#define BUG_TITLE curl_easy_recv%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_RECV

--- a/libcurl/c/_curl_easy_reset.html
+++ b/libcurl/c/_curl_easy_reset.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_reset.md
-#define BUG_TITLE curl_easy_reset%20man%20page:
+#define BUG_TITLE curl_easy_reset%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_RESET

--- a/libcurl/c/_curl_easy_send.html
+++ b/libcurl/c/_curl_easy_send.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_send.md
-#define BUG_TITLE curl_easy_send%20man%20page:
+#define BUG_TITLE curl_easy_send%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SEND

--- a/libcurl/c/_curl_easy_setopt.html
+++ b/libcurl/c/_curl_easy_setopt.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_setopt.md
-#define BUG_TITLE curl_easy_setopt%20man%20page:
+#define BUG_TITLE curl_easy_setopt%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SETOPT

--- a/libcurl/c/_curl_easy_strerror.html
+++ b/libcurl/c/_curl_easy_strerror.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_strerror.md
-#define BUG_TITLE curl_easy_strerror%20man%20page:
+#define BUG_TITLE curl_easy_strerror%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_STRERROR

--- a/libcurl/c/_curl_easy_unescape.html
+++ b/libcurl/c/_curl_easy_unescape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_unescape.md
-#define BUG_TITLE curl_easy_unescape%20man%20page:
+#define BUG_TITLE curl_easy_unescape%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_UNESCAPE

--- a/libcurl/c/_curl_easy_upkeep.html
+++ b/libcurl/c/_curl_easy_upkeep.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_upkeep.md
-#define BUG_TITLE curl_easy_upkeep%20man%20page:
+#define BUG_TITLE curl_easy_upkeep%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_UPKEEP

--- a/libcurl/c/_curl_escape.html
+++ b/libcurl/c/_curl_escape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_escape.md
-#define BUG_TITLE curl_escape%20man%20page:
+#define BUG_TITLE curl_escape%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_ESCAPE

--- a/libcurl/c/_curl_formadd.html
+++ b/libcurl/c/_curl_formadd.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_formadd.md
-#define BUG_TITLE curl_formadd%20man%20page:
+#define BUG_TITLE curl_formadd%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FORMADD

--- a/libcurl/c/_curl_formfree.html
+++ b/libcurl/c/_curl_formfree.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_formfree.md
-#define BUG_TITLE curl_formfree%20man%20page:
+#define BUG_TITLE curl_formfree%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FORMFREE

--- a/libcurl/c/_curl_formget.html
+++ b/libcurl/c/_curl_formget.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_formget.md
-#define BUG_TITLE curl_formget%20man%20page:
+#define BUG_TITLE curl_formget%20manpage:
 #define LIBCURL_DOCS
 #define DOCS_FORMGET
 #define CURL_URL libcurl/c/curl_formget.html

--- a/libcurl/c/_curl_free.html
+++ b/libcurl/c/_curl_free.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_free.md
-#define BUG_TITLE curl_free%20man%20page:
+#define BUG_TITLE curl_free%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FREE

--- a/libcurl/c/_curl_getdate.html
+++ b/libcurl/c/_curl_getdate.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_getdate.md
-#define BUG_TITLE curl_getdate%20man%20page:
+#define BUG_TITLE curl_getdate%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_GETDATE

--- a/libcurl/c/_curl_getenv.html
+++ b/libcurl/c/_curl_getenv.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_getenv.md
-#define BUG_TITLE curl_getenv%20man%20page:
+#define BUG_TITLE curl_getenv%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_GETENV

--- a/libcurl/c/_curl_global_cleanup.html
+++ b/libcurl/c/_curl_global_cleanup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_global_cleanup.md
-#define BUG_TITLE curl_global_cleanup%20man%20page:
+#define BUG_TITLE curl_global_cleanup%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_GLOBAL_CLEANUP

--- a/libcurl/c/_curl_global_init.html
+++ b/libcurl/c/_curl_global_init.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_global_init.md
-#define BUG_TITLE curl_global_init%20man%20page:
+#define BUG_TITLE curl_global_init%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_GLOBAL_INIT

--- a/libcurl/c/_curl_global_init_mem.html
+++ b/libcurl/c/_curl_global_init_mem.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_global_init_mem.md
-#define BUG_TITLE curl_global_init_mem%20man%20page:
+#define BUG_TITLE curl_global_init_mem%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_GLOBAL_INIT_MEM

--- a/libcurl/c/_curl_global_sslset.html
+++ b/libcurl/c/_curl_global_sslset.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_global_sslset.md
-#define BUG_TITLE curl_global_sslset%20man%20page:
+#define BUG_TITLE curl_global_sslset%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_GLOBAL_SSLSET

--- a/libcurl/c/_curl_global_trace.html
+++ b/libcurl/c/_curl_global_trace.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_global_trace.md
-#define BUG_TITLE curl_global_trace%20man%20page:
+#define BUG_TITLE curl_global_trace%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_GLOBAL_TRACE

--- a/libcurl/c/_curl_mime_addpart.html
+++ b/libcurl/c/_curl_mime_addpart.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_addpart.md
-#define BUG_TITLE curl_mime_addpart%20man%20page:
+#define BUG_TITLE curl_mime_addpart%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_ADDPART

--- a/libcurl/c/_curl_mime_data.html
+++ b/libcurl/c/_curl_mime_data.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_data.md
-#define BUG_TITLE curl_mime_data%20man%20page:
+#define BUG_TITLE curl_mime_data%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_DATA

--- a/libcurl/c/_curl_mime_data_cb.html
+++ b/libcurl/c/_curl_mime_data_cb.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_data_cb.md
-#define BUG_TITLE curl_mime_data_cb%20man%20page:
+#define BUG_TITLE curl_mime_data_cb%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_DATA_CB

--- a/libcurl/c/_curl_mime_encoder.html
+++ b/libcurl/c/_curl_mime_encoder.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_encoder.md
-#define BUG_TITLE curl_mime_encoder%20man%20page:
+#define BUG_TITLE curl_mime_encoder%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_ENCODER

--- a/libcurl/c/_curl_mime_filedata.html
+++ b/libcurl/c/_curl_mime_filedata.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_filedata.md
-#define BUG_TITLE curl_mime_filedata%20man%20page:
+#define BUG_TITLE curl_mime_filedata%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_FILEDATA

--- a/libcurl/c/_curl_mime_filename.html
+++ b/libcurl/c/_curl_mime_filename.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_filename.md
-#define BUG_TITLE curl_mime_filename%20man%20page:
+#define BUG_TITLE curl_mime_filename%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_FILENAME

--- a/libcurl/c/_curl_mime_free.html
+++ b/libcurl/c/_curl_mime_free.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_free.md
-#define BUG_TITLE curl_mime_free%20man%20page:
+#define BUG_TITLE curl_mime_free%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_FREE

--- a/libcurl/c/_curl_mime_headers.html
+++ b/libcurl/c/_curl_mime_headers.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_headers.md
-#define BUG_TITLE curl_mime_headers%20man%20page:
+#define BUG_TITLE curl_mime_headers%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_HEADERS

--- a/libcurl/c/_curl_mime_init.html
+++ b/libcurl/c/_curl_mime_init.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_init.md
-#define BUG_TITLE curl_mime_init%20man%20page:
+#define BUG_TITLE curl_mime_init%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_INIT

--- a/libcurl/c/_curl_mime_name.html
+++ b/libcurl/c/_curl_mime_name.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_name.md
-#define BUG_TITLE curl_mime_name%20man%20page:
+#define BUG_TITLE curl_mime_name%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_NAME

--- a/libcurl/c/_curl_mime_subparts.html
+++ b/libcurl/c/_curl_mime_subparts.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_subparts.md
-#define BUG_TITLE curl_mime_subparts%20man%20page:
+#define BUG_TITLE curl_mime_subparts%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_SUBPARTS

--- a/libcurl/c/_curl_mime_type.html
+++ b/libcurl/c/_curl_mime_type.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mime_type.md
-#define BUG_TITLE curl_mime_type%20man%20page:
+#define BUG_TITLE curl_mime_type%20manpage:
 #define MENU_MIME
 #define LIBCURL_DOCS
 #define DOCS_MIME_TYPE

--- a/libcurl/c/_curl_mprintf.html
+++ b/libcurl/c/_curl_mprintf.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_mprintf.md
-#define BUG_TITLE curl_mprintf%20man%20page:
+#define BUG_TITLE curl_mprintf%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_MPRINTF

--- a/libcurl/c/_curl_multi_add_handle.html
+++ b/libcurl/c/_curl_multi_add_handle.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_add_handle.md
-#define BUG_TITLE curl_multi_add_handle%20man%20page:
+#define BUG_TITLE curl_multi_add_handle%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_ADD_HANDLE

--- a/libcurl/c/_curl_multi_assign.html
+++ b/libcurl/c/_curl_multi_assign.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_assign.md
-#define BUG_TITLE curl_multi_assign%20man%20page:
+#define BUG_TITLE curl_multi_assign%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_ASSIGN

--- a/libcurl/c/_curl_multi_cleanup.html
+++ b/libcurl/c/_curl_multi_cleanup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_cleanup.md
-#define BUG_TITLE curl_multi_cleanup%20man%20page:
+#define BUG_TITLE curl_multi_cleanup%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_CLEANUP

--- a/libcurl/c/_curl_multi_fdset.html
+++ b/libcurl/c/_curl_multi_fdset.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_fdset.md
-#define BUG_TITLE curl_multi_fdset%20man%20page:
+#define BUG_TITLE curl_multi_fdset%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_FDSET

--- a/libcurl/c/_curl_multi_get_handles.html
+++ b/libcurl/c/_curl_multi_get_handles.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_get_handles.md
-#define BUG_TITLE curl_multi_get_handles%20man%20page:
+#define BUG_TITLE curl_multi_get_handles%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_GET_HANDLES

--- a/libcurl/c/_curl_multi_info_read.html
+++ b/libcurl/c/_curl_multi_info_read.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_info_read.md
-#define BUG_TITLE curl_multi_info_read%20man%20page:
+#define BUG_TITLE curl_multi_info_read%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_INFO_READ

--- a/libcurl/c/_curl_multi_init.html
+++ b/libcurl/c/_curl_multi_init.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_init.md
-#define BUG_TITLE curl_multi_init%20man%20page:
+#define BUG_TITLE curl_multi_init%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_INIT

--- a/libcurl/c/_curl_multi_perform.html
+++ b/libcurl/c/_curl_multi_perform.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_perform.md
-#define BUG_TITLE curl_multi_perform%20man%20page:
+#define BUG_TITLE curl_multi_perform%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_PERFORM

--- a/libcurl/c/_curl_multi_poll.html
+++ b/libcurl/c/_curl_multi_poll.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_poll.md
-#define BUG_TITLE curl_multi_poll%20man%20page:
+#define BUG_TITLE curl_multi_poll%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_POLL

--- a/libcurl/c/_curl_multi_remove_handle.html
+++ b/libcurl/c/_curl_multi_remove_handle.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_remove_handle.md
-#define BUG_TITLE curl_multi_remove_handle%20man%20page:
+#define BUG_TITLE curl_multi_remove_handle%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_REMOVE_HANDLE

--- a/libcurl/c/_curl_multi_setopt.html
+++ b/libcurl/c/_curl_multi_setopt.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_setopt.md
-#define BUG_TITLE curl_multi_setopt%20man%20page:
+#define BUG_TITLE curl_multi_setopt%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_SETOPT

--- a/libcurl/c/_curl_multi_socket.html
+++ b/libcurl/c/_curl_multi_socket.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_socket.md
-#define BUG_TITLE curl_multi_socket%20man%20page:
+#define BUG_TITLE curl_multi_socket%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_SOCKET

--- a/libcurl/c/_curl_multi_socket_action.html
+++ b/libcurl/c/_curl_multi_socket_action.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_socket_action.md
-#define BUG_TITLE curl_multi_socket_action%20man%20page:
+#define BUG_TITLE curl_multi_socket_action%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_SOCKET_ACTION

--- a/libcurl/c/_curl_multi_socket_all.html
+++ b/libcurl/c/_curl_multi_socket_all.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_socket_all.md
-#define BUG_TITLE curl_multi_socket_all%20man%20page:
+#define BUG_TITLE curl_multi_socket_all%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_SOCKET_ALL

--- a/libcurl/c/_curl_multi_strerror.html
+++ b/libcurl/c/_curl_multi_strerror.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_strerror.md
-#define BUG_TITLE curl_multi_strerror%20man%20page:
+#define BUG_TITLE curl_multi_strerror%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_STRERROR

--- a/libcurl/c/_curl_multi_timeout.html
+++ b/libcurl/c/_curl_multi_timeout.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_timeout.md
-#define BUG_TITLE curl_multi_timeout%20man%20page:
+#define BUG_TITLE curl_multi_timeout%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_TIMEOUT

--- a/libcurl/c/_curl_multi_wait.html
+++ b/libcurl/c/_curl_multi_wait.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_wait.md
-#define BUG_TITLE curl_multi_wait%20man%20page:
+#define BUG_TITLE curl_multi_wait%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_WAIT

--- a/libcurl/c/_curl_multi_waitfds.html
+++ b/libcurl/c/_curl_multi_waitfds.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_waitfds.md
-#define BUG_TITLE curl_multi_waitfds%20man%20page:
+#define BUG_TITLE curl_multi_waitfds%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_WAITFDS

--- a/libcurl/c/_curl_multi_wakeup.html
+++ b/libcurl/c/_curl_multi_wakeup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_multi_wakeup.md
-#define BUG_TITLE curl_multi_wakeup%20man%20page:
+#define BUG_TITLE curl_multi_wakeup%20manpage:
 #define MENU_MULTI
 #define LIBCURL_DOCS
 #define DOCS_MULTI_WAKEUP

--- a/libcurl/c/_curl_pushheader_byname.html
+++ b/libcurl/c/_curl_pushheader_byname.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_pushheader_byname.md
-#define BUG_TITLE curl_pushheader_byname%20man%20page:
+#define BUG_TITLE curl_pushheader_byname%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FREE

--- a/libcurl/c/_curl_pushheader_bynum.html
+++ b/libcurl/c/_curl_pushheader_bynum.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_pushheader_bynum.md
-#define BUG_TITLE curl_pushheader_bynum%20man%20page:
+#define BUG_TITLE curl_pushheader_bynum%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FREE

--- a/libcurl/c/_curl_share_cleanup.html
+++ b/libcurl/c/_curl_share_cleanup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_share_cleanup.md
-#define BUG_TITLE curl_share_cleanup%20man%20page:
+#define BUG_TITLE curl_share_cleanup%20manpage:
 #define MENU_SHARE
 #define LIBCURL_DOCS
 #define DOCS_SHARE_CLEANUP

--- a/libcurl/c/_curl_share_init.html
+++ b/libcurl/c/_curl_share_init.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_share_init.md
-#define BUG_TITLE curl_share_init%20man%20page:
+#define BUG_TITLE curl_share_init%20manpage:
 #define MENU_SHARE
 #define LIBCURL_DOCS
 #define DOCS_SHARE_INIT

--- a/libcurl/c/_curl_share_setopt.html
+++ b/libcurl/c/_curl_share_setopt.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_share_setopt.md
-#define BUG_TITLE curl_sahre_setopt%20man%20page:
+#define BUG_TITLE curl_sahre_setopt%20manpage:
 #define MENU_SHARE
 #define LIBCURL_DOCS
 #define DOCS_SHARE_SETOPT

--- a/libcurl/c/_curl_share_strerror.html
+++ b/libcurl/c/_curl_share_strerror.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_share_strerror.md
-#define BUG_TITLE curl_share_strerror%20man%20page:
+#define BUG_TITLE curl_share_strerror%20manpage:
 #define MENU_SHARE
 #define LIBCURL_DOCS
 #define DOCS_SHARE_STRERROR

--- a/libcurl/c/_curl_slist_append.html
+++ b/libcurl/c/_curl_slist_append.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_slist_append.md
-#define BUG_TITLE curl_slist_append%20man%20page:
+#define BUG_TITLE curl_slist_append%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_SLIST_APPEND

--- a/libcurl/c/_curl_slist_free_all.html
+++ b/libcurl/c/_curl_slist_free_all.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_slist_free_all.md
-#define BUG_TITLE curl_slist_free_all%20man%20page:
+#define BUG_TITLE curl_slist_free_all%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_SLIST_FREE_ALL

--- a/libcurl/c/_curl_strequal.html
+++ b/libcurl/c/_curl_strequal.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_strequal.md
-#define BUG_TITLE curl_strequal%20man%20page:
+#define BUG_TITLE curl_strequal%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_STREQUAL

--- a/libcurl/c/_curl_strnequal.html
+++ b/libcurl/c/_curl_strnequal.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_strequal.md
-#define BUG_TITLE curl_strequal%20man%20page:
+#define BUG_TITLE curl_strequal%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_STREQUAL

--- a/libcurl/c/_curl_unescape.html
+++ b/libcurl/c/_curl_unescape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_unescape.md
-#define BUG_TITLE curl_unescape%20man%20page:
+#define BUG_TITLE curl_unescape%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_UNESCAPE

--- a/libcurl/c/_curl_url.html
+++ b/libcurl/c/_curl_url.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_url.md
-#define BUG_TITLE curl_url%20man%20page:
+#define BUG_TITLE curl_url%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_url_cleanup.html
+++ b/libcurl/c/_curl_url_cleanup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_url_cleanup.md
-#define BUG_TITLE curl_url_cleanup%20man%20page:
+#define BUG_TITLE curl_url_cleanup%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_CLEANUP

--- a/libcurl/c/_curl_url_dup.html
+++ b/libcurl/c/_curl_url_dup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_url_dup.md
-#define BUG_TITLE curl_url_dup%20man%20page:
+#define BUG_TITLE curl_url_dup%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_DUP

--- a/libcurl/c/_curl_url_get.html
+++ b/libcurl/c/_curl_url_get.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_url_get.md
-#define BUG_TITLE curl_url_get%20man%20page:
+#define BUG_TITLE curl_url_get%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_url_set.html
+++ b/libcurl/c/_curl_url_set.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_url_set.md
-#define BUG_TITLE curl_url_set%20man%20page:
+#define BUG_TITLE curl_url_set%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_SET

--- a/libcurl/c/_curl_url_strerror.html
+++ b/libcurl/c/_curl_url_strerror.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_url_strerror.md
-#define BUG_TITLE curl_url_strerror%20man%20page:
+#define BUG_TITLE curl_url_strerror%20manpage:
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_version.html
+++ b/libcurl/c/_curl_version.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_version.md
-#define BUG_TITLE curl_version%20man%20page:
+#define BUG_TITLE curl_version%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_VERSION

--- a/libcurl/c/_curl_version_info.html
+++ b/libcurl/c/_curl_version_info.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_version_info.md
-#define BUG_TITLE curl_version_info%20man%20page:
+#define BUG_TITLE curl_version_info%20manpage:
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_VERSION_INFO

--- a/libcurl/c/_curl_ws_meta.html
+++ b/libcurl/c/_curl_ws_meta.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_ws_meta.md
-#define BUG_TITLE curl_ws_meta%20man%20page:
+#define BUG_TITLE curl_ws_meta%20manpage:
 #define MENU_WS
 #define LIBCURL_DOCS
 #define DOCS_WS_META

--- a/libcurl/c/_curl_ws_recv.html
+++ b/libcurl/c/_curl_ws_recv.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_ws_recv.md
-#define BUG_TITLE curl_ws_recv%20man%20page:
+#define BUG_TITLE curl_ws_recv%20manpage:
 #define MENU_WS
 #define LIBCURL_DOCS
 #define DOCS_WS_RECV

--- a/libcurl/c/_curl_ws_send.html
+++ b/libcurl/c/_curl_ws_send.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_ws_send.md
-#define BUG_TITLE curl_ws_send%20man%20page:
+#define BUG_TITLE curl_ws_send%20manpage:
 #define MENU_WS
 #define LIBCURL_DOCS
 #define DOCS_WS_SEND

--- a/libcurl/c/_example-templ.html
+++ b/libcurl/c/_example-templ.html
@@ -17,7 +17,7 @@ TITLE(%cfile%)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="allfuncs.html">All functions</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=%cfile%%20example&amp;labels=documentation" target="_new">File a bug</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=%cfile%%20example&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug</a>
 <br><a href="symbols-in-versions.html">Symbols</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/examples/%cfile%" target="_new">View in git</a>
 <br><a href="https://github.com/curl/curl/raw/master/docs/examples/%cfile%">View raw</a>

--- a/libcurl/c/libcurl-related.t
+++ b/libcurl/c/libcurl-related.t
@@ -4,6 +4,6 @@
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="symbols-in-versions.html">Symbols</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=BUG_TITLE&amp;labels=documentation" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=BUG_TITLE&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/RAW_FILE" target="_new">View manpage source</a>
 </div>


### PR DESCRIPTION
The previous links stopped working correctly at some point. They would still end up in the bug tracker but not with the title correctly filled in and the 'documentation' label set as intended.

This should bring back this feature.

Reported-by: James Abbatiello
Fixes #351