### PR TITLE
all: stop using source label in github form url

### DIFF
--- a/docs/_bugs.html
+++ b/docs/_bugs.html
@@ -17,7 +17,7 @@ WHERE3(Docs, "/docs/", Project, "/docs/projdocs.html", Report Bugs)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=BUGS&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=BUGS%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="knownbugs.html">Known bugs</a>
 <br><a href="tutorial.html">Tutorial</a>
 </div>

--- a/docs/_bugs.html
+++ b/docs/_bugs.html
@@ -17,7 +17,7 @@ WHERE3(Docs, "/docs/", Project, "/docs/projdocs.html", Report Bugs)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=BUGS%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=BUGS%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="knownbugs.html">Known bugs</a>
 <br><a href="tutorial.html">Tutorial</a>
 </div>

--- a/docs/_faq.html
+++ b/docs/_faq.html
@@ -17,7 +17,7 @@ WHERE3(Docs, "/docs/", Project, "/docs/projdocs.html", FAQ)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=FAQ&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about the FAQ</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=FAQ%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about the FAQ</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
 <br><a href="tutorial.html">Tutorial</a>
 <br><a href="todo.html">TODO</a>

--- a/docs/_faq.html
+++ b/docs/_faq.html
@@ -17,7 +17,7 @@ WHERE3(Docs, "/docs/", Project, "/docs/projdocs.html", FAQ)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="manpage.html">curl man page</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=FAQ%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about the FAQ</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=FAQ%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about the FAQ</a>
 <br><a href="httpscripting.html">HTTP Scripting</a>
 <br><a href="tutorial.html">Tutorial</a>
 <br><a href="todo.html">TODO</a>

--- a/docs/_sslcerts.html
+++ b/docs/_sslcerts.html
@@ -18,7 +18,7 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", SSL Certificates)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="caextract.html">CA extract</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=SSLCERTS.md&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=SSLCERTS%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 </div>
 #include "sslcerts.gen"
 #include "_footer.html"

--- a/docs/_sslcerts.html
+++ b/docs/_sslcerts.html
@@ -18,7 +18,7 @@ WHERE3(Docs, "/docs/", Protocols, "/docs/protdocs.html", SSL Certificates)
 <div class="relatedbox">
 <b>Related:</b>
 <br><a href="caextract.html">CA extract</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=SSLCERTS%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=SSLCERTS%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 </div>
 #include "sslcerts.gen"
 #include "_footer.html"

--- a/libcurl/c/_CURLINFO_template.html
+++ b/libcurl/c/_CURLINFO_template.html
@@ -24,7 +24,7 @@ TITLE(@template@ explained)
 <br><a href="easy_getinfo_options.html">info options</a>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLINFO_template.html
+++ b/libcurl/c/_CURLINFO_template.html
@@ -24,7 +24,7 @@ TITLE(@template@ explained)
 <br><a href="easy_getinfo_options.html">info options</a>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLMINFO_template.html
+++ b/libcurl/c/_CURLMINFO_template.html
@@ -23,7 +23,7 @@ TITLE(@template@ explained)
 <b>Related:</b>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLMINFO_template.html
+++ b/libcurl/c/_CURLMINFO_template.html
@@ -23,7 +23,7 @@ TITLE(@template@ explained)
 <b>Related:</b>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLMOPT_template.html
+++ b/libcurl/c/_CURLMOPT_template.html
@@ -23,7 +23,7 @@ TITLE(@template@ explained)
 <b>Related:</b>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLMOPT_template.html
+++ b/libcurl/c/_CURLMOPT_template.html
@@ -23,7 +23,7 @@ TITLE(@template@ explained)
 <b>Related:</b>
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLOPT_template.html
+++ b/libcurl/c/_CURLOPT_template.html
@@ -24,7 +24,7 @@ TITLE(@template@ explained)
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLOPT_template.html
+++ b/libcurl/c/_CURLOPT_template.html
@@ -24,7 +24,7 @@ TITLE(@template@ explained)
 <br><a href="easy_setopt_options.html">easy options</a>
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLSHOPT_template.html
+++ b/libcurl/c/_CURLSHOPT_template.html
@@ -25,7 +25,7 @@ TITLE(@template@ explained)
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="curl_share_setopt.html">share options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage:%20&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_CURLSHOPT_template.html
+++ b/libcurl/c/_CURLSHOPT_template.html
@@ -25,7 +25,7 @@ TITLE(@template@ explained)
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="curl_share_setopt.html">share options</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=@template%20manpage:@&amp;labels=documentation&amp;template=docs.yml&amp;source=CURL_URL" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=@template@%20manpage&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/opts/@template@.md" target="_new">View man page source</a>
 </div>
 

--- a/libcurl/c/_curl_easy_cleanup.html
+++ b/libcurl/c/_curl_easy_cleanup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_cleanup.md
-#define BUG_TITLE curl_easy_cleanup%20manpage:
+#define BUG_TITLE curl_easy_cleanup%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_CLEANUP

--- a/libcurl/c/_curl_easy_cleanup.html
+++ b/libcurl/c/_curl_easy_cleanup.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_cleanup.md
-#define BUG_TITLE curl_easy_cleanup%20manpage
+#define BUG_TITLE curl_easy_cleanup%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_CLEANUP

--- a/libcurl/c/_curl_easy_duphandle.html
+++ b/libcurl/c/_curl_easy_duphandle.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_duphandle.md
-#define BUG_TITLE curl_easy_duphandle%20manpage
+#define BUG_TITLE curl_easy_duphandle%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_DUPHANDLE

--- a/libcurl/c/_curl_easy_duphandle.html
+++ b/libcurl/c/_curl_easy_duphandle.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_duphandle.md
-#define BUG_TITLE curl_easy_duphandle%20manpage:
+#define BUG_TITLE curl_easy_duphandle%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_DUPHANDLE

--- a/libcurl/c/_curl_easy_escape.html
+++ b/libcurl/c/_curl_easy_escape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_escape.md
-#define BUG_TITLE curl_easy_escape%20manpage:
+#define BUG_TITLE curl_easy_escape%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_ESCAPE

--- a/libcurl/c/_curl_easy_escape.html
+++ b/libcurl/c/_curl_easy_escape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_escape.md
-#define BUG_TITLE curl_easy_escape%20manpage
+#define BUG_TITLE curl_easy_escape%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_ESCAPE

--- a/libcurl/c/_curl_easy_getinfo.html
+++ b/libcurl/c/_curl_easy_getinfo.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_getinfo.md
-#define BUG_TITLE curl_easy_getinfo%20manpage:
+#define BUG_TITLE curl_easy_getinfo%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_GETINFO

--- a/libcurl/c/_curl_easy_getinfo.html
+++ b/libcurl/c/_curl_easy_getinfo.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_getinfo.md
-#define BUG_TITLE curl_easy_getinfo%20manpage
+#define BUG_TITLE curl_easy_getinfo%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_GETINFO

--- a/libcurl/c/_curl_easy_header.html
+++ b/libcurl/c/_curl_easy_header.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_header.md
-#define BUG_TITLE curl_easy_header%20manpage
+#define BUG_TITLE curl_easy_header%20manpage:%20
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_easy_header.html
+++ b/libcurl/c/_curl_easy_header.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_header.md
-#define BUG_TITLE curl_easy_header%20manpage:
+#define BUG_TITLE curl_easy_header%20manpage
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_easy_init.html
+++ b/libcurl/c/_curl_easy_init.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_init.md
-#define BUG_TITLE curl_easy_init%20manpage:
+#define BUG_TITLE curl_easy_init%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_INIT

--- a/libcurl/c/_curl_easy_init.html
+++ b/libcurl/c/_curl_easy_init.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_init.md
-#define BUG_TITLE curl_easy_init%20manpage
+#define BUG_TITLE curl_easy_init%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_INIT

--- a/libcurl/c/_curl_easy_nextheader.html
+++ b/libcurl/c/_curl_easy_nextheader.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_nextheader.md
-#define BUG_TITLE curl_easy_nextheader%20manpage
+#define BUG_TITLE curl_easy_nextheader%20manpage:%20
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_easy_nextheader.html
+++ b/libcurl/c/_curl_easy_nextheader.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_nextheader.md
-#define BUG_TITLE curl_easy_nextheader%20manpage:
+#define BUG_TITLE curl_easy_nextheader%20manpage
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL_GET

--- a/libcurl/c/_curl_easy_option_by_id.html
+++ b/libcurl/c/_curl_easy_option_by_id.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_by_id.md
-#define BUG_TITLE curl_easy_option_by_id%20manpage
+#define BUG_TITLE curl_easy_option_by_id%20manpage:%20
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_option_by_id.html
+++ b/libcurl/c/_curl_easy_option_by_id.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_by_id.md
-#define BUG_TITLE curl_easy_option_by_id%20manpage:
+#define BUG_TITLE curl_easy_option_by_id%20manpage
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_option_by_name.html
+++ b/libcurl/c/_curl_easy_option_by_name.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_by_name.md
-#define BUG_TITLE curl_easy_option_by_name%20manpage:
+#define BUG_TITLE curl_easy_option_by_name%20manpage
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_option_by_name.html
+++ b/libcurl/c/_curl_easy_option_by_name.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_by_name.md
-#define BUG_TITLE curl_easy_option_by_name%20manpage
+#define BUG_TITLE curl_easy_option_by_name%20manpage:%20
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_option_next.html
+++ b/libcurl/c/_curl_easy_option_next.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_next.md
-#define BUG_TITLE curl_easy_option_next%20manpage:
+#define BUG_TITLE curl_easy_option_next%20manpage
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_option_next.html
+++ b/libcurl/c/_curl_easy_option_next.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_option_next.md
-#define BUG_TITLE curl_easy_option_next%20manpage
+#define BUG_TITLE curl_easy_option_next%20manpage:%20
 #define MENU_URL
 #define LIBCURL_DOCS
 #define DOCS_URL

--- a/libcurl/c/_curl_easy_pause.html
+++ b/libcurl/c/_curl_easy_pause.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_pause.md
-#define BUG_TITLE curl_easy_pause%20manpage:
+#define BUG_TITLE curl_easy_pause%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_PAUSE

--- a/libcurl/c/_curl_easy_pause.html
+++ b/libcurl/c/_curl_easy_pause.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_pause.md
-#define BUG_TITLE curl_easy_pause%20manpage
+#define BUG_TITLE curl_easy_pause%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_PAUSE

--- a/libcurl/c/_curl_easy_perform.html
+++ b/libcurl/c/_curl_easy_perform.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_perform.md
-#define BUG_TITLE curl_easy_perform%20manpage
+#define BUG_TITLE curl_easy_perform%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_PERFORM

--- a/libcurl/c/_curl_easy_perform.html
+++ b/libcurl/c/_curl_easy_perform.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_perform.md
-#define BUG_TITLE curl_easy_perform%20manpage:
+#define BUG_TITLE curl_easy_perform%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_PERFORM

--- a/libcurl/c/_curl_easy_recv.html
+++ b/libcurl/c/_curl_easy_recv.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_recv.md
-#define BUG_TITLE curl_easy_recv%20manpage
+#define BUG_TITLE curl_easy_recv%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_RECV

--- a/libcurl/c/_curl_easy_recv.html
+++ b/libcurl/c/_curl_easy_recv.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_recv.md
-#define BUG_TITLE curl_easy_recv%20manpage:
+#define BUG_TITLE curl_easy_recv%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_RECV

--- a/libcurl/c/_curl_easy_reset.html
+++ b/libcurl/c/_curl_easy_reset.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_reset.md
-#define BUG_TITLE curl_easy_reset%20manpage:
+#define BUG_TITLE curl_easy_reset%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_RESET

--- a/libcurl/c/_curl_easy_reset.html
+++ b/libcurl/c/_curl_easy_reset.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_reset.md
-#define BUG_TITLE curl_easy_reset%20manpage
+#define BUG_TITLE curl_easy_reset%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_RESET

--- a/libcurl/c/_curl_easy_send.html
+++ b/libcurl/c/_curl_easy_send.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_send.md
-#define BUG_TITLE curl_easy_send%20manpage
+#define BUG_TITLE curl_easy_send%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SEND

--- a/libcurl/c/_curl_easy_send.html
+++ b/libcurl/c/_curl_easy_send.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_send.md
-#define BUG_TITLE curl_easy_send%20manpage:
+#define BUG_TITLE curl_easy_send%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SEND

--- a/libcurl/c/_curl_easy_setopt.html
+++ b/libcurl/c/_curl_easy_setopt.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_setopt.md
-#define BUG_TITLE curl_easy_setopt%20manpage:
+#define BUG_TITLE curl_easy_setopt%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SETOPT

--- a/libcurl/c/_curl_easy_setopt.html
+++ b/libcurl/c/_curl_easy_setopt.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_setopt.md
-#define BUG_TITLE curl_easy_setopt%20manpage
+#define BUG_TITLE curl_easy_setopt%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SETOPT

--- a/libcurl/c/_curl_easy_ssls_export.html
+++ b/libcurl/c/_curl_easy_ssls_export.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_ssls_export.md
-#define BUG_TITLE curl_easy_ssls_export%20manpage:
+#define BUG_TITLE curl_easy_ssls_export%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SSLS_EXPORT

--- a/libcurl/c/_curl_easy_ssls_export.html
+++ b/libcurl/c/_curl_easy_ssls_export.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_ssls_export.md
-#define BUG_TITLE curl_easy_ssls_export%20manpage
+#define BUG_TITLE curl_easy_ssls_export%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SSLS_EXPORT

--- a/libcurl/c/_curl_easy_ssls_import.html
+++ b/libcurl/c/_curl_easy_ssls_import.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_ssls_import.md
-#define BUG_TITLE curl_easy_ssls_import%20manpage
+#define BUG_TITLE curl_easy_ssls_import%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SSLS_IMPORT

--- a/libcurl/c/_curl_easy_ssls_import.html
+++ b/libcurl/c/_curl_easy_ssls_import.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_ssls_import.md
-#define BUG_TITLE curl_easy_ssls_import%20manpage:
+#define BUG_TITLE curl_easy_ssls_import%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_SSLS_IMPORT

--- a/libcurl/c/_curl_easy_strerror.html
+++ b/libcurl/c/_curl_easy_strerror.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_strerror.md
-#define BUG_TITLE curl_easy_strerror%20manpage
+#define BUG_TITLE curl_easy_strerror%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_STRERROR

--- a/libcurl/c/_curl_easy_strerror.html
+++ b/libcurl/c/_curl_easy_strerror.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_strerror.md
-#define BUG_TITLE curl_easy_strerror%20manpage:
+#define BUG_TITLE curl_easy_strerror%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_STRERROR

--- a/libcurl/c/_curl_easy_unescape.html
+++ b/libcurl/c/_curl_easy_unescape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_unescape.md
-#define BUG_TITLE curl_easy_unescape%20manpage
+#define BUG_TITLE curl_easy_unescape%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_UNESCAPE

--- a/libcurl/c/_curl_easy_unescape.html
+++ b/libcurl/c/_curl_easy_unescape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_unescape.md
-#define BUG_TITLE curl_easy_unescape%20manpage:
+#define BUG_TITLE curl_easy_unescape%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_UNESCAPE

--- a/libcurl/c/_curl_easy_upkeep.html
+++ b/libcurl/c/_curl_easy_upkeep.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_upkeep.md
-#define BUG_TITLE curl_easy_upkeep%20manpage
+#define BUG_TITLE curl_easy_upkeep%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_UPKEEP

--- a/libcurl/c/_curl_easy_upkeep.html
+++ b/libcurl/c/_curl_easy_upkeep.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_easy_upkeep.md
-#define BUG_TITLE curl_easy_upkeep%20manpage:
+#define BUG_TITLE curl_easy_upkeep%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_EASY_UPKEEP

--- a/libcurl/c/_curl_escape.html
+++ b/libcurl/c/_curl_escape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_escape.md
-#define BUG_TITLE curl_escape%20manpage:
+#define BUG_TITLE curl_escape%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_ESCAPE

--- a/libcurl/c/_curl_escape.html
+++ b/libcurl/c/_curl_escape.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_escape.md
-#define BUG_TITLE curl_escape%20manpage
+#define BUG_TITLE curl_escape%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_ESCAPE

--- a/libcurl/c/_curl_formadd.html
+++ b/libcurl/c/_curl_formadd.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_formadd.md
-#define BUG_TITLE curl_formadd%20manpage:
+#define BUG_TITLE curl_formadd%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FORMADD

--- a/libcurl/c/_curl_formadd.html
+++ b/libcurl/c/_curl_formadd.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_formadd.md
-#define BUG_TITLE curl_formadd%20manpage
+#define BUG_TITLE curl_formadd%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FORMADD

--- a/libcurl/c/_curl_formfree.html
+++ b/libcurl/c/_curl_formfree.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_formfree.md
-#define BUG_TITLE curl_formfree%20manpage:
+#define BUG_TITLE curl_formfree%20manpage
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FORMFREE

--- a/libcurl/c/_curl_formfree.html
+++ b/libcurl/c/_curl_formfree.html
@@ -6,7 +6,7 @@
 </head>
 
 #define RAW_FILE curl_formfree.md
-#define BUG_TITLE curl_formfree%20manpage
+#define BUG_TITLE curl_formfree%20manpage:%20
 #define MENU_EASY
 #define LIBCURL_DOCS
 #define DOCS_FORMFREE

--- a/libcurl/c/libcurl-related.t
+++ b/libcurl/c/libcurl-related.t
@@ -4,6 +4,6 @@
 <br><a href="easy_getinfo_options.html">getinfo options</a>
 <br><a href="multi_setopt_options.html">multi options</a>
 <br><a href="symbols-in-versions.html">Symbols</a>
-<br><a href="https://github.com/curl/curl/issues/new?title=BUG_TITLE&amp;labels=documentation&amp;template=docs.yml&amp;source=RAW_FILE" target="_new">File a bug about this page</a>
+<br><a href="https://github.com/curl/curl/issues/new?title=BUG_TITLE&amp;labels=documentation&amp;template=docs.yml" target="_new">File a bug about this page</a>
 <br><a href="https://github.com/curl/curl/blob/master/docs/libcurl/RAW_FILE" target="_new">View man page source</a>
 </div>


### PR DESCRIPTION
Prior to this change the "File a bug about this page" URLs, which direct to a GitHub new issue, included a "source=" component with the filename of the page. GitHub then would set the "Which documentation" field as read-only with that source. That prevented users from modifying the field with more information.

Also, prior to this change, some of the URLs used an erroneous placeholder for the template "`@template%20manpage:@`" which should be "`@template@%20manpage`", which meant the issue title was missing what the actual file was.

We now rely exclusively on the title of the report which is the name + " manpage". For example, user clicks on the file a bug link on curl_easy_setopt and then their github issue title is "curl_easy_setopt manpage". The "which documentation" field is now blank so the user can fill it in.

Reported-by: Christian Ullrich

Fix-suggested-by: Viktor Szakats

Ref: https://github.com/curl/curl-www/issues/608#issuecomment-4961187991

Fixes https://github.com/curl/curl-www/issues/608
Closes #xxxx

---

eg [https://curl.se/libcurl/c/CURLMOPT_MAX_HOST_CONNECTIONS.html](https://curl.se/libcurl/c/CURLMOPT_MAX_HOST_CONNECTIONS.html) file a bug link currently results in an erroneous title due to `@template%20manpage:@`