### PR TITLE
curlopt2href: make sure version numbers end with digit

### DIFF
--- a/libcurl/c/curlopt2href.pl
+++ b/libcurl/c/curlopt2href.pl
@@ -16,7 +16,7 @@ while(<STDIN>) {
     $_ =~ s/([^\">\/]|^)(curl_(url|ws|pushheader|global|version|slist|share|mime|easy|curl|multi)_[a-z_]*)(\()/$1<a href="$2.html">$2<\/a>$4/g;
     $_ =~ s/([^\">\/]|^)(curl_(url|getenv|strequal|strnequal|getdate|formfree|formadd|formget|free|escape|unescape|version|mprintf))(\()/$1<a href="$2.html">$2<\/a>$4/g;
     $_ =~ s/([^\">\/]|^)(curl_(mfprintf|msprintf|msnprintf|mvprintf|mvfprintf|mvsprintf|mvsnprintf|maprintf|mvaprintf))(\()/$1<a href="curl_mprintf.html">$2<\/a>$4/g;
-    $_ =~ s/([78]\.\d+[.0-9]*)/<a href="\/ch\/$1.html">$1<\/a>$2/g;
+    $_ =~ s/([78]\.\d+[.0-9]*[0-9])/<a href="\/ch\/$1.html">$1<\/a>$2/g;
     print $_;
 }
 


### PR DESCRIPTION
To make sure links don't end with a period.

Fixes #460
Reported-by: lf- on github