### PR TITLE
thanks.gen: don't add an extra &middot; at the end

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -343,7 +343,7 @@ thanksnum.gen: $(DOCROOT)/THANKS
 	egrep '^[^ $$]' $< | wc -l  | awk '{print "#define __THANKSNUM__ " $$1}' > $@
 
 thanks.gen: $(DOCROOT)/THANKS
-	grep '^[^ ]' $< | sort | sed -e 's/ /\&nbsp;/g' -e 's/-/\&\#8209/g' | awk '{print $$0 "&nbsp;&middot; "; }' > $@
+	grep '^[^ ]' $< | sort | sed -e 's/ /\&nbsp;/g' -e 's/-/\&\#8209/g' -e '$$!s/$$/\&nbsp;\&middot;/' > $@
 
 faq.html: _faq.shtml $(MAINPARTS) faq.gen
 	$(ACTION)


### PR DESCRIPTION
curl/curl-www#187 version 2 :D

This is achieved by generating thanks.gen as

    user1
    &middot;
    user2
    &middot;
    user3

Instead of as

    user1&nbsp;&middot;
    user2&nbsp;&middot;
    user3&nbsp;&middot;

`&nbsp;` would add an unwanted extra (non-breaking) space, so I just removed it.
