### PR TITLE
GHA: use `pyspelling` directly, setup yearly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Copyright (C) Viktor Szakats. See LICENSE.md
+# SPDX-License-Identifier: MIT
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'yearly'
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'yearly'

--- a/.github/scripts/requirements-docs.txt
+++ b/.github/scripts/requirements-docs.txt
@@ -1,0 +1,5 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+pyspelling==2.11

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -28,8 +28,8 @@ on:
 permissions: {}
 
 jobs:
-  spellcheck:
-    name: 'spellcheck'
+  pyspelling:
+    name: 'pyspelling'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - '*.md'
       - '*/*.md'
+      - '**/requirements*'
       - '**/spellcheck.yml'
       - '**/spellcheck.yaml'
       - '**/wordlist.txt'
@@ -19,6 +20,7 @@ on:
     paths:
       - '*.md'
       - '*/*.md'
+      - '**/requirements*'
       - '**/spellcheck.yml'
       - '**/spellcheck.yaml'
       - '**/wordlist.txt'
@@ -26,7 +28,8 @@ on:
 permissions: {}
 
 jobs:
-  check:
+  spellcheck:
+    name: 'spellcheck'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -36,10 +39,20 @@ jobs:
       - name: strip "uncheckable" sections from .md pages
         run: find docs -name "*.md" | xargs -t -n1 ./.github/scripts/cleanspell.pl
 
-      - name: setup the custom wordlist
-        run: grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
+      - name: 'install'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo rm -f /var/lib/man-db/auto-update
+          sudo apt-get -o Dpkg::Use-Pty=0 install aspell aspell-en
+          python3 -m venv ~/venv
+          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r .github/scripts/requirements-docs.txt
 
-      - name: Check Spelling
-        uses: rojopolis/spellcheck-github-actions@739a1e3ceb79a98a5d4a9bf76f351137f9d78892 # v0
-        with:
-          config_path: .github/scripts/spellcheck.yaml
+      - name: 'check spelling'
+        run: |
+          source ~/venv/bin/activate
+          # setup the custom wordlist
+          grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
+          aspell --version
+          pyspelling --version
+          pyspelling --verbose --jobs 5 --config .github/scripts/spellcheck.yaml


### PR DESCRIPTION
To avoid these extra layers when using `pyspelling`:
- a GitHub Action
- a docker container image
- Docker Hub

The cost is a slower install step. Benefits are 3x faster, parallel
spellcheck, being in sync with the same logic in curl/curl, and direct
pin and bump for the pip package. Mostly the latters, because this is
a rarely run CI job, and speed isn't critical.

pyspelling is configured to use aspell and aspell-en. These packages
are not seeing many updates anymore, and after this patch aspell is
bumped to its latest minor revision 0.60.8.1 (from 0.60.8):
https://sources.debian.org/src/aspell/
https://sources.debian.org/src/aspell-en/
