### PR TITLE
docs/vuln2json.pl: add "affects" within database_specific

### DIFF
--- a/docs/vuln2json.pl
+++ b/docs/vuln2json.pl
@@ -187,6 +187,7 @@ for(@vuln) {
         "  \"modified\": \"$modified\",\n".
         "  \"database_specific\": {\n".
         "    \"package\": \"curl\",\n".
+        "    \"affects\": \"$part\",\n".
         "    \"URL\": \"https://curl.se/docs/$cve.json\",\n".
         "    \"www\": \"https://curl.se/docs/$cve.html\",\n".
         $jissue.


### PR DESCRIPTION
The "affects" key specifies "both", "lib" or "tool" to specify what the CVE in quetion affects.

Ref: https://github.com/curl/curl/discussions/16967