### PR TITLE
windows/microsoft: add padding to the "terminal lines"

### DIFF
--- a/windows/Makefile
+++ b/windows/Makefile
@@ -13,7 +13,7 @@ all: $(PAGES)
 index.html: _index.html $(MAINPARTS) files.gen
 	$(ACTION)
 
-microsoft.html: _microsoft.html $(MAINPARTS)
+microsoft.html: _microsoft.html $(MAINPARTS) term.t
 	$(ACTION)
 
 files.gen: mkfiles.pl latest.txt

--- a/windows/_microsoft.html
+++ b/windows/_microsoft.html
@@ -2,8 +2,10 @@
 <html>
 <head> <title>curl shipped by Microsoft</title>
 #include "css.t"
+#include "term.t"
+</head>
 
- #define CURL_URL /windows/microsoft.html
+#define CURL_URL /windows/microsoft.html
 #define WINDOWS_MS
 
 #include "_menu.html"
@@ -36,12 +38,12 @@ SUBTITLE(Windows 10/11 bundle curl)
  Invoking curl -V after the <b>June 2024</b> update shows this on these
  platforms:
 <p>
-<pre style="white-space: pre-wrap; word-break: keep-all; color: #e0e080; background: #000000; padding: 8px 8px 8px 8px;">
-curl 8.7.1 (Windows) libcurl/8.7.1 Schannel zlib/1.3 WinIDN
-Release-Date: 2024-03-27
-Protocols: dict file ftp ftps http https imap imaps ipfs ipns mqtt pop3 pop3s smb smbs smtp smtps telnet tftp
-Features: alt-svc AsynchDNS HSTS HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM SPNEGO SSL SSPI threadsafe Unicode UnixSockets
-</pre>
+<div class="term">
+<div class="tline">curl 8.7.1 (Windows) libcurl/8.7.1 Schannel zlib/1.3 WinIDN</div>
+<div class="tline">Release-Date: 2024-03-27</div>
+<div class="tline">Protocols: dict file ftp ftps http https imap imaps ipfs ipns mqtt pop3 pop3s smb smbs smtp smtps telnet tftp</div>
+<div class="tline">Features: alt-svc AsynchDNS HSTS HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM SPNEGO SSL SSPI threadsafe Unicode UnixSockets</div>
+</div>
 
 SUBTITLE(Disabled features)
 <p>

--- a/windows/term.css
+++ b/windows/term.css
@@ -1,0 +1,9 @@
+.tline {
+    padding-bottom: 8px;
+    font-family: monospace;
+}
+.term {
+    color: #e0e080;
+    background: #000000;
+    padding: 8px 8px 0px 8px;
+}

--- a/windows/term.t
+++ b/windows/term.t
@@ -1,0 +1,1 @@
+<link rel="stylesheet" type="text/css" href="term.css">


### PR DESCRIPTION
To make them easier to read.

Makes it look like this:

![Screenshot 2024-09-02 at 17-02-12 curl shipped by Microsoft](https://github.com/user-attachments/assets/dec03044-f50b-486d-9826-4599daf7069f)
