### PR TITLE
docs: update 47 CVEs with new info

### DIFF
--- a/docs/CVE-2025-10148.md
+++ b/docs/CVE-2025-10148.md
@@ -42,6 +42,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.11.0 to and including 8.15.0
 - Not affected versions: curl < 8.11.0 and >= 8.16.0
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/d78e129d50b2d1
 
 WebSocket was considered experimental before 8.11.0 and therefore we do not

--- a/docs/CVE-2025-10966.md
+++ b/docs/CVE-2025-10966.md
@@ -49,6 +49,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.69.0 to and including 8.16.0
 - Not affected versions: curl < 7.69.0 and >= 8.17.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/6773c7ca65cf2183295e56
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2025-13034.md
+++ b/docs/CVE-2025-13034.md
@@ -43,6 +43,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.8.0 to and including 8.17.0
 - Not affected versions: curl < 8.8.0 and >= 8.18.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/3210101088dfa3d6a125
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2025-14017.md
+++ b/docs/CVE-2025-14017.md
@@ -41,6 +41,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.17.0 to and including 8.17.0
 - Not affected versions: curl < 7.17.0 and >= 8.18.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/ccba0d10b6baf5c73ca
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2025-14524.md
+++ b/docs/CVE-2025-14524.md
@@ -39,6 +39,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.33.0 to and including 8.17.0
 - Not affected versions: curl < 7.33.0 and >= 8.18.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/06c1bea72faabb6fad4b7ef8
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2025-14819.md
+++ b/docs/CVE-2025-14819.md
@@ -49,6 +49,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.87.0 to and including 8.17.0
 - Not affected versions: curl < 7.87.0 and >= 8.18.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/3c16697ebd796f799227b
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2025-15079.md
+++ b/docs/CVE-2025-15079.md
@@ -35,6 +35,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.58.0 to and including 8.17.0
 - Not affected versions: curl < 7.58.0 and >= 8.18.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/c92d2e14cfb0db662f958effd2ac86f99
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2025-15224.md
+++ b/docs/CVE-2025-15224.md
@@ -33,6 +33,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.58.0 to and including 8.17.0
 - Not affected versions: curl < 7.58.0 and >= 8.18.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/c92d2e14cfb0db662f958effd2ac86f99
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2025-9086.md
+++ b/docs/CVE-2025-9086.md
@@ -47,6 +47,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.13.0 to and including 8.15.0
 - Not affected versions: curl < 8.13.0 and >= 8.16.0
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/1aea05a6c2699e80c7593
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-10536.md
+++ b/docs/CVE-2026-10536.md
@@ -41,6 +41,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.88.0 to and including 8.20.0
 - Not affected versions: curl < 7.88.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/71b7e0161032927cdfb
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-11352.md
+++ b/docs/CVE-2026-11352.md
@@ -36,6 +36,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.18.0 to and including 8.20.0
 - Not affected versions: curl < 8.18.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
 - Introduced-in: https://github.com/curl/curl/commit/6a3d0b6d631d5e9bec7
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-11564.md
+++ b/docs/CVE-2026-11564.md
@@ -45,6 +45,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.17.0 to and including 8.20.0
 - Not affected versions: curl < 8.17.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
 - Introduced-in: https://github.com/curl/curl/commit/eefd03c572996e5de4dec4fe
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-11586.md
+++ b/docs/CVE-2026-11586.md
@@ -39,6 +39,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.16.0 to and including 8.20.0
 - Not affected versions: curl < 8.16.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
 - Introduced-in: https://github.com/curl/curl/commit/0b091328773c64e23f5
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-11856.md
+++ b/docs/CVE-2026-11856.md
@@ -46,6 +46,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.10.6 to and including 8.20.0
 - Not affected versions: curl < 7.10.6 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/334d78cd18a7310144383
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-12064.md
+++ b/docs/CVE-2026-12064.md
@@ -39,6 +39,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.81.0 to and including 8.20.0
 - Not affected versions: curl < 7.81.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/18270893abdb19f0ca170c118f8a
 
 SOLUTION

--- a/docs/CVE-2026-13608.md
+++ b/docs/CVE-2026-13608.md
@@ -38,6 +38,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.82.0 to and including 8.21.0
 - Not affected versions: curl < 7.82.0 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/eeca818b1e8d1e61c2d4d833aed5
 
 SOLUTION

--- a/docs/CVE-2026-18924.md
+++ b/docs/CVE-2026-18924.md
@@ -45,6 +45,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.44.0 to and including 8.21.0
 - Not affected versions: curl < 7.44.0 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/ea7134ac874a66107e54ff93657ac5
 
 SOLUTION

--- a/docs/CVE-2026-1965.md
+++ b/docs/CVE-2026-1965.md
@@ -57,6 +57,8 @@ This flaw has existed since curl started to support Negotiate.
 
 - Affected versions: from curl 7.10.6 to and including 8.18.0
 - Not affected versions: curl < 7.10.6 and >= 8.19.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/e56ae1426c
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-19931.md
+++ b/docs/CVE-2026-19931.md
@@ -39,6 +39,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.64.1 to and including 8.21.0
 - Not affected versions: curl < 7.64.1 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/6c6035532383e300c712e4c1
 
 SOLUTION

--- a/docs/CVE-2026-3783.md
+++ b/docs/CVE-2026-3783.md
@@ -30,6 +30,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.33.0 to and including 8.18.0
 - Not affected versions: curl < 7.33.0 and >= 8.19.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/06c1bea72faabb6fad4b7ef8
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-3784.md
+++ b/docs/CVE-2026-3784.md
@@ -26,6 +26,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.7 to and including 8.18.0
 - Not affected versions: curl < 7.7 and >= 8.19.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/a1d6ad26100bc493c7b
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-3805.md
+++ b/docs/CVE-2026-3805.md
@@ -39,6 +39,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.13.0 to and including 8.18.0
 - Not affected versions: curl < 8.13.0 and >= 8.19.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/f4831daa9b2a97e8a29
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-4873.md
+++ b/docs/CVE-2026-4873.md
@@ -39,6 +39,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.20.0 to and including 8.19.0
 - Not affected versions: curl < 7.20.0 and >= 8.20.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/ec3bb8f727405642a
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-5545.md
+++ b/docs/CVE-2026-5545.md
@@ -54,6 +54,8 @@ This flaw has existed since curl started to support Negotiate.
 
 - Affected versions: from curl 7.10.6 to and including 8.19.0
 - Not affected versions: curl < 7.10.6 and >= 8.20.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/e56ae1426c
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-5773.md
+++ b/docs/CVE-2026-5773.md
@@ -48,6 +48,8 @@ This flaw has existed since curl started to support SMB.
 
 - Affected versions: from curl 7.40.0 to and including 8.19.0
 - Not affected versions: curl < 7.40.0 and >= 8.20.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/aec2e865f0
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-6253.md
+++ b/docs/CVE-2026-6253.md
@@ -40,6 +40,8 @@ strings.
 
 - Affected versions: from curl 7.14.1 to and including 8.19.0
 - Not affected versions: curl < 7.14.1 and >= 8.20.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/3b60bb725913ce
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-6276.md
+++ b/docs/CVE-2026-6276.md
@@ -34,6 +34,8 @@ AFFECTED VERSIONS
 
 - Affected versions: from curl 7.71.0 to and including 8.19.0
 - Not affected versions: curl < 7.71.0 and >= 8.20.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/e15e51384a423be3131
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-6429.md
+++ b/docs/CVE-2026-6429.md
@@ -32,6 +32,8 @@ AFFECTED VERSIONS
 
 - Affected versions: from curl 7.14.0 to and including 8.19.0
 - Not affected versions: curl < 7.14.0 and >= 8.20.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/01165e08e0d131b399fb
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-7168.md
+++ b/docs/CVE-2026-7168.md
@@ -40,6 +40,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.12.0 to and including 8.19.0
 - Not affected versions: curl < 7.12.0 and >= 8.20.0
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/fc6eff13b5414caf6edf
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-80229.md
+++ b/docs/CVE-2026-80229.md
@@ -38,6 +38,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.14.0 to and including 8.21.0
 - Not affected versions: curl < 8.14.0 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/f2ce6c46b9dcc46ced0ce43f
 
 SOLUTION

--- a/docs/CVE-2026-80230.md
+++ b/docs/CVE-2026-80230.md
@@ -41,6 +41,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.45.0 to and including 8.21.0
 - Not affected versions: curl < 7.45.0 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/8363656cb4e0c60a11d8531
 
 SOLUTION

--- a/docs/CVE-2026-80231.md
+++ b/docs/CVE-2026-80231.md
@@ -33,6 +33,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.71.0 to and including 8.21.0
 - Not affected versions: curl < 7.71.0 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/148534db57dda611cf8516e9
 
 SOLUTION

--- a/docs/CVE-2026-80255.md
+++ b/docs/CVE-2026-80255.md
@@ -32,6 +32,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.13.0 to and including 8.21.0
 - Not affected versions: curl < 7.13.0 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/1aea05a6c2699e80c75936d5
 
 SOLUTION

--- a/docs/CVE-2026-82208.md
+++ b/docs/CVE-2026-82208.md
@@ -35,6 +35,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.9.1 to and including 8.21.0
 - Not affected versions: curl < 8.9.1 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/0f2876b2c33f6784a27b6f7345bd
 
 SOLUTION

--- a/docs/CVE-2026-82209.md
+++ b/docs/CVE-2026-82209.md
@@ -41,6 +41,9 @@ this correctly.
 
 - Affected versions: curl 7.46.0 to and including 8.21.0
 - Not affected versions: curl < 7.46.0 and >= 8.22.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/e77b5b7453c1e8ccd7ec08
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-8286.md
+++ b/docs/CVE-2026-8286.md
@@ -32,6 +32,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.30.0 to and including 8.20.0
 - Not affected versions: curl < 7.30.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/a1701eea289fe7ea8065
 
 STARTTLS support was introduced in curl via a number of separate commits for

--- a/docs/CVE-2026-8458.md
+++ b/docs/CVE-2026-8458.md
@@ -46,6 +46,9 @@ for Negotiate.
 
 - Affected versions: from curl 7.43.0 to and including 8.20.0
 - Not affected versions: curl < 7.43.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/97c272e5d173ad5f706
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-8924.md
+++ b/docs/CVE-2026-8924.md
@@ -39,6 +39,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.46.0 to and including 8.20.0
 - Not affected versions: curl < 7.46.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/e77b5b7453c1e8c
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-8925.md
+++ b/docs/CVE-2026-8925.md
@@ -34,6 +34,8 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.15.0 to and including 8.20.0
 - Not affected versions: curl < 8.15.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
 - Introduced-in: https://github.com/curl/curl/commit/ab650379a8c25ca952f6
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-8926.md
+++ b/docs/CVE-2026-8926.md
@@ -28,6 +28,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.11.1 to and including 8.20.0
 - Not affected versions: curl < 8.11.1 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/e9b9bbac22c26cf67
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-8927.md
+++ b/docs/CVE-2026-8927.md
@@ -45,6 +45,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.12.0 to and including 8.20.0
 - Not affected versions: curl < 7.12.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/fc6eff13b5414caf6edf
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-8932.md
+++ b/docs/CVE-2026-8932.md
@@ -39,6 +39,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.7 to and including 8.20.0
 - Not affected versions: curl < 7.7 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/a1d6ad26100bc493c7b0
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-9079.md
+++ b/docs/CVE-2026-9079.md
@@ -31,6 +31,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.8.0 to and including 8.20.0
 - Not affected versions: curl < 8.8.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/d5e83eb745762f48d8f
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-9080.md
+++ b/docs/CVE-2026-9080.md
@@ -32,6 +32,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.13.0 to and including 8.20.0
 - Not affected versions: curl < 8.13.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/cfc657a48d
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-9545.md
+++ b/docs/CVE-2026-9545.md
@@ -41,6 +41,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.11.0 to and including 8.20.0
 - Not affected versions: curl < 8.11.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/962097b8dd44ed5b9
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-9546.md
+++ b/docs/CVE-2026-9546.md
@@ -34,6 +34,7 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 8.18.0 to and including 8.20.0
 - Not affected versions: curl < 8.18.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
 - Introduced-in: https://github.com/curl/curl/commit/2cb868242dc2ac9cd5
 
 libcurl is used by many applications, but not always advertised as such!

--- a/docs/CVE-2026-9547.md
+++ b/docs/CVE-2026-9547.md
@@ -38,6 +38,9 @@ AFFECTED VERSIONS
 
 - Affected versions: curl 7.69.0 to and including 8.20.0
 - Not affected versions: curl < 7.69.0 and >= 8.21.0
+- Not affected versions: curl >= 8.20.1
+- Not affected versions: curl >= 8.16.1
+- Not affected versions: curl >= 8.14.2
 - Introduced-in: https://github.com/curl/curl/commit/507cf6a13db0375eadd
 
 libcurl is used by many applications, but not always advertised as such!


### PR DESCRIPTION
We ship three Rock-solid curl releases today with backports for these vulnerabilities.