### PR TITLE
CVE-2017-7407.md: modified fix commit

### DIFF
--- a/docs/CVE-2017-7407.md
+++ b/docs/CVE-2017-7407.md
@@ -44,7 +44,7 @@ This flaw exists in the following curl versions.
 
 - Affected versions: curl 6.5 to and including 7.53.1
 - Not affected versions: curl < 6.5 and >= 7.54.0
-- Introduced-in: https://github.com/curl/curl/commit/90030a49c7facfefeca8
+- Introduced-in: https://github.com/curl/curl/commit/d073ec0a719bfad2
 
 SOLUTION
 ------------


### PR DESCRIPTION
It looks like this advisory listed the wrong commit hash for the introduction of this bug. It does not change the version range.

URL: https://curl.se/mail/lib-2024-12/0024.html