### PR TITLE
companies: unlink sites whose domains no longer exist

### DIFF
--- a/docs/_companies.html
+++ b/docs/_companies.html
@@ -41,9 +41,9 @@ Browser NX</a> for embedded systems.
 
 <li> <a href="https://www.actuate.com/">Actuate</a> uses libcurl in BIRT Analytics
 
-<li> <a href="http://www.adaranet.com/">Adara Networks</a>
+<li> Adara Networks
 
-<li> <a href="http://www.addlive.com/">AddLive</a> used libcurl - now purchased by Snapchat
+<li> AddLive used libcurl - now purchased by Snapchat
 
 <li> <a href="https://www.adobe.com/">Adobe</a> - <a
 href="ftp://ftp.adobe.com/pub/adobe/reader/unix/7x/7.0/enu/">Acrobat Reader
@@ -153,7 +153,7 @@ Win-XP) uses libcurl and so does ClusterXL
 
 <li> Chevrolet includes the curl license in their "2013 Chevrolet Volt Owner Manual"
 
-<li> <a href="https://www.chronosnet.com/">Chronos</a> <i>uses libcurl as a
+<li> Chronos <i>uses libcurl as a
 WebDAV &amp; CalDAV engine primarily. We also use it to publish, unpublish, and
 subscribe to remote vCal files over FTP, FTPS, and SFTP.</i>
 
@@ -169,11 +169,11 @@ This application runs on Windows.
 
 <li> Comcast uses libcurl in XFINITY TV.
 
-<li> <a href="http://www.contactor.se/">Contactor Data AB</a>
+<li> Contactor Data AB
 
 <li> <a href="https://www.counterpath.com/">CounterPath</a> uses libcurl in CounterPath Bria 3 for Windows
 
-<li> <a href="https://www.cyber.ee/">Cybernetica AS</a> - <i>in our <a href="http://www.timestamp.cyber.ee/">time-stamping software</a></i>
+<li> <a href="https://www.cyber.ee/">Cybernetica AS</a> - <i>in our time-stamping software</i>
 
 <li> Dacia uses curl in cars.
 
@@ -256,7 +256,7 @@ binding
 for all sorts of things, from Social Network sharing to database backing up to
 DropBox, to a plethora of other uses."
 
-<li> <a href="https://www.grin.se/">GRIN</a> uses libcurl in their game <a
+<li> GRIN uses libcurl in their game <a
 href="https://www.ghostrecon.com/">Ghost Recon</a>
 
 <li> <a href="http://groopex.com/">Groopex</a>
@@ -322,7 +322,7 @@ using libcurl.
 <li> <a href="https://www.idsoftware.com/">Id Software</a> used libcurl in <a
 href="https://fabiensanglard.net/doom3/index.php">Doom 3</a>
 
-<li> Infomedia Business Systems Division - <a href="http://www.bsd.infomedia.com.au/autoledgers.htm">AutoLedgers</a>
+<li> Infomedia Business Systems Division - AutoLedgers
 
 <li> <a href="https://www.informatica.com/">Informatica</a> PowerCenter uses curl
 
@@ -422,7 +422,7 @@ optional TURN REST API support, and the HTTP based stats extractor"
 
 <li> <a href="http://www4.mercedes-benz.com/manual-cars/ba/foss/content/en/assets/FOSS_licences.pdf">Mercedes-Benz</a> uses curl in almost every car model.
 
-<li> <a href="http://www.metaio.com/">Metaio</a> - Junaio App uses libcurl
+<li> Metaio - Junaio App uses libcurl
 
 <li> <a href="https://www.micromuse.com/">Micromuse Inc.</a>
 
@@ -507,7 +507,7 @@ and HTTPS traffic in our OptimTalk platform
 <li> <a href="http://www.outrider.se/">Outrider</a>
 
 <li> <a href="https://www.palm.com/">Palm</a> uses libcurl in the
-<a href="http://palm.cdnetworks.net/opensource/Open_Source_Information.pdf">Palm Pre</a>.
+Palm Pre.
 
 <li> <a href="https://www.panasonic.com/">Panasonic</a> uses libcurl in TVs
 and the DC-GH5 camera.
@@ -566,7 +566,7 @@ Windows</a>.
 
 <li> Roland makes keyboards running curl
 
-<li> <a href="http://www.rolltech.co.jp/en/">Rolltech, Inc</a> - commercial
+<li> Rolltech, Inc - commercial
 media player application on Android
 
 <li> <a href="https://www.rsa.com/">RSA Security Inc</a>
@@ -729,9 +729,8 @@ fundamental "hand tool" for moving data</i>
 
 <li> <a href="https://www.xonasoftware.com/">XonaSoftware</a>
 
-<li> <a href="https://www.yahoo.com/">Yahoo</a> (via the PHP/CURL binding, see
-<a href="https://public.yahoo.com/~radwin/talks/php-at-yahoo-zend2005.pdf">PHP
-at yahoo</a>), used by https://search.yahoo.com and https://babelfish.yahoo.com
+<li> <a href="https://www.yahoo.com/">Yahoo</a> (via the PHP/CURL binding),
+used by https://search.yahoo.com and https://babelfish.yahoo.com
 
 <li> <a href="https://www.yamaha.com/">Yamaha</a> uses libcurl in AV Receivers and Blu-ray palyers
 


### PR DESCRIPTION
Follow-up to your comment on #629:

> I think all links on the current website that are dead should either be removed or made to point to something that works.

This does the eleven on `docs/_companies.html` where the domain itself is gone, so there is nothing to point at. The `href` is dropped and the visible text kept, so the record of who used libcurl stays intact:

`adaranet.com`, `addlive.com`, `bsd.infomedia.com.au`, `chronosnet.com`, `contactor.se`, `grin.se`, `metaio.com`, `rolltech.co.jp`, `timestamp.cyber.ee`, `palm.cdnetworks.net`, `public.yahoo.com`

Each one returns NXDOMAIN from **both** the Google and Cloudflare resolvers. I used DNS rather than HTTP status deliberately, and it caught my own mistake: my local resolver reported `grooveshark.com`, `nortel.com`, `devicescape.com`, `datasphere.ch` and `steambird.com` as gone too, but all five resolve on the public resolvers, so they are untouched.

One wording change beyond removing an `href`: the Yahoo entry read "(via the PHP/CURL binding, see PHP at yahoo)", where "PHP at yahoo" was the dead PDF. De-linking alone would leave a "see …" pointing at nothing, so the clause went with it.

## What I did not touch, and why

- **Sites that are alive but block scripted requests.** Around 190 URLs on that page answer 403/401/405/400/202 to a scripted `User-Agent` while working fine in a browser — `cisco.com`, `intel.com`, `autodesk.com`, `sap.com`, `lg.com`, `games-workshop.com` and many more. Treating those as dead would delete working links.
- **404s on domains that still exist**, such as `1c.ru/eng/`, `actuate.com`, `canonical.com/projects/landscape` and `sandisk.com`. Those are page moves, and the right target is usually a judgement call about which successor page the entry means. Happy to work through them as a second pass if you want, but I did not want to guess at a dozen companies' site structures in the same PR.
- **`_changes.html`.** I cannot audit it honestly right now: it holds 10,705 URLs and 9,550 of them are `curl.se/bug/?i=NNNN`, which answered **429** to my sweep. That is your server rate-limiting me, not dead links, and I am not going to hammer it to find out. If you want that file checked I would rather do it slowly against a local copy of the bug redirector, or you tell me the five you already know about.

I used Claude Code for the sweep and this description; every DNS result above I verified myself against both resolvers.