### PR TITLE
windows: show -V output

### DIFF
--- a/windows/_index.html
+++ b/windows/_index.html
@@ -2,6 +2,7 @@
 <html>
 <head> <title>curl for Windows</title>
 #include "css.t"
+#include "term.t"
 <style type="text/css">
 a.windl {
   font-size: 200%;
@@ -90,12 +91,12 @@ DEP_TOOLS
 </ul>
 
 #ifdef CURL_WIN64_VERSION_1
-<pre style="white-space: pre-wrap; word-break: keep-all; color: #e0e080; font-size: 45%; background: #000000; padding: 8px 8px 8px 8px;">
-CURL_WIN64_VERSION_1
-CURL_WIN64_VERSION_2
-CURL_WIN64_VERSION_3
-CURL_WIN64_VERSION_4
-</pre>
+<div class="term">
+<div class="tline">CURL_WIN64_VERSION_1</div>
+<div class="tline">CURL_WIN64_VERSION_2</div>
+<div class="tline">CURL_WIN64_VERSION_3</div>
+<div class="tline">CURL_WIN64_VERSION_4</div>
+</div>
 #endif
 
 <p>

--- a/windows/_index.html
+++ b/windows/_index.html
@@ -90,7 +90,7 @@ DEP_TOOLS
 </ul>
 
 #ifdef CURL_WIN64_VERSION_1
-<pre style="white-space: pre-wrap; word-break: keep-all; color: #ffcc00; font-size: 45%; background: #0a0a0a; padding: 8px 8px 8px 8px;">
+<pre style="white-space: pre-wrap; word-break: keep-all; color: #e0e080; font-size: 45%; background: #000000; padding: 8px 8px 8px 8px;">
 CURL_WIN64_VERSION_1
 CURL_WIN64_VERSION_2
 CURL_WIN64_VERSION_3

--- a/windows/_index.html
+++ b/windows/_index.html
@@ -89,6 +89,15 @@ DEP_PKGS
 DEP_TOOLS
 </ul>
 
+#ifdef CURL_WIN64_VERSION_1
+<pre style="white-space: pre-wrap; word-break: keep-all; color: #ffcc00; font-size: 50%; background: #0a0a0a; padding: 8px 8px 8px 8px;">
+CURL_WIN64_VERSION_1
+CURL_WIN64_VERSION_2
+CURL_WIN64_VERSION_3
+CURL_WIN64_VERSION_4
+</pre>
+#endif
+
 <p>
  The <a href="BUILD_LOGURL">log from the build</a>.
 

--- a/windows/_index.html
+++ b/windows/_index.html
@@ -90,7 +90,7 @@ DEP_TOOLS
 </ul>
 
 #ifdef CURL_WIN64_VERSION_1
-<pre style="white-space: pre-wrap; word-break: keep-all; color: #ffcc00; font-size: 50%; background: #0a0a0a; padding: 8px 8px 8px 8px;">
+<pre style="white-space: pre-wrap; word-break: keep-all; color: #ffcc00; font-size: 45%; background: #0a0a0a; padding: 8px 8px 8px 8px;">
 CURL_WIN64_VERSION_1
 CURL_WIN64_VERSION_2
 CURL_WIN64_VERSION_3

--- a/windows/mkfiles.pl
+++ b/windows/mkfiles.pl
@@ -105,6 +105,17 @@ sub getlog {
     printf "#define BUILD_LOGURL %s\n", $l[0];
 }
 
+sub getcurlv {
+    my ($dir)=@_; # where the download files are
+    open(L, "$dir/curl-version-x86_64.txt") || return;
+    my @l = <L>;
+    close(L);
+    chomp $l[0]; printf "#define CURL_WIN64_VERSION_1 %s\n", $l[0];
+    chomp $l[1]; printf "#define CURL_WIN64_VERSION_2 %s\n", $l[1];
+    chomp $l[2]; printf "#define CURL_WIN64_VERSION_3 %s\n", $l[2];
+    chomp $l[3]; printf "#define CURL_WIN64_VERSION_4 %s\n", $l[3];
+}
+
 my $dl = latest();
 
 my @files = getdl($dl);
@@ -166,3 +177,5 @@ if($gen) {
 gethashes($dl);
 
 getlog($dl);
+
+getcurlv($dl);


### PR DESCRIPTION
It will be picked up from the next curl-for-win release.

Ref: https://github.com/curl/curl-for-win/commit/053daa195f2656cf297c7972a345ea16ef4cb1a1

---

![Screen Shot 2024-09-02 at curl-V-3](https://github.com/user-attachments/assets/d24abd47-465f-4632-ae36-6403b46cd2df)
