### PR TITLE
.htaccess: set base-uri to none

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -121,7 +121,7 @@ AddType application/x-bzip2 .bz2
 AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
-Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; base-uri 'none'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; base-uri 'self'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
 Header set Cross-Origin-Embedder-Policy: "require-corp"
 Header set Cross-Origin-Opener-Policy: "same-origin"
 Header set Cross-Origin-Resource-Policy: "same-origin"
@@ -145,7 +145,7 @@ Header unset Cross-Origin-Resource-Policy:
 # https://support.google.com/programmable-search/thread/60663049?hl=en
 # The hash is for the inline script in sitesearch.t
 <FilesMatch "^search\.html$|^list\.cgi$">
-Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'self' curl.se cse.google.com www.google.com www.googleapis.com clients1.google.com; style-src 'unsafe-inline' 'self' curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'self' curl.se cse.google.com www.google.com www.googleapis.com clients1.google.com; base-uri 'none'; style-src 'unsafe-inline' 'self' curl.se www.google.com; script-src 'unsafe-eval' 'self' curl.se cse.google.com www.google.com clients1.google.com 'sha256-n9QfETfN26toA8vPrDtfLIC9jm4B8HE2KsS/pOkgPJ4=';"
 </FilesMatch>
 
 <ifmodule mod_expires.c>

--- a/.htaccess
+++ b/.htaccess
@@ -121,7 +121,7 @@ AddType application/x-bzip2 .bz2
 AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
-Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; base-uri 'none'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
 Header set Cross-Origin-Embedder-Policy: "require-corp"
 Header set Cross-Origin-Opener-Policy: "same-origin"
 Header set Cross-Origin-Resource-Policy: "same-origin"

--- a/.htaccess
+++ b/.htaccess
@@ -121,7 +121,7 @@ AddType application/x-bzip2 .bz2
 AddType application/x-tar .tar
 AddType application/x-pem-file .pem
 
-Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; base-uri 'self'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; base-uri 'none'; img-src 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
 Header set Cross-Origin-Embedder-Policy: "require-corp"
 Header set Cross-Origin-Opener-Policy: "same-origin"
 Header set Cross-Origin-Resource-Policy: "same-origin"


### PR DESCRIPTION
`default-src` does not apply to it, when missing.

Refs:
https://developer.mozilla.org/en-US/observatory/analyze?host=curl.se#csp
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/base-uri

Ref: #571
Ref: #622
