### PR TITLE
libs: point c-ares at its own site

### DIFF
--- a/docs/_libs.html
+++ b/docs/_libs.html
@@ -97,7 +97,7 @@ TITLE(Dependencies)
 
 <tr class="odd">
 <td>
-  <a href="https://daniel.haxx.se/projects/c-ares/">c-ares</a>
+  <a href="https://c-ares.org/">c-ares</a>
 </td>
 <td>
   For asynchronous name resolves.


### PR DESCRIPTION
The c-ares row in `docs/_libs.html` links `https://daniel.haxx.se/projects/c-ares/`, which returns 404. `https://c-ares.org/` is the project home and returns 200; `c-ares.haxx.se` redirects there as well.

I requested all 11806 URLs in the `.md` and `.html` sources. This is the only dead one outside two places I left alone on purpose:

- `_changes.html` has five dead links (an old mail archive URL, an lxr source path, a feedback CGI, a 2000 archive page, a deleted tweet). That file is the historical changelog, so rewriting old entries would falsify the record.
- `docs/_companies.html` has 22 dead company links (1c.ru, actuate.com, biicode.com, canonical.com/projects/landscape, fmwebschool, focuseek and others). Those are companies whose sites or products are gone, so pruning or repointing them is a curation decision for you rather than a link fix.

Happy to do either of those as a separate change if you want it.

I used Claude Code to sweep the links; I verified c-ares.org and the old URL myself before reporting.