### PR TITLE
changes: move the bugfixes from 6.1 beta into 6.1

### DIFF
--- a/_changes.html
+++ b/_changes.html
@@ -14395,12 +14395,6 @@ VULNBOX(6.1)
  BGF #include zlib.h fixes
  BGF adjusted the maketgz script to reduce reruns of the configure when
       building
-</ul>
-
-<a name="6_1beta"></a>
-SUBTITLE(Fixed in 6.1 beta)
-<p> Bugfixes:
-<ul class="bugfixes">
  BGF -d now can get data from a file or stdin
  BGF HTTP: "Accept-Encoding: gzip,compress,deflate" - experiments
  BGF Misc: Multiple URL download capacity


### PR DESCRIPTION
... as we don't consider the beta a "real" release in most other places

This way, the release count matches.