### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/badwords.yml
+++ b/.github/workflows/badwords.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    - uses: actions/checkout@v4
 
     - name: check
       run: ./.github/scripts/badwords.pl -w ./.github/scripts/badwords.ok < .github/scripts/badwords.txt docs/*.md '*html'

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: install prereqs
       run: sudo apt-get install pandoc libcgi-pm-perl

--- a/.github/workflows/perlcheck.yml
+++ b/.github/workflows/perlcheck.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: install prereqs
       run: sudo apt-get install libcgi-pm-perl libstring-crc32-perl

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -29,7 +29,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: strip "uncheckable" sections from .md pages
       run: find docs -name "*.md" | xargs -t -n1 ./.github/scripts/cleanspell.pl


### PR DESCRIPTION
Fixes deprecation warnings.

`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.`
`The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v2.`