### PR TITLE
windows: fix and add link and set attribute

### DIFF
--- a/windows/_microsoft.html
+++ b/windows/_microsoft.html
@@ -25,7 +25,7 @@ TITLE(curl shipped by Microsoft)
 
 <p>
  On December 19
- 2017, <a href="https://docs.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows">Microsoft
+ 2017, <a target="_blank" rel="external" href="https://techcommunity.microsoft.com/blog/containers/tar-and-curl-come-to-windows/382409">Microsoft
  announced</a> that since insider build 17063 of Windows 10, curl is a default
  component.
 
@@ -62,6 +62,9 @@ SUBTITLE(Separate)
  enabled and disabled compared to the <a href="/windows/">Windows builds</a>
  offered by the curl project. They do however build curl from the same source
  code. If you have problems with their curl version, report that to them.
+ See <a target="_blank" rel="external" 
+  href="https://support.microsoft.com/en-us/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332">
+  Microsoft Feedback Hub</a> from more information.
 <p>
  You can probably assume that the curl packages from Microsoft will always lag
  behind the versions provided by the curl project itself.
@@ -69,7 +72,8 @@ SUBTITLE(Separate)
 SUBTITLE(A Powershell alias)
 <p>
  The curl tool comes installed <i>in addition to</i> the
- dreaded <a href="https://daniel.haxx.se/blog/2016/08/19/removing-the-powershell-curl-alias/">curl
+ dreaded <a target="_blank" rel="author" 
+          href="https://daniel.haxx.se/blog/2016/08/19/removing-the-powershell-curl-alias/">curl
  alias</a> that plagues Powershell users since it is an alias that runs the
  invoke-webrequest command and therefore is not acting much like curl at all.
 <p>


### PR DESCRIPTION
Repaired broken link to Microsoft announcement, adding attributes `rel` and `target` to tag. Added new link to Microsoft Feedback Hub for reporting issues to Microsoft. Set additional link attributes for outside domains accordingly.