### PR TITLE
docs: fix CVE broken commit links

### DIFF
--- a/docs/CVE-2026-12064.md
+++ b/docs/CVE-2026-12064.md
@@ -39,7 +39,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.81.0 to and including 8.20.0
 - Not affected versions: curl < 7.81.0 and >= 8.21.0
-- Introduced-in: https://github.com/curl/curl/18270893abdb19f0ca170c118f8a
+- Introduced-in: https://github.com/curl/curl/commit/18270893abdb19f0ca170c118f8a
 
 SOLUTION
 ------------

--- a/docs/CVE-2026-13608.md
+++ b/docs/CVE-2026-13608.md
@@ -38,7 +38,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.82.0 to and including 8.21.0
 - Not affected versions: curl < 7.82.0 and >= 8.22.0
-- Introduced-in: https://github.com/curl/curl/eeca818b1e8d1e61c2d4d833aed5
+- Introduced-in: https://github.com/curl/curl/commit/eeca818b1e8d1e61c2d4d833aed5
 
 SOLUTION
 ------------

--- a/docs/CVE-2026-18924.md
+++ b/docs/CVE-2026-18924.md
@@ -45,7 +45,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.44.0 to and including 8.21.0
 - Not affected versions: curl < 7.44.0 and >= 8.22.0
-- Introduced-in: https://github.com/curl/curl/ea7134ac874a66107e54ff93657ac5
+- Introduced-in: https://github.com/curl/curl/commit/ea7134ac874a66107e54ff93657ac5
 
 SOLUTION
 ------------

--- a/docs/CVE-2026-19931.md
+++ b/docs/CVE-2026-19931.md
@@ -39,7 +39,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.64.1 to and including 8.21.0
 - Not affected versions: curl < 7.64.1 and >= 8.22.0
-- Introduced-in: https://github.com/curl/curl/6c6035532383e300c712e4c1
+- Introduced-in: https://github.com/curl/curl/commit/6c6035532383e300c712e4c1
 
 SOLUTION
 ------------

--- a/docs/CVE-2026-80230.md
+++ b/docs/CVE-2026-80230.md
@@ -41,7 +41,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.45.0 to and including 8.21.0
 - Not affected versions: curl < 7.45.0 and >= 8.22.0
-- Introduced-in: https://github.com/curl/curl/8363656cb4e0c60a11d8531
+- Introduced-in: https://github.com/curl/curl/commit/8363656cb4e0c60a11d8531
 
 SOLUTION
 ------------

--- a/docs/CVE-2026-80231.md
+++ b/docs/CVE-2026-80231.md
@@ -33,7 +33,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.71.0 to and including 8.21.0
 - Not affected versions: curl < 7.71.0 and >= 8.22.0
-- Introduced-in: https://github.com/curl/curl/148534db57dda611cf8516e9
+- Introduced-in: https://github.com/curl/curl/commit/148534db57dda611cf8516e9
 
 SOLUTION
 ------------

--- a/docs/CVE-2026-80255.md
+++ b/docs/CVE-2026-80255.md
@@ -32,7 +32,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.13.0 to and including 8.21.0
 - Not affected versions: curl < 7.13.0 and >= 8.22.0
-- Introduced-in: https://github.com/curl/curl/1aea05a6c2699e80c75936d5
+- Introduced-in: https://github.com/curl/curl/commit/1aea05a6c2699e80c75936d5
 
 SOLUTION
 ------------

--- a/docs/CVE-2026-82208.md
+++ b/docs/CVE-2026-82208.md
@@ -35,7 +35,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.9.1 to and including 8.21.0
 - Not affected versions: curl < 8.9.1 and >= 8.22.0
-- Introduced-in: https://github.com/curl/curl/0f2876b2c33f6784a27b6f7345bd
+- Introduced-in: https://github.com/curl/curl/commit/0f2876b2c33f6784a27b6f7345bd
 
 SOLUTION
 ------------


### PR DESCRIPTION
Prior to this change some of the commit links were broken due to a bad format. GitHub requires a commit/ component to show the commit.

No: `https://github.com/curl/curl/8363656cb4e0c60a11d8531`

Yes: `https://github.com/curl/curl/commit/8363656cb4e0c60a11d8531`

Closes #xxxx