### PR TITLE
wcurl: Update installation instructions

### DIFF
--- a/wcurl/_index.html
+++ b/wcurl/_index.html
@@ -40,6 +40,17 @@ SUBTITLE(Manual install)
 <pre style="white-space: pre-wrap; word-break: keep-all; color: #e0e080; background: #000000; padding: 8px 8px 8px 8px;">
 $ curl -fLO https://github.com/curl/wcurl/releases/latest/download/wcurl
 $ chmod +x wcurl
+$ sudo mv wcurl /usr/local/bin/wcurl
+</pre>
+
+<p>
+  Install wcurl's manpage manually like this:
+
+<pre style="white-space: pre-wrap; word-break: keep-all; color: #e0e080; background: #000000; padding: 8px 8px 8px 8px;">
+$ curl -fLO https://github.com/curl/wcurl/releases/latest/download/wcurl.1
+$ sudo mkdir -p /usr/local/share/man/man1/
+$ sudo mv wcurl.1 /usr/local/share/man/man1/wcurl.1
+$ sudo mandb
 </pre>
 
 SUBTITLE(Pronunciation)


### PR DESCRIPTION
 Based on what's used in wcurl's README:
 https://github.com/curl/wcurl/blob/fec0da4c2acd5be8a4be906150796f17446f1096/README.md

 * Install the wcurl script in /usr/local/bin/wcurl by default
 * Download manpage from GitHub releases and install it in /usr/local/share/man/man1/wcurl.1