### PR TITLE
changes: adjust release date for 0.3

### DIFF
--- a/_changes.html
+++ b/_changes.html
@@ -15404,7 +15404,7 @@ THISBOX(1.0)
   The changes for httpget 1.0 have been lost.
 
 <a name="0_3"></a>
-SUBTITLE(Fixed in 0.3 - January 1 1997)
+SUBTITLE(Fixed in 0.3 - February 1 1997)
 THISBOX(0.3)
 <p>
   The changes for httpget 0.3 release have been lost.


### PR DESCRIPTION
The previous estimate (1 Jan 1997) is most likely wrong. Kjell Ericson found an email from me to him dated January 17, 1997 in which I email him a copy of httpget 0.2. It seems reasonable to assume that I would have emailed him the latest version at the time, so therfore 0.3 cannot have been released until *after* January 17.

Hence, I move the estimated release date forward one month.