### PR TITLE
comparison-table: add client cert for aria2c

### DIFF
--- a/docs/_comparison-table.html
+++ b/docs/_comparison-table.html
@@ -150,7 +150,7 @@ TITLE(Compare curl with other download tools)
   FEAT( TFTP )                   YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( Tiny Executable )        no___ no___ no___ YES__ no___ no___ no___ no___ no___ ENDLINE
   FEAT( TLS: BearSSL )           YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
-  FEAT( TLS: Client certs )      YES__ YES__ YES__ no___ no___ no___ no___ no___ YES__ ENDLINE
+  FEAT( TLS: Client certs )      YES__ YES__ YES__ no___ no___ YES__ no___ no___ YES__ ENDLINE
   FEAT( TLS: GnuTLS )            YES__ YES__ YES__ no___ YES__ YES__ no___ YES_P no___ ENDLINE
   FEAT( TLS: mbedTLS )           YES__ no___ no___ no___ no___ no___ no___ no___ no___ ENDLINE
   FEAT( TLS: OpenSSL )           YES__ YES__ no___ YES__ YES__ YES__ YES__ YES__ YES__ ENDLINE


### PR DESCRIPTION
Ref: https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-certificate

Reported-by: Vulpes Vulpes
Fixes #426