### PR TITLE
CVE-2024-11053.md: update fixes

### DIFF
--- a/docs/CVE-2024-11053.md
+++ b/docs/CVE-2024-11053.md
@@ -71,7 +71,7 @@ preference:
  A - Upgrade curl and libcurl to 8.12.0 or later.
 
  B - Upgrade curl and libcurl to version 8.11.1 and apply the second patch
-     9fce2c5.
+     via `git cherry-pick 9fce2c5`.
 
  C - Apply both patches to your version and rebuild.
 

--- a/docs/CVE-2024-11053.md
+++ b/docs/CVE-2024-11053.md
@@ -60,7 +60,7 @@ SOLUTION
 - Also-apply: https://github.com/curl/curl/commit/9fce2c55d4b0273ac99
 
 The fix also addresses a few other .netrc related issues. The fix caused a
-regression that was fixed by the second commit 9fce2c5.
+regression that was fixed by the second commit `9fce2c5`.
 
 RECOMMENDATIONS
 ---------------

--- a/docs/CVE-2024-11053.md
+++ b/docs/CVE-2024-11053.md
@@ -57,8 +57,10 @@ SOLUTION
 ------------
 
 - Fixed-in: https://github.com/curl/curl/commit/e9b9bbac22c26cf6731
+- Also-apply: https://github.com/curl/curl/commit/9fce2c55d4b0273ac99
 
-The fix also addresses a few other .netrc related issues.
+The fix also addresses a few other .netrc related issues. The fix caused a
+regression that was fixed by the second commit 9fce2c5.
 
 RECOMMENDATIONS
 ---------------
@@ -68,7 +70,7 @@ preference:
 
  A - Upgrade curl and libcurl to version 8.11.1
 
- B - Apply the patch to your version and rebuild
+ B - Apply the patches to your version and rebuild
 
  C - Avoid using netrc together with redirects
 

--- a/docs/CVE-2024-11053.md
+++ b/docs/CVE-2024-11053.md
@@ -68,11 +68,14 @@ RECOMMENDATIONS
 We suggest you take one of the following actions immediately, in order of
 preference:
 
- A - Upgrade curl and libcurl to version 8.11.1
+ A - Upgrade curl and libcurl to 8.12.0 or later.
 
- B - Apply the patches to your version and rebuild
+ B - Upgrade curl and libcurl to version 8.11.1 and apply the second patch
+     9fce2c5.
 
- C - Avoid using netrc together with redirects
+ C - Apply both patches to your version and rebuild.
+
+ D - Avoid using netrc together with redirects.
 
 TIMELINE
 ---------


### PR DESCRIPTION
- Mention that the fix for this CVE, curl/curl@e9b9bba, caused a regression that was fixed by curl/curl@9fce2c5.

Bug: https://github.com/curl/curl/issues/15767#issuecomment-2638547551
Reported-by: Dan Fandrich

Closes #xxxxx