### PR TITLE
curlver-to-vulnlink.pl: use VERSIONS.md to match versions better

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -539,11 +539,11 @@ seclist-c.gen: listvulns.pl vuln.pm $(CVELIST)
 	./listvulns.pl critical > seclist-c.gen
 
 CVE-2025-11563.html: CVE-2025-11563.md $(MAINPARTS) advisory.t $(ADVBOX) mk-wcurl-adv-template.pl
-	$(MARKDOWN) < $< | ./curlver-to-vulnlink.pl | ./mk-wcurl-adv-template.pl $@ | fcpp $(FCPP_OPTS) -I$(ROOT) -WWW -Uunix -P -H -C -V -LL - > $@
+	$(MARKDOWN) < $< | ./curlver-to-vulnlink.pl $(DOCROOT)/VERSIONS.md | ./mk-wcurl-adv-template.pl $@ | fcpp $(FCPP_OPTS) -I$(ROOT) -WWW -Uunix -P -H -C -V -LL - > $@
 
 CVE-%.html: CVE-%.md $(MAINPARTS) advisory.t $(ADVBOX) curlver-to-vulnlink.pl mk-adv-template.pl cve-checker.pl
 	@./cve-checker.pl $<
-	$(MARKDOWN) < $< | ./curlver-to-vulnlink.pl | ./mk-adv-template.pl $@ | fcpp $(FCPP_OPTS) -I$(ROOT) -WWW -Uunix -P -H -C -V -LL - > $@
+	$(MARKDOWN) < $< | ./curlver-to-vulnlink.pl $(DOCROOT)/VERSIONS.md | ./mk-adv-template.pl $@ | fcpp $(FCPP_OPTS) -I$(ROOT) -WWW -Uunix -P -H -C -V -LL - > $@
 
 vulnerabilities.html: _vulnerabilities.html vuln.gen $(MAINPARTS)
 	$(ACTION)

--- a/docs/curlver-to-vulnlink.pl
+++ b/docs/curlver-to-vulnlink.pl
@@ -24,11 +24,7 @@ sub inject {
 }
 
 while(<STDIN>) {
-    if($_ =~ s/([45678][0-9.]*)/inject($1)/eg) {
-        # to avoid that 7.X matches a substring of a longer version like
-        # 7.1 in 7.17.1
-        ;
-    }
+    $_ =~ s/([45678][0-9.]*)/inject($1)/eg;
     $_ =~ s/(CURLOPT_([A-Z0-9_]+))/<a href="https:\/\/curl.se\/libcurl\/c\/$1.html">$1<\/a>/g;
     print $_;
 }

--- a/docs/curlver-to-vulnlink.pl
+++ b/docs/curlver-to-vulnlink.pl
@@ -3,11 +3,11 @@
 my $versions = shift @ARGV;
 
 if(!$versions) {
-    die "no VERSIONS.md path provided";
+    die "no VERSIONS.md path provided\n";
 }
 
 my %exists;
-open(V, "<$versions");
+open(V, "<$versions") or die "Failed to open $versions: $!\n";
 while(<V>) {
     if(/^- ([45678][0-9.]*):/) {
         $exists{$1} = 1;
@@ -18,7 +18,7 @@ close(V);
 sub inject {
     my ($version) = @_;
     if($exists{$version}) {
-        return "<a href=\"vuln-$version.html\">$1<\/a>";
+        return "<a href=\"vuln-$version.html\">$version</a>";
     }
     return $version;
 }

--- a/docs/curlver-to-vulnlink.pl
+++ b/docs/curlver-to-vulnlink.pl
@@ -24,7 +24,7 @@ sub inject {
 }
 
 while(<STDIN>) {
-    $_ =~ s/([45678][0-9.]*)/inject($1)/eg;
+    $_ =~ s/([45678]\.[0-9.]*)/inject($1)/eg;
     $_ =~ s/(CURLOPT_([A-Z0-9_]+))/<a href="https:\/\/curl.se\/libcurl\/c\/$1.html">$1<\/a>/g;
     print $_;
 }

--- a/docs/curlver-to-vulnlink.pl
+++ b/docs/curlver-to-vulnlink.pl
@@ -1,12 +1,34 @@
 #!/usr/bin/env perl
 
+my $versions = shift @ARGV;
+
+if(!$versions) {
+    die "no VERSIONS.md path provided";
+}
+
+my %exists;
+open(V, "<$versions");
+while(<V>) {
+    if(/^- ([45678][0-9.]*):/) {
+        $exists{$1} = 1;
+    }
+}
+close(V);
+
+sub inject {
+    my ($version) = @_;
+    if($exists{$version}) {
+        return "<a href=\"vuln-$version.html\">$1<\/a>";
+    }
+    return $version;
+}
+
 while(<STDIN>) {
-    if($_ =~ s/([78]\.(\d+)\.(\d+))/<a href="vuln-$1.html">$1<\/a>/g) {
+    if($_ =~ s/([45678][0-9.]*)/inject($1)/eg) {
         # to avoid that 7.X matches a substring of a longer version like
         # 7.1 in 7.17.1
         ;
     }
-    $_ =~ s/(7\.[1-9])([^0-9\.])/<a href="vuln-$1.html">$1<\/a>$2/g;
     $_ =~ s/(CURLOPT_([A-Z0-9_]+))/<a href="https:\/\/curl.se\/libcurl\/c\/$1.html">$1<\/a>/g;
     print $_;
 }


### PR DESCRIPTION
By using the list of all known and existing version numbers, this script now only creates links to actual curl releases.