### PR TITLE
Spell check

### DIFF
--- a/docs/CVE-2024-6197.md
+++ b/docs/CVE-2024-6197.md
@@ -18,7 +18,7 @@ available chunks. This leads to the overwriting of nearby stack memory. The
 content of the overwrite is decided by the `free()` implementation; likely to
 be memory pointers and a set of flags.
 
-The most likely outcome of exploting this flaw is a crash, although it cannot
+The most likely outcome of exploiting this flaw is a crash, although it cannot
 be ruled out that more serious results can be had in special circumstances.
 
 INFO

--- a/docs/CVE-2024-6874.md
+++ b/docs/CVE-2024-6874.md
@@ -14,7 +14,7 @@ bytes, libcurl ends up reading outside of a stack based buffer when built to
 use the *macidn* IDN backend. The conversion function then fills up the
 provided buffer exactly - but does not null terminate the string.
 
-This flaw can lead to stack contents accidently getting returned as part of
+This flaw can lead to stack contents accidentally getting returned as part of
 the converted string.
 
 INFO


### PR DESCRIPTION
accidently to accidentally
exploting to exploiting 