### PR TITLE
CVE-2024-11053.md: add follow-up patch

### DIFF
--- a/docs/CVE-2024-11053.md
+++ b/docs/CVE-2024-11053.md
@@ -56,7 +56,8 @@ libcurl is used by many applications, but not always advertised as such!
 SOLUTION
 ------------
 
-- Fixed-in: https://github.com/curl/curl/commit/e9b9bbac22c26cf6731
+- Fixed-in: https://github.com/curl/curl/commit/e9b9bbac22c26cf6731 and
+  https://github.com/curl/curl/commit/9fce2c55d4b0273ac99b59bd8cb982a6d96b88cf
 
 The fix also addresses a few other .netrc related issues.
 


### PR DESCRIPTION
The first patch introduced a regression that is fixed in the second.