### PR TITLE
Update rc’s _index.html for typos

### DIFF
--- a/rc/_index.html
+++ b/rc/_index.html
@@ -10,7 +10,7 @@
 #include "setup.t"
 #include "release.t"
 
-WHERE2(Download, "/download.html", relase candidates)
+WHERE2(Download, "/download.html", release candidates)
 
 TITLE(curl release candidates)
 <div class="relatedbox">
@@ -59,7 +59,7 @@ SUBTITLE(Release cycle)
 
 <p>
   <ul>
-    <li> rc1 comes the day the feature release starts, 25 days before release
+    <li> rc1 comes the day the feature freeze starts, 25 days before release
     <li> rc2 comes nine days after rc1, 16 days before release
     <li> rc3 comes nine days after rc2, 7 days before release
   </ul>


### PR DESCRIPTION
fixes for what I think are “typos” after browsing from https://mastodon.social/@bagder/114434508745355021. unbuilt and untested, sorry.