### PR TITLE
wcurl/_index.html: Use link to latest release to install it

### DIFF
--- a/wcurl/_index.html
+++ b/wcurl/_index.html
@@ -28,8 +28,14 @@ defaults; using curl under the hood.
 
 SUBTITLE(Download)
 <pre style="white-space: pre-wrap; word-break: keep-all; color: #e0e080; background: #000000; padding: 8px 8px 8px 8px;">
-$ curl -fLO https://raw.githubusercontent.com/curl/wcurl/main/wcurl
+$ curl -fLO https://github.com/curl/wcurl/releases/latest/download/wcurl
 $ chmod +x wcurl
+</pre>
+
+SUBTITLE(Download manpage)
+<pre style="white-space: pre-wrap; word-break: keep-all; color: #e0e080; background: #000000; padding: 8px 8px 8px 8px;">
+$ curl -fLO https://github.com/curl/wcurl/releases/latest/download/wcurl.1
+$ sudo mv wcurl.1 /usr/share/man/man1/wcurl.1
 </pre>
 
 SUBTITLE(Pronunciation)


### PR DESCRIPTION
 And add instructions to install manpage.

 https://github.com/curl/wcurl/issues/21