### PR TITLE
download: call it pgp, not gpg

### DIFF
--- a/_download.html
+++ b/_download.html
@@ -2,6 +2,12 @@
 <html lang="en">
 <head> <title>curl - Download</title>
 #include "css.t"
+
+<style type="text/css">
+  .download {
+      font-size: 140%;
+  }
+</style>
 </head>
 
 #define CURL_DOWNLOAD
@@ -22,7 +28,7 @@ TITLE(Releases and Downloads)
 <br><a href="/download/">Old Releases</a>
 <br><a href="/dev/source.html">Source code repo</a>
 <br><a href="https://curl.se/snapshots/">Daily Snapshots</a>
-<br><a href="https://daniel.haxx.se/address.html">GPG Key</a>
+<br><a href="https://daniel.haxx.se/address.html">PGP Key</a>
 <br><a href="/rc/">Release Candidates</a>
 <br><a href="/docs/releases.html">Release log</a>
 </div>
@@ -36,20 +42,20 @@ SUBTITLE(Source Archives)
 
 <table class="download">
   <tr>
-    <td class="download"><a href="/download/curl-__STABLE.tar.gz" type="application/x-gzip">curl-__STABLE.tar.gz</a></td>
-    <td class="download"><a href="/download/curl-__STABLE.tar.gz.asc" type="application/pgp-signature">gpg</a></td>
+    <td class="download"><a href="/download/curl-__STABLE.tar.xz" type="application/x-xz">curl-__STABLE.tar.xz</a></td>
+    <td><a href="/download/curl-__STABLE.tar.xz.asc" type="application/pgp-signature">[pgp]</a></td>
   </tr>
   <tr>
     <td class="download"><a href="/download/curl-__STABLE.tar.bz2" type="application/x-bzip2">curl-__STABLE.tar.bz2</a></td>
-    <td class="download"><a href="/download/curl-__STABLE.tar.bz2.asc" type="application/pgp-signature">gpg</a></td>
+    <td><a href="/download/curl-__STABLE.tar.bz2.asc" type="application/pgp-signature">[pgp]</a></td>
+  </tr>
+  <tr>
+    <td class="download"><a href="/download/curl-__STABLE.tar.gz" type="application/x-gzip">curl-__STABLE.tar.gz</a></td>
+    <td><a href="/download/curl-__STABLE.tar.gz.asc" type="application/pgp-signature">[pgp]</a></td>
   </tr>
   <tr>
     <td class="download"><a href="/download/curl-__STABLE.zip" type="application/zip">curl-__STABLE.zip</a></td>
-    <td class="download"><a href="/download/curl-__STABLE.zip.asc" type="application/pgp-signature">gpg</a></td>
-  </tr>
-  <tr>
-    <td class="download"><a href="/download/curl-__STABLE.tar.xz" type="application/x-xz">curl-__STABLE.tar.xz</a></td>
-    <td class="download"><a href="/download/curl-__STABLE.tar.xz.asc" type="application/pgp-signature">gpg</a></td>
+    <td><a href="/download/curl-__STABLE.zip.asc" type="application/pgp-signature">[pgp]</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
- order the tarball downloads by size (smallest first)
- use slightly larger text for the tarballs